### PR TITLE
Use KnownOIDs class for known curve constants

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/CurveUtil.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/CurveUtil.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 import java.security.InvalidParameterException;
 import java.util.HashMap;
 import java.util.Map;
-
+import sun.security.util.KnownOIDs;
 import sun.security.util.ObjectIdentifier;
 import sun.security.x509.AlgorithmId;
 
@@ -186,13 +186,13 @@ class CurveUtil {
     public static AlgorithmId getAlgId(CurveUtil.CURVE curve) throws IOException {
         switch (curve) {
             case Ed25519:
-                return new AlgorithmId(AlgorithmId.ed25519_oid);
+                return new AlgorithmId(ObjectIdentifier.of(KnownOIDs.Ed25519));
             case Ed448:
-                return new AlgorithmId(AlgorithmId.ed448_oid);
+                return new AlgorithmId(ObjectIdentifier.of(KnownOIDs.Ed448));
             case X25519:
-                return new AlgorithmId(AlgorithmId.x25519_oid);
+                return new AlgorithmId(ObjectIdentifier.of(KnownOIDs.X25519));
             case X448:
-                return new AlgorithmId(AlgorithmId.x448_oid);
+                return new AlgorithmId(ObjectIdentifier.of(KnownOIDs.X448));
             case FFDHE2048:
                 return new AlgorithmId(ObjectIdentifier.of("1.2.840.113549.1.3.1"));
             case FFDHE3072:


### PR DESCRIPTION
While developing necessary changes for Java 21 we noticed that the CurveUtil class needed to make use of the sun.security.util.KnownOIDs class. This update simply matches that required behavior for JDK 21 to define various OID constants.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>