### PR TITLE
Update dependant mvn libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -382,7 +382,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.10.1</version>
+                <version>5.10.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -414,7 +414,7 @@
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.11.0</version>
+            <version>3.12.1</version>
             <type>maven-plugin</type>
             <exclusions>
                 <exclusion>
@@ -444,6 +444,17 @@
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-archiver</artifactId>
             <version>4.9.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.26.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This update splits out the `common-compress` library into its own
dependency definition. This allows us to update to the latest
version of this library.

This update also updates `maven-compiler-plugin` and `junit-bom`
libraries to the latest versions available.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>