### PR TITLE
Document algorithms registered by OpenJCEPlus and OpenJCEPlusFIPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   - [Run All Tests](#run-all-tests)
   - [Run Single Test](#run-single-test)
 - [OpenJCEPlus and OpenJCEPlusFIPS Provider SDK Installation](#openjceplus-and-openjceplusfips-provider-sdk-installation)
+- [Features and Algorithms](#features-and-algorithms)
 - [Contributions](#contributions)
 
 # Overview
@@ -182,6 +183,148 @@ below represents your desired preference order.
     ```console
     -Djgskit.library.path=$ANYDIRECTORY
     ```
+
+# Features And Algorithms
+
+The following algorothms are registered by the OpenJCEPlus and OpenJCEPlusFIPS providers.
+
+| Algorithm Type            | Algorithm Name             | OpenJCEPlusFIPS | OpenJCEPlus  |
+| --------------------------|----------------------------|-----------------|--------------|
+AlgorithmParameterGenerator | CCM                        |X                |X             |
+AlgorithmParameterGenerator | DSA                        |                 |X             |
+AlgorithmParameterGenerator | DiffieHellman              |X                |X             |
+AlgorithmParameterGenerator | EC                         |X                |X             |
+AlgorithmParameterGenerator | GCM                        |X                |X             |
+AlgorithmParameters         | AES                        |X                |X             |
+AlgorithmParameters         | CCM                        |X                |X             |
+AlgorithmParameters         | ChaCha20-Poly1305          |                 |X             |
+AlgorithmParameters         | DESede                     |                 |X             |
+AlgorithmParameters         | DSA                        |X                |X             |
+AlgorithmParameters         | DiffieHellman              |X                |X             |
+AlgorithmParameters         | EC                         |X                |X             |
+AlgorithmParameters         | GCM                        |X                |X             |
+AlgorithmParameters         | OAEP                       |X                |X             |
+AlgorithmParameters         | RSAPSS                     |X                |X             |
+Cipher                      | AES                        |X                |X             |
+Cipher                      | AES/CCM/NoPadding          |X                |X             |
+Cipher                      | AES/GCM/NoPadding          |X                |X             |
+Cipher                      | ChaCha20                   |                 |X             |
+Cipher                      | ChaCha20-Poly1305          |                 |X             |
+Cipher                      | DESede                     |                 |X             |
+Cipher                      | RSA                        |X                |X             |
+KeyAgreement                | DiffieHellman              |X                |X             |
+KeyAgreement                | ECDH                       |X                |X             |
+KeyAgreement                | X25519                     |                 |X             |
+KeyAgreement                | X448                       |                 |X             |
+KeyAgreement                | XDH                        |                 |X             |
+KeyFactory                  | DSA                        |X                |X             |
+KeyFactory                  | DiffieHellman              |X                |X             |
+KeyFactory                  | EC                         |X                |X             |
+KeyFactory                  | Ed25519                    |                 |X             |
+KeyFactory                  | Ed448                      |                 |X             |
+KeyFactory                  | EdDSA                      |                 |X             |
+KeyFactory                  | RSA                        |X                |X             |
+KeyFactory                  | RSAPSS                     |X                |X             |
+KeyFactory                  | X25519                     |                 |X             |
+KeyFactory                  | X448                       |                 |X             |
+KeyFactory                  | XDH                        |                 |X             |
+KeyGenerator                | AES                        |X                |X             |
+KeyGenerator                | ChaCha20                   |                |X             |
+KeyGenerator                | DESede                     |                 |X             |
+KeyGenerator                | HmacMD5                    |                 |X             |
+KeyGenerator                | HmacSHA1                   |                 |X             |
+KeyGenerator                | HmacSHA224                 |X                |X             |
+KeyGenerator                | HmacSHA256                 |X                |X             |
+KeyGenerator                | HmacSHA3-224               |X                |X             |
+KeyGenerator                | HmacSHA3-256               |X                |X             |
+KeyGenerator                | HmacSHA3-384               |X                |X             |
+KeyGenerator                | HmacSHA3-512               |X                |X             |
+KeyGenerator                | HmacSHA384                 |X                |X             |
+KeyGenerator                | HmacSHA512                 |X                |X             |
+KeyGenerator                | SunTls12KeyMaterial        |X                |X             |
+KeyGenerator                | SunTls12MasterSecret       |X                |X             |
+KeyGenerator                | SunTls12Prf                |X                |X             |
+KeyGenerator                | SunTls12RsaPremasterSecret |X                |X             |
+KeyGenerator                | SunTlsKeyMaterial          |X                |X             |
+KeyGenerator                | SunTlsMasterSecret         |X                |X             |
+KeyGenerator                | SunTlsPrf                  |X                |X             |
+KeyGenerator                | SunTlsRsaPremasterSecret   |X                |X             |
+KeyGenerator                | kda-hkdf-with-sha1         |                 |X             |
+KeyGenerator                | kda-hkdf-with-sha224       |X                |X             |
+KeyGenerator                | kda-hkdf-with-sha256       |X                |X             |
+KeyGenerator                | kda-hkdf-with-sha384       |X                |X             |
+KeyGenerator                | kda-hkdf-with-sha512       |X                |X             |
+KeyPairGenerator            | DSA                        |                 |X             |
+KeyPairGenerator            | DiffieHellman              |X                |X             |
+KeyPairGenerator            | EC                         |X                |X             |
+KeyPairGenerator            | Ed25519                    |                 |X             |
+KeyPairGenerator            | Ed448                      |                 |X             |
+KeyPairGenerator            | EdDSA                      |                 |X             |
+KeyPairGenerator            | RSA                        |X                |X             |
+KeyPairGenerator            | RSAPSS                     |X                |X             |
+KeyPairGenerator            | X25519                     |                 |X             |
+KeyPairGenerator            | X448                       |                 |X             |
+KeyPairGenerator            | XDH                        |                 |X             |
+Mac                         | HmacMD5                    |                 |X             |
+Mac                         | HmacSHA1                   |                 |X             |
+Mac                         | HmacSHA224                 |X                |X             |
+Mac                         | HmacSHA256                 |X                |X             |
+Mac                         | HmacSHA3-224               |X                |X             |
+Mac                         | HmacSHA3-256               |X                |X             |
+Mac                         | HmacSHA3-384               |X                |X             |
+Mac                         | HmacSHA3-512               |X                |X             |
+Mac                         | HmacSHA384                 |X                |X             |
+Mac                         | HmacSHA512                 |X                |X             |
+MessageDigest               | MD5                        |X                |X             |
+MessageDigest               | SHA-1                      |X                |X             |
+MessageDigest               | SHA-224                    |X                |X             |
+MessageDigest               | SHA-256                    |X                |X             |
+MessageDigest               | SHA-384                    |X                |X             |
+MessageDigest               | SHA-512                    |X                |X             |
+MessageDigest               | SHA-512/224                |X                |X             |
+MessageDigest               | SHA-512/256                |X                |X             |
+MessageDigest               | SHA3-224                   |X                |X             |
+MessageDigest               | SHA3-256                   |X                |X             |
+MessageDigest               | SHA3-384                   |X                |X             |
+MessageDigest               | SHA3-512                   |X                |X             |
+SecretKeyFactory            | AES                        |X                |X             |
+SecretKeyFactory            | ChaCha20                   |                 |X             |
+SecretKeyFactory            | DESede                     |                 |X             |
+SecureRandom                | SHA256DRBG                 |X                |X             |
+SecureRandom                | SHA512DRBG                 |X                |X             |
+Signature                   | Ed25519                    |                 |X             |
+Signature                   | Ed448                      |                 |X             |
+Signature                   | EdDSA                      |X                |X             |
+Signature                   | NONEwithDSA                |X                |X             |
+Signature                   | NONEwithECDSA              |X                |X             |
+Signature                   | NONEwithRSA                |X                |X             |
+Signature                   | RSAPSS                     |X                |X             |
+Signature                   | RSAforSSL                  |X                |X             |
+Signature                   | SHA1withDSA                |                 |X             |
+Signature                   | SHA1withECDSA              |                 |X             |
+Signature                   | SHA1withRSA                |X                |X             |
+Signature                   | SHA224withDSA              |X                |X             |
+Signature                   | SHA224withECDSA            |X                |X             |
+Signature                   | SHA224withRSA              |X                |X             |
+Signature                   | SHA256withDSA              |X                |X             |
+Signature                   | SHA256withECDSA            |X                |X             |
+Signature                   | SHA256withRSA              |X                |X             |
+Signature                   | SHA3-224withDSA            |                 |X             |
+Signature                   | SHA3-224withECDSA          |                 |X             |
+Signature                   | SHA3-224withRSA            |                 |X             |
+Signature                   | SHA3-256withDSA            |                 |X             |
+Signature                   | SHA3-256withECDSA          |                 |X             |
+Signature                   | SHA3-256withRSA            |                 |X             |
+Signature                   | SHA3-384withDSA            |                 |X             |
+Signature                   | SHA3-384withECDSA          |                 |X             |
+Signature                   | SHA3-384withRSA            |                 |X             |
+Signature                   | SHA3-512withDSA            |                 |X             |
+Signature                   | SHA3-512withECDSA          |                 |X             |
+Signature                   | SHA3-512withRSA            |                 |X             |
+Signature                   | SHA384withECDSA            |X                |X             |
+Signature                   | SHA384withRSA              |X                |X             |
+Signature                   | SHA512withECDSA            |X                |X             |
+Signature                   | SHA512withRSA              |X                |X             |
 
 # Contributions
 


### PR DESCRIPTION
This update documents the available algorithms that are implemented in
the `OpenJCEPlus` and `OpenJCEPlusFIPS` providers that are available
within the Open Cryptography Kit C and exposed via a JCE interface.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>