### PR TITLE
Support JDK 21

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Semeru JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '17.0.9+9'
+          java-version: '21.0.2+13'
           distribution: 'semeru'
           architecture: 'x64'
       # Uncomment to capture all files in the runner for debugging purposes.          

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ considered FIPS compliant. Achieving certified FIPS cryptography requires the un
 and architectures. Any cryptographic libraries developed must adhere to rigorous FIPS standards and should not be assumed to be available in any environment.
 All environments and binaries must undergo the FIPS certification process with NIST to ensure compliance.**
 
-This github branch can only be used with Java version 17.
+This github branch can only be used with Java version 21.
 
 ## How to Build `OpenJCEPlus` and Java Native Interface Library
 
@@ -80,7 +80,7 @@ You can test your installation by issuing `mvn --version`. For example:
     $ mvn --version
     Apache Maven 3.9.2 (c9616018c7a021c1c39be70fb2843d6f5f9b8a1c)
     Maven home: /tools/apache-maven-3.9.2
-    Java version: 1.8.0_361, vendor: IBM Corporation, runtime: /opt/ibm/sdks/jdk-17.0.5+8
+    Java version: 1.8.0_361, vendor: IBM Corporation, runtime: /opt/ibm/sdks/jdk-21.0.2+13
     Default locale: en_US, platform encoding: ISO8859-1
     OS name: "aix", version: "7.2", arch: "ppc64", family: "unix"
     ```
@@ -93,10 +93,10 @@ You can test your installation by issuing `mvn --version`. For example:
     cd OpenJCEPlus
     ```
 
-1. Set your `JAVA_HOME` environment variable. This will be the SDK used to compile the project. You must set your JAVA_HOME value to Java version 17 when using code located in the `main` branch.
+1. Set your `JAVA_HOME` environment variable. This will be the SDK used to compile the project. You must set your JAVA_HOME value to Java version 21 when using code located in the `main` branch.
 
     ```console
-    export JAVA_HOME="/opt/ibm/sdks/jdk-17.0.5+8"
+    export JAVA_HOME="/opt/ibm/sdks/jdk-21.0.2+13"
     ```
 
 1. Set the location of the variable `GSKIT_SDK` to the directory extracted in the above steps.
@@ -135,10 +135,10 @@ On AIX you must set an additional setting for the `LIBPATH` environment variable
 export LIBPATH="$PROJECT_HOME/OCK/:$PROJECT_HOME/OCK/jgsk_sdk"
 ```
 
-On all platforms set the following environment variables and execute all the tests using `mvn`. You must set your JAVA_HOME value to Java version 17 when using code located in the `main` branch.
+On all platforms set the following environment variables and execute all the tests using `mvn`. You must set your JAVA_HOME value to Java version 21 when using code located in the `main` branch.
 
 ```console
-export JAVA_HOME="$JAVA_INSTALL_DIRECTORY/jdk-17.0.5+8"
+export JAVA_HOME="$JAVA_INSTALL_DIRECTORY/jdk-21.0.2+13"
 export GSKIT_HOME="$PROJECT_HOME/OCK/jgsk_sdk"
 mvn '-Dock.library.path=$PROJECT_HOME/OCK/' test
 ```
@@ -151,11 +151,11 @@ On AIX you must set an additional setting for the `LIBPATH` environment variable
 export LIBPATH="$PROJECT_HOME/OCK/:$PROJECT_HOME/OCK/jgsk_sdk"
 ```
 
-On all platforms change to the OpenJCEPlus directory and set the following environment variables and execute a specific test name using `mvn`. You must set your JAVA_HOME value to Java version 17 when using code located in the `main` branch.
+On all platforms change to the OpenJCEPlus directory and set the following environment variables and execute a specific test name using `mvn`. You must set your JAVA_HOME value to Java version 21 when using code located in the `main` branch.
 
 ```console
 cd OpenJCEPlus
-export JAVA_HOME="$JAVA_INSTALL_DIRECTORY/jdk-17.0.5+8"
+export JAVA_HOME="$JAVA_INSTALL_DIRECTORY/jdk-21.0.2+13"
 export GSKIT_HOME="$PROJECT_HOME/OCK/jgsk_sdk"
 mvn '-Dock.library.path=$PROJECT_HOME/OCK/' test -Dtest=TestClassname
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>OpenJCEPlus</artifactId>
-    <version>17</version>
+    <version>21</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -105,12 +105,12 @@
             </properties>
           </profile>
           <profile>
-            <id>Profile for JDK 17 Build</id>
+            <id>Profile for JDK 21 Build</id>
             <activation>
-              <jdk>17</jdk>
+              <jdk>21</jdk>
             </activation>
             <properties>
-                <jdk.build.target>17</jdk.build.target>
+                <jdk.build.target>21</jdk.build.target>
             </properties>
           </profile>
         </profiles>
@@ -146,8 +146,8 @@
                         <message>"Property ock.library.path is not set, perhaps this required property is missing from the command line?"</message>
                       </requireProperty>
                       <requireJavaVersion>
-                        <version>x >= 17</version>
-                        <message>"Java 17 or higher required to build OpenJCEPlus."</message>
+                        <version>x = 21</version>
+                        <message>"Java 21 required to build OpenJCEPlus."</message>
                       </requireJavaVersion>
                       <requireEnvironmentVariable>
                         <variableName>JAVA_HOME</variableName>

--- a/src/main/java/com/ibm/crypto/plus/provider/CurveUtil.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/CurveUtil.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 import java.security.InvalidParameterException;
 import java.util.HashMap;
 import java.util.Map;
-
+import sun.security.util.KnownOIDs;
 import sun.security.util.ObjectIdentifier;
 import sun.security.x509.AlgorithmId;
 
@@ -186,13 +186,13 @@ class CurveUtil {
     public static AlgorithmId getAlgId(CurveUtil.CURVE curve) throws IOException {
         switch (curve) {
             case Ed25519:
-                return new AlgorithmId(AlgorithmId.ed25519_oid);
+                return new AlgorithmId(ObjectIdentifier.of(KnownOIDs.Ed25519));
             case Ed448:
-                return new AlgorithmId(AlgorithmId.ed448_oid);
+                return new AlgorithmId(ObjectIdentifier.of(KnownOIDs.Ed448));
             case X25519:
-                return new AlgorithmId(AlgorithmId.x25519_oid);
+                return new AlgorithmId(ObjectIdentifier.of(KnownOIDs.X25519));
             case X448:
-                return new AlgorithmId(AlgorithmId.x448_oid);
+                return new AlgorithmId(ObjectIdentifier.of(KnownOIDs.X448));
             case FFDHE2048:
                 return new AlgorithmId(ObjectIdentifier.of("1.2.840.113549.1.3.1"));
             case FFDHE3072:

--- a/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
@@ -94,8 +94,6 @@ final class DHPrivateKey extends PKCS8Key implements javax.crypto.interfaces.DHP
             this.key = new DerValue(DerValue.tag_Integer, this.x.toByteArray()).toByteArray();
             this.encodedKey = getEncoded();
             this.dhKey = DHKey.createPrivateKey(provider.getOCKContext(), encodedKey);
-        } catch (IOException e) {
-            throw new InvalidKeyException("Cannot produce ASN.1 encoding");
         } catch (OCKException e) {
             throw new InvalidKeyException("Failure in DHPrivateKey");
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/DHPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHPublicKey.java
@@ -63,8 +63,6 @@ final class DHPublicKey extends X509Key
             dhParams.engineInit(new DHParameterSpec(p, g, l));
             this.key = new DerValue(DerValue.tag_Integer, this.y.toByteArray()).toByteArray();
             this.encodedKey = getEncoded();
-        } catch (IOException e) {
-            throw new InvalidKeyException("Cannot produce ASN.1 encoding");
         } catch (InvalidParameterSpecException e) {
             throw new InvalidKeyException("Cannot initialize parameters");
         }
@@ -92,12 +90,8 @@ final class DHPublicKey extends X509Key
         this.provider = provider;
         this.y = y;
         this.dhParams = params;
-        try {
-            this.key = new DerValue(DerValue.tag_Integer, this.y.toByteArray()).toByteArray();
-            this.encodedKey = getEncoded();
-        } catch (IOException e) {
-            throw new InvalidKeyException("Cannot produce ASN.1 encoding");
-        }
+        this.key = new DerValue(DerValue.tag_Integer, this.y.toByteArray()).toByteArray();
+        this.encodedKey = getEncoded();
     }
 
     public DHPublicKey(OpenJCEPlusProvider provider, DHKey dhKey) {
@@ -235,8 +229,6 @@ final class DHPublicKey extends X509Key
         DerOutputStream asn1Key = new DerOutputStream();
         try {
             asn1Key.putSequence(value);
-        } catch (IOException e) {
-            throw e;
         } finally {
             closeStream(asn1Key);
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAPrivateKey.java
@@ -62,11 +62,7 @@ final class DSAPrivateKey extends PKCS8Key
         this.provider = provider;
         this.x = x;
 
-        try {
-            key = new DerValue(DerValue.tag_Integer, x.toByteArray()).toByteArray();
-        } catch (IOException e) {
-            throw new InvalidKeyException("could not DER encode x: " + e.getMessage());
-        }
+        key = new DerValue(DerValue.tag_Integer, x.toByteArray()).toByteArray();
 
         try {
             byte[] privateKeyBytes = buildOCKPrivateKeyBytes();

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAPublicKey.java
@@ -62,13 +62,9 @@ final class DSAPublicKey extends X509Key
         this.provider = provider;
         this.y = y;
 
-        try {
-            byte[] keyArray = new DerValue(DerValue.tag_Integer, y.toByteArray()).toByteArray();
-            setKey(new BitArray(keyArray.length * 8, keyArray));
-            encode();
-        } catch (IOException e) {
-            throw new InvalidKeyException("coud not DER encode y: " + e.getMessage());
-        }
+        byte[] keyArray = new DerValue(DerValue.tag_Integer, y.toByteArray()).toByteArray();
+        setKey(new BitArray(keyArray.length * 8, keyArray));
+        encode();
 
         try {
             byte[] publicKeyBytes = buildOCKPublicKeyBytes();

--- a/src/main/java/com/ibm/crypto/plus/provider/ECNamedCurve.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECNamedCurve.java
@@ -71,8 +71,6 @@ final class ECNamedCurve extends ECGenParameterSpec implements AlgorithmParamete
             out.putOID(oid);
             encoded = out.toByteArray();
 
-        } catch (IOException e) {
-            throw new InvalidParameterException("The OID could not be DER-encoded");
         } finally {
             try {
                 out.close();

--- a/src/main/java/com/ibm/crypto/plus/provider/ECParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECParameters.java
@@ -288,28 +288,20 @@ public final class ECParameters extends AlgorithmParametersSpi {
 
     private static DerValue encodeEllipticCurve(EllipticCurve curve) throws IOException {
 
-        try {
-            byte[] aByteArray = trimZeroes(curve.getA().toByteArray());
-            byte[] bByteArray = trimZeroes(curve.getB().toByteArray());
-
-            byte[] seed = curve.getSeed(); // May be null
-
-            DerOutputStream out = new DerOutputStream();
-            out.putOctetString(aByteArray);
-            out.putOctetString(bByteArray);
-            if (seed != null) {
-                out.putBitString(seed);
-            }
-
-            // Observe that the DerValues above are the
-            // "data" of the DerValue with the SEQUENCE TAG
-            DerValue val = new DerValue(DerValue.tag_Sequence, out.toByteArray());
-
-            return val;
-
-        } catch (IOException e) {
-            throw new IOException("Exception in encodeEllipticCurve(): " + e);
+        byte[] aByteArray = trimZeroes(curve.getA().toByteArray());
+        byte[] bByteArray = trimZeroes(curve.getB().toByteArray());
+        byte[] seed = curve.getSeed(); // May be null
+        DerOutputStream out = new DerOutputStream();
+        out.putOctetString(aByteArray);
+        out.putOctetString(bByteArray);
+        if (seed != null) {
+            out.putBitString(seed);
         }
+        // Observe that the DerValues above are the
+        // "data" of the DerValue with the SEQUENCE TAG
+        DerValue val = new DerValue(DerValue.tag_Sequence, out.toByteArray());
+        return val;
+
     }
 
     // Curve ::= SEQUENCE {

--- a/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
@@ -100,31 +100,24 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
         // e.getMessage());
         // }
 
-        try {
-            byte[] sArr = s.toByteArray();
-            // convert to fixed-length array
-            int numOctets = (params.getOrder().bitLength() + 7) / 8;
-            byte[] sOctets = new byte[numOctets];
-            int inPos = Math.max(sArr.length - sOctets.length, 0);
-            int outPos = Math.max(sOctets.length - sArr.length, 0);
-            int length = Math.min(sArr.length, sOctets.length);
-            System.arraycopy(sArr, inPos, sOctets, outPos, length);
 
-            DerOutputStream out = new DerOutputStream();
-
-            // PKCS8Key contains the decoding logic for all instances of
-            // PrivateKeys.
-            // It is checking that this version is set to zero.
-
-            // This section matches with what we do in FIPS70.
-            out.putInteger(1); // version 1
-            out.putOctetString(sOctets);
-            DerValue val = new DerValue(DerValue.tag_Sequence, out.toByteArray());
-            key = val.toByteArray();
-        } catch (IOException exc) {
-            // should not occur
-            throw new InvalidKeyException(exc);
-        }
+        byte[] sArr = s.toByteArray();
+        // convert to fixed-length array
+        int numOctets = (params.getOrder().bitLength() + 7) / 8;
+        byte[] sOctets = new byte[numOctets];
+        int inPos = Math.max(sArr.length - sOctets.length, 0);
+        int outPos = Math.max(sOctets.length - sArr.length, 0);
+        int length = Math.min(sArr.length, sOctets.length);
+        System.arraycopy(sArr, inPos, sOctets, outPos, length);
+        DerOutputStream out = new DerOutputStream();
+        // PKCS8Key contains the decoding logic for all instances of
+        // PrivateKeys.
+        // It is checking that this version is set to zero.
+        // This section matches with what we do in FIPS70.
+        out.putInteger(1); // version 1
+        out.putOctetString(sOctets);
+        DerValue val = new DerValue(DerValue.tag_Sequence, out.toByteArray());
+        key = val.toByteArray();
 
         try {
             this.publicKeyBytes = null;

--- a/src/main/java/com/ibm/crypto/plus/provider/OAEPParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OAEPParameters.java
@@ -170,7 +170,7 @@ public final class OAEPParameters extends AlgorithmParametersSpi {
             throw new IOException("AlgorithmId " + mdName + " impl not found");
         }
         tmp2 = new DerOutputStream();
-        mdAlgId.derEncode(tmp2);
+        mdAlgId.encode(tmp2);
         tmp.write(DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte) 0), tmp2);
 
         // MGF

--- a/src/main/native/jgskit_resource.rc
+++ b/src/main/native/jgskit_resource.rc
@@ -27,13 +27,13 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "IBM\0"
             VALUE "FileDescription", "Native JGSKIT runtime library\0"
-            VALUE "FileVersion", "17\0"
+            VALUE "FileVersion", "21\0"
 	        VALUE "Build Increment", "0\0"
             VALUE "InternalName", "jgskit.dll\0"
-            VALUE "LegalCopyright", "(C) Copyright IBM Corp. 2023.\0"
+            VALUE "LegalCopyright", "(C) Copyright IBM Corp. 2023. Licensed under the Apache License 2.0.\0"
             VALUE "OriginalFilename", "jgskit.dll\0"
-            VALUE "ProductName", "IBM JCEPlus Crypto Provider for Windows, Java 2(tm), 17.0\0"
-            VALUE "ProductVersion", "17.0\0"
+            VALUE "ProductName", "OpenJCEPlus Crypto Provider for Windows, 21.0\0"
+            VALUE "ProductVersion", "21.0\0"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/test/java/ibm/jceplus/junit/base/certificateutils/CertAndKeyGen.java
+++ b/src/test/java/ibm/jceplus/junit/base/certificateutils/CertAndKeyGen.java
@@ -399,29 +399,22 @@ public final class CertAndKeyGen {
             X509CertInfo info = new X509CertInfo();
             // Add all mandatory attributes
             // Note here that V1 = 0, V2 = 1, V3 = 2
-            info.set(X509CertInfo.VERSION, new CertificateVersion(CertificateVersion.V3));
+            info.setVersion(new CertificateVersion(CertificateVersion.V3));
 
 
-            info.set(X509CertInfo.SERIAL_NUMBER,
-                    new CertificateSerialNumber((int) (firstDate.getTime() / 1000)));
+            info.setSerialNumber(new CertificateSerialNumber((int) (firstDate.getTime() / 1000)));
             AlgorithmId algID = issuer.getAlgorithmId();
-            info.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algID));
-            //info.set(X509CertInfo.SUBJECT, new CertificateSubjectName(myname));
-            info.set(X509CertInfo.SUBJECT, myname);
-            info.set(X509CertInfo.KEY, new CertificateX509Key(publicKey));
-            info.set(X509CertInfo.VALIDITY, interval);
-            //            info.set(X509CertInfo.ISSUER,
-            //                     new CertificateIssuerName(issuer.getSigner()));
-            info.set(X509CertInfo.ISSUER, issuer.getSigner());
+            info.setAlgorithmId(new CertificateAlgorithmId(algID));
+            //info.setSubject(new CertificateSubjectName(myname));
+            info.setSubject(myname);
+            info.setKey(new CertificateX509Key(publicKey));
+            info.setValidity(interval);
+            info.setIssuer(issuer.getSigner());
 
-            cert = new X509CertImpl(info);
-            // 991119 - Updated to match JDK 1.2.2 source.
-            //cert.sign(privateKey, algID.getName());
-            //cert.sign(privateKey, this.sigAlg);
             if (provider == null) {
-                cert.sign(privateKey, this.sigAlg);
+                cert = X509CertImpl.newSigned(info, privateKey, this.sigAlg);
             } else {
-                cert.sign(privateKey, this.sigAlg, provider);
+                cert = X509CertImpl.newSigned(info, privateKey, this.sigAlg, provider);
             }
 
             if (debug != null) {
@@ -469,29 +462,22 @@ public final class CertAndKeyGen {
             X509CertInfo info = new X509CertInfo();
             // Add all mandatory attributes
             // Note here that V1 = 0, V2 = 1, V3 = 2
-            info.set(X509CertInfo.VERSION, new CertificateVersion(CertificateVersion.V3));
+            info.setVersion(new CertificateVersion(CertificateVersion.V3));
 
-            info.set(X509CertInfo.SERIAL_NUMBER,
-                    new CertificateSerialNumber((int) (firstDate.getTime() / 1000)));
+            info.setSerialNumber(new CertificateSerialNumber((int) (firstDate.getTime() / 1000)));
             AlgorithmId algID = issuer.getAlgorithmId();
-            info.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algID));
-            // info.set(X509CertInfo.SUBJECT, new
+            info.setAlgorithmId(new CertificateAlgorithmId(algID));
+            // info.setSubject(new
             // CertificateSubjectName(myname));
-            info.set(X509CertInfo.SUBJECT, myname);
-            info.set(X509CertInfo.KEY, new CertificateX509Key(publicKey));
-            info.set(X509CertInfo.VALIDITY, interval);
-            // info.set(X509CertInfo.ISSUER,
-            // new CertificateIssuerName(issuer.getSigner()));
-            info.set(X509CertInfo.ISSUER, issuer.getSigner());
+            info.setSubject(myname);
+            info.setKey(new CertificateX509Key(publicKey));
+            info.setValidity(interval);
+            info.setIssuer(issuer.getSigner());
 
-            cert = new X509CertImpl(info);
-            // 991119 - Updated to match JDK 1.2.2 source.
-            // cert.sign(privateKey, algID.getName());
-            // cert.sign(privateKey, this.sigAlg);
             if (provider == null) {
-                cert.sign(privateKey, this.sigAlg);
+                cert = X509CertImpl.newSigned(info, privateKey, this.sigAlg);
             } else {
-                cert.sign(privateKey, this.sigAlg, provider);
+                cert = X509CertImpl.newSigned(info, privateKey, this.sigAlg, provider);
             }
 
             if (debug != null) {
@@ -600,28 +586,23 @@ public final class CertAndKeyGen {
             // Note here that V1 = 0, V2 = 1, V3 = 2
             if ((version != CertificateVersion.V1) && (version != CertificateVersion.V2)
                     && (version != CertificateVersion.V3)) {
-                info.set(X509CertInfo.VERSION, new CertificateVersion(CertificateVersion.V3));
+                info.setVersion(new CertificateVersion(CertificateVersion.V3));
             } else {
-                info.set(X509CertInfo.VERSION, new CertificateVersion(version));
+                info.setVersion(new CertificateVersion(version));
             }
 
-            info.set(X509CertInfo.SERIAL_NUMBER,
-                    new CertificateSerialNumber((int) (firstDate.getTime() / 1000)));
+            info.setSerialNumber(new CertificateSerialNumber((int) (firstDate.getTime() / 1000)));
             AlgorithmId algID = issuer.getAlgorithmId();
-            info.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algID));
-            info.set(X509CertInfo.SUBJECT, myname);
-            info.set(X509CertInfo.KEY, new CertificateX509Key(publicKey));
-            info.set(X509CertInfo.VALIDITY, interval);
-            info.set(X509CertInfo.ISSUER, issuer.getSigner());
+            info.setAlgorithmId(new CertificateAlgorithmId(algID));
+            info.setSubject(myname);
+            info.setKey(new CertificateX509Key(publicKey));
+            info.setValidity(interval);
+            info.setIssuer(issuer.getSigner());
 
-            cert = new X509CertImpl(info);
-            // 991119 - Updated to match JDK 1.2.2 source.
-            // cert.sign(privateKey, algID.getName());
-            // cert.sign(privateKey, this.sigAlg);
             if (provider == null) {
-                cert.sign(privateKey, this.sigAlg);
+                cert = X509CertImpl.newSigned(info, privateKey, this.sigAlg);
             } else {
-                cert.sign(privateKey, this.sigAlg, provider);
+                cert = X509CertImpl.newSigned(info, privateKey, this.sigAlg, provider);
             }
 
             if (debug != null) {
@@ -695,28 +676,23 @@ public final class CertAndKeyGen {
             // Note here that V1 = 0, V2 = 1, V3 = 2
             if ((version != CertificateVersion.V1) && (version != CertificateVersion.V2)
                     && (version != CertificateVersion.V3)) {
-                info.set(X509CertInfo.VERSION, new CertificateVersion(CertificateVersion.V3));
+                info.setVersion(new CertificateVersion(CertificateVersion.V3));
             } else {
-                info.set(X509CertInfo.VERSION, new CertificateVersion(version));
+                info.setVersion(new CertificateVersion(version));
             }
 
-            info.set(X509CertInfo.SERIAL_NUMBER,
-                    new CertificateSerialNumber((int) (firstDate.getTime() / 1000)));
+            info.setSerialNumber(new CertificateSerialNumber((int) (firstDate.getTime() / 1000)));
             AlgorithmId algID = issuer.getAlgorithmId();
-            info.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algID));
-            info.set(X509CertInfo.SUBJECT, myname);
-            info.set(X509CertInfo.KEY, new CertificateX509Key(publicKey));
-            info.set(X509CertInfo.VALIDITY, interval);
-            info.set(X509CertInfo.ISSUER, issuer.getSigner());
+            info.setAlgorithmId(new CertificateAlgorithmId(algID));
+            info.setSubject(myname);
+            info.setKey(new CertificateX509Key(publicKey));
+            info.setValidity(interval);
+            info.setIssuer(issuer.getSigner());
 
-            cert = new X509CertImpl(info);
-            // 991119 - Updated to match JDK 1.2.2 source.
-            // cert.sign(privateKey, algID.getName());
-            // cert.sign(privateKey, this.sigAlg);
             if (provider == null) {
-                cert.sign(privateKey, this.sigAlg);
+                cert = X509CertImpl.newSigned(info, privateKey, this.sigAlg);
             } else {
-                cert.sign(privateKey, this.sigAlg, provider);
+                cert = X509CertImpl.newSigned(info, privateKey, this.sigAlg, provider);
             }
 
             if (debug != null) {
@@ -786,20 +762,19 @@ public final class CertAndKeyGen {
 
             X509CertInfo info = new X509CertInfo();
             // Add all mandatory attributes
-            info.set(X509CertInfo.VERSION, new CertificateVersion(CertificateVersion.V3));
-            info.set(X509CertInfo.SERIAL_NUMBER,
-                    new CertificateSerialNumber(new java.util.Random().nextInt() & 0x7fffffff));
+            info.setVersion(new CertificateVersion(CertificateVersion.V3));
+            info.setSerialNumber(new CertificateSerialNumber(new java.util.Random().nextInt() & 0x7fffffff));
             AlgorithmId algID = AlgorithmId.get(sigAlg);
-            info.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algID));
-            info.set(X509CertInfo.SUBJECT, myname);
-            info.set(X509CertInfo.KEY, new CertificateX509Key(publicKey));
-            info.set(X509CertInfo.VALIDITY, interval);
-            info.set(X509CertInfo.ISSUER, myname);
+            info.setAlgorithmId(new CertificateAlgorithmId(algID));
+            info.setSubject(myname);
+            info.setKey(new CertificateX509Key(publicKey));
+            info.setValidity(interval);
+            info.setIssuer(myname);
             if (ext != null)
-                info.set(X509CertInfo.EXTENSIONS, ext);
+                info.setExtensions(ext);
 
-            cert = new X509CertImpl(info);
-            cert.sign(privateKey, this.sigAlg);
+            cert = X509CertImpl.newSigned(info, privateKey, this.sigAlg);
+
             if (debug != null) {
                 debug.exit(Debug.TYPE_PUBLIC, className, "getSelfCertificate",
                         (X509Certificate) cert);
@@ -836,20 +811,19 @@ public final class CertAndKeyGen {
 
             X509CertInfo info = new X509CertInfo();
             // Add all mandatory attributes
-            info.set(X509CertInfo.VERSION, new CertificateVersion(CertificateVersion.V3));
-            info.set(X509CertInfo.SERIAL_NUMBER,
-                    new CertificateSerialNumber(new java.util.Random().nextInt() & 0x7fffffff));
+            info.setVersion(new CertificateVersion(CertificateVersion.V3));
+            info.setSerialNumber(new CertificateSerialNumber(new java.util.Random().nextInt() & 0x7fffffff));
             AlgorithmId algID = AlgorithmId.get(sigAlg);
-            info.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algID));
-            info.set(X509CertInfo.SUBJECT, myname);
-            info.set(X509CertInfo.KEY, new CertificateX509Key(publicKey));
-            info.set(X509CertInfo.VALIDITY, interval);
-            info.set(X509CertInfo.ISSUER, myname);
+            info.setAlgorithmId(new CertificateAlgorithmId(algID));
+            info.setSubject(myname);
+            info.setKey(new CertificateX509Key(publicKey));
+            info.setValidity(interval);
+            info.setIssuer(myname);
             if (ext != null)
-                info.set(X509CertInfo.EXTENSIONS, ext);
+                info.setExtensions(ext);
 
-            cert = new X509CertImpl(info);
-            cert.sign(privateKey, this.sigAlg);
+            cert = X509CertImpl.newSigned(info, privateKey, this.sigAlg);
+
             if (debug != null) {
                 debug.exit(Debug.TYPE_PUBLIC, className, "getSelfCertificate",
                         (X509Certificate) cert);


### PR DESCRIPTION
Modifications were made to support `OpenJCEPlus` and `OpenJCEPlusFIPS` providers with Java version 21. This includes the following updates:

- The github action pipeline was updated to install and use JDK version 21 of Semeru for both compiliation and testing.
- `README.md` was updated to specifically document the requirement to use JDK 21 within the main branch.
- The maven `pom.xml` file was updated to enforce the use of JDK 21 when compiling and testing.
- The `AlgorithmId` class no longer defines OIDs as constants for Ed25519, Ed448, X25519, and X448. Code that references these variables was updated to make use of the `KnownOIDs` class where these algorithms OID values are defined.
- The `AlgorithmId` class no longer has a method named `derEncode`, instead we now use the method named `encode`.
- The DER encoding and decoding classes no longer throw an `IOException` under many conditions. Code handling this exception has been removed from various locations due to this change.
- Various references to Java 17 were updated to hardcode Java 21 where appropriate.
- Modifications were required to the `CertAndKeyGen` class to use a new set of APIs in the `X509CertImpl` class. Changes in this class includes using specific setter methods within `X509CertImpl` for certificate encodings and changing the way in which a signed certrificate is created with a new set of constructors.
- Modifications are made to the jgskit product info.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>