### PR TITLE
Update eyecatcher LegalCopyright and ProductName

### DIFF
--- a/src/main/native/jgskit_resource.rc
+++ b/src/main/native/jgskit_resource.rc
@@ -30,9 +30,9 @@ BEGIN
             VALUE "FileVersion", "17\0"
 	        VALUE "Build Increment", "0\0"
             VALUE "InternalName", "jgskit.dll\0"
-            VALUE "LegalCopyright", "(C) Copyright IBM Corp. 2023.\0"
+            VALUE "LegalCopyright", "(C) Copyright IBM Corp. 2023. Licensed under the Apache License 2.0.\0"
             VALUE "OriginalFilename", "jgskit.dll\0"
-            VALUE "ProductName", "IBM JCEPlus Crypto Provider for Windows, Java 2(tm), 17.0\0"
+            VALUE "ProductName", "OpenJCEPlus Crypto Provider for Windows, 17.0\0"
             VALUE "ProductVersion", "17.0\0"
         END
     END


### PR DESCRIPTION
This update adds the Apache V2 license to the LegalCopyright value
for the eyecatcher of the jgskit library.

The ProductName also removed Java 2 from the description.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>