### PR TITLE
Automatically get provider version

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
@@ -72,7 +72,7 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     public OpenJCEPlus() {
-        super("OpenJCEPlus", 17, info);
+        super("OpenJCEPlus", info);
 
         if (debug2) {
             System.out.println("New OpenJCEPlus instance");

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -69,7 +69,7 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     public OpenJCEPlusFIPS() {
-        super("OpenJCEPlusFIPS", 17, info);
+        super("OpenJCEPlusFIPS", info);
         if (debug2) {
             System.out.println("New OpenJCEPlusFIPS instance");
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
@@ -19,6 +19,12 @@ import com.ibm.crypto.plus.provider.ock.OCKContext;
 //
 @SuppressWarnings({"serial", "removal", "deprecation"})
 abstract class OpenJCEPlusProvider extends java.security.Provider {
+    private static final String PROVIDER_VER = java.security.AccessController
+                .doPrivileged(new java.security.PrivilegedAction<String>() {
+                    public String run() {
+                        return (System.getProperty("java.specification.version"));
+                    }
+                });
 
     // Are we debugging? -- for developers
     static final boolean debug2 = false;
@@ -26,8 +32,8 @@ abstract class OpenJCEPlusProvider extends java.security.Provider {
     //    private static boolean verifiedSelfIntegrity = false;
     private static boolean verifiedSelfIntegrity = true;
 
-    OpenJCEPlusProvider(String name, double version, String info) {
-        super(name, version, info);
+    OpenJCEPlusProvider(String name, String info) {
+        super(name, PROVIDER_VER, info);
     }
 
     static final boolean verifySelfIntegrity(Class c) {


### PR DESCRIPTION
The provider's version is inferred automatically based on the `Java` version that is used at that point.

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)