### PR TITLE
Make cleanAll idempotent

### DIFF
--- a/src/main/native/jgskit.mak
+++ b/src/main/native/jgskit.mak
@@ -163,9 +163,8 @@ TARGET = ${HOSTOUT}/libjgskit.so
 all: dircreate javah ${SOURCES} ${TARGET}
 
 dircreate:
-	mkdir -p ${HOSTOUT} 
-	mkdir -p ${JAVACLASSDIR} 
-
+	mkdir -p ${HOSTOUT}
+	mkdir -p ${JAVACLASSDIR}
 
 ifeq ($(PLAT),mz)
 ${TARGET}: $(OBJS)
@@ -190,12 +189,12 @@ javah: dircreate
 	${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/FastJNIBuffer.java \
 	${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/OCKContext.java \
 	${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/OCKException.java \
-	-d ${JAVACLASSDIR} -h ${TOPDIR}/src/main/native/ 
+	-d ${JAVACLASSDIR} -h ${TOPDIR}/src/main/native/
 
 clean:
 	rm -f ${HOSTOUT}/*.o
 	rm -f ${HOSTOUT}/*.so
 cleanAll:
 	rm -rf ${TOPDIR}/target
-	rm com_ibm_crypto_plus_provider_ock_NativeInterface.h
-	rm com_ibm_crypto_plus_provider_ock_FastJNIBuffer.h 
+	rm -f com_ibm_crypto_plus_provider_ock_NativeInterface.h
+	rm -f com_ibm_crypto_plus_provider_ock_FastJNIBuffer.h


### PR DESCRIPTION
Use "rm -f" so it doesn't fail if the header files don't exist.

(Discovered while reviewing https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/238).