### PR TITLE
Update plexus-archiver and commons-io packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -416,12 +416,34 @@
             <artifactId>maven-compiler-plugin</artifactId>
             <version>3.11.0</version>
             <type>maven-plugin</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.15.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
             <version>3.3.0</version>
             <type>maven-plugin</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-archiver</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-archiver</artifactId>
+            <version>4.9.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The plexus-archiver and commons-io packages need to be updated to the latest package levels to pick up various security related fixes. This update no longer picks up the default versions of these packages that are nested within other dependencies.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>