### PR TITLE
Remove MD5 and SHA1 algorithms from OpenJCEPlusFIPS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ KeyFactory                  | X25519                     |                 |X   
 KeyFactory                  | X448                       |                 |X             |
 KeyFactory                  | XDH                        |                 |X             |
 KeyGenerator                | AES                        |X                |X             |
-KeyGenerator                | ChaCha20                   |                |X             |
+KeyGenerator                | ChaCha20                   |                 |X             |
 KeyGenerator                | DESede                     |                 |X             |
 KeyGenerator                | HmacMD5                    |                 |X             |
 KeyGenerator                | HmacSHA1                   |                 |X             |
@@ -289,8 +289,8 @@ Mac                         | HmacSHA3-384               |X                |X   
 Mac                         | HmacSHA3-512               |X                |X             |
 Mac                         | HmacSHA384                 |X                |X             |
 Mac                         | HmacSHA512                 |X                |X             |
-MessageDigest               | MD5                        |X                |X             |
-MessageDigest               | SHA-1                      |X                |X             |
+MessageDigest               | MD5                        |                 |X             |
+MessageDigest               | SHA-1                      |                 |X             |
 MessageDigest               | SHA-224                    |X                |X             |
 MessageDigest               | SHA-256                    |X                |X             |
 MessageDigest               | SHA-384                    |X                |X             |
@@ -316,7 +316,7 @@ Signature                   | RSAPSS                     |X                |X   
 Signature                   | RSAforSSL                  |X                |X             |
 Signature                   | SHA1withDSA                |                 |X             |
 Signature                   | SHA1withECDSA              |                 |X             |
-Signature                   | SHA1withRSA                |X                |X             |
+Signature                   | SHA1withRSA                |                 |X             |
 Signature                   | SHA224withDSA              |X                |X             |
 Signature                   | SHA224withECDSA            |X                |X             |
 Signature                   | SHA224withRSA              |X                |X             |

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -52,7 +52,7 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
             + "Signature algorithms               : NONEwithDSA, SHA224withDSA, SHA256withDSA,\n"
             + "                                     NONEwithECDSA, SHA224withECDSA,\n"
             + "                                       SHA256withECDSA, SHA384withECDSA, SHA512withECDSA,\n"
-            + "                                       NONEwithRSA, SHA1withRSA, SHA224withRSA,\n"
+            + "                                       NONEwithRSA, SHA224withRSA,\n"
             + "                                       SHA256withRSA, SHA384withRSA, SHA512withRSA, RSAPSS\n";
 
     private static final String OID_PKCS3 = "1.2.840.113549.1.3.1";
@@ -411,14 +411,6 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
          * MessageDigest engines
          * =======================================================================
          */
-        aliases = null;
-        putService(new OpenJCEPlusService(jce, "MessageDigest", "MD5",
-                "com.ibm.crypto.plus.provider.MessageDigest$MD5", aliases));
-
-        aliases = new String[] {"SHA", "SHA1", "OID.1.3.14.3.2.26", "1.3.14.3.2.26"};
-        putService(new OpenJCEPlusService(jce, "MessageDigest", "SHA-1",
-                "com.ibm.crypto.plus.provider.MessageDigest$SHA1", aliases));
-
         aliases = new String[] {"OID.2.16.840.1.101.3.4.2.4", "2.16.840.1.101.3.4.2.4", "SHA224"};
         putService(new OpenJCEPlusService(jce, "MessageDigest", "SHA-224",
                 "com.ibm.crypto.plus.provider.MessageDigest$SHA224", aliases));
@@ -557,13 +549,6 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
                 "SHA5/ECDSA", "SHA-512/ECDSA"};
         putService(new OpenJCEPlusService(jce, "Signature", "SHA512withECDSA",
                 "com.ibm.crypto.plus.provider.ECDSASignature$SHA512withECDSA", aliases));
-
-
-        aliases = new String[] {"OID.1.2.840.113549.1.1.5", "1.2.840.113549.1.1.5",
-                "OID.1.3.14.3.2.29", "1.3.14.3.2.29", "OID.1.3.14.3.2.26", "1.3.14.3.2.26",
-                "SHA-1withRSA", "SHAwithRSA", "SHA-1/RSA", "SHA1/RSA", "SHA/RSA", "RSA"};
-        putService(new OpenJCEPlusService(jce, "Signature", "SHA1withRSA",
-                "com.ibm.crypto.plus.provider.RSASignature$SHA1withRSA", aliases));
 
         aliases = new String[] {"OID.1.2.840.113549.1.1.14", "1.2.840.113549.1.1.14", "SHA-224/RSA",
                 "SHA224/RSA"};

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSASignatureChunkUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSASignatureChunkUpdate.java
@@ -10,6 +10,7 @@ package ibm.jceplus.junit.base;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
 import java.security.Signature;
 import java.security.SignatureException;
 
@@ -38,9 +39,27 @@ public class BaseTestRSASignatureChunkUpdate extends BaseTestSignature {
     public void tearDown() throws Exception {}
 
     public void testSignatureChunks() throws Exception {
-        testSignatureChunkUpdate(1024, "SHA1WithRSA", 100);
+        try {
+            testSignatureChunkUpdate(1024, "SHA1WithRSA", 100);
+        } catch (NoSuchAlgorithmException nsae) {
+            if (providerName.contains("FIPS")) {
+                assertEquals("no such algorithm: SHA1WithRSA for provider OpenJCEPlusFIPS", nsae.getMessage());
+            } else {
+                throw nsae;
+            }
+        }
+        
         testSignatureChunkUpdate(1024, "SHA256WithRSA", 100);
-        testSignatureChunkUpdate2(1024, "SHA1WithRSA", 100); // Test signing failure with OpenJCEPlusFIPS
+        
+        try {
+            testSignatureChunkUpdate2(1024, "SHA1WithRSA", 100);
+        } catch (NoSuchAlgorithmException nsae) {
+            if (providerName.contains("FIPS")) {
+                assertEquals("no such algorithm: SHA1WithRSA for provider OpenJCEPlusFIPS", nsae.getMessage());
+            } else {
+                throw nsae;
+            }
+        }
     }
 
     private void testSignatureChunkUpdate(int inputSize, String sigAlgo, int chunkSize)

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAll.java
@@ -33,7 +33,7 @@ import junit.framework.Test;
         TestHmacSHA3_512.class, TestImplementationClassesExist.class,
         TestImplementationClassesFinal.class, TestInvalidArrayIndex.class,
         TestPublicMethodsToMakeNonPublic.class, TestRSA.class, TestRSAKey.class,
-        TestRSAPSS.class, TestMiniRSAPSS2.class, TestRSASignature.class,
+        TestRSAPSS.class, TestMD5.class, TestMiniRSAPSS2.class, TestRSASignature.class,
         TestRSASignatureInteropSunRsaSign.class, TestRSASignatureChunkUpdate.class,
         TestRSATypeCheckDefault.class, TestSHA1.class, TestSHA224.class, TestSHA256.class,
         TestSHA384.class, TestSHA512.class, TestRSAPSSInterop2.class, TestRSAPSSInterop3.class,

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestMD5.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestMD5.java
@@ -8,10 +8,14 @@
 
 package ibm.jceplus.junit.openjceplusfips;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.Cipher;
+import ibm.jceplus.junit.base.BaseTest;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
-public class TestMD5 extends ibm.jceplus.junit.base.BaseTestMD5 {
+public class TestMD5 extends BaseTest {
 
     //--------------------------------------------------------------------------
     //
@@ -25,6 +29,14 @@ public class TestMD5 extends ibm.jceplus.junit.base.BaseTestMD5 {
     //
     public TestMD5() {
         super(Utils.TEST_SUITE_PROVIDER_NAME);
+    }
+
+    public static void testMD5Cipher() throws Exception {
+        try {
+            Cipher.getInstance("MD5", Utils.TEST_SUITE_PROVIDER_NAME);
+        } catch (NoSuchAlgorithmException nsae) {
+            assertEquals("No such algorithm: MD5", nsae.getMessage());
+        }
     }
 
     //--------------------------------------------------------------------------

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA1.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA1.java
@@ -8,10 +8,14 @@
 
 package ibm.jceplus.junit.openjceplusfips;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.Cipher;
+import ibm.jceplus.junit.base.BaseTest;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
-public class TestSHA1 extends ibm.jceplus.junit.base.BaseTestSHA1 {
+public class TestSHA1 extends BaseTest {
 
     //--------------------------------------------------------------------------
     //
@@ -25,6 +29,14 @@ public class TestSHA1 extends ibm.jceplus.junit.base.BaseTestSHA1 {
     //
     public TestSHA1() {
         super(Utils.TEST_SUITE_PROVIDER_NAME);
+    }
+
+    public static void testSHA1Cipher() throws Exception {
+        try {
+            Cipher.getInstance("SHA1", Utils.TEST_SUITE_PROVIDER_NAME);
+        } catch (NoSuchAlgorithmException nsae) {
+            assertEquals("No such algorithm: SHA1", nsae.getMessage());
+        }
     }
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
MD5 and SHA1 algorithms do not strictly adhere to FIPS policies.

These algorithms should be removed from registration within the OpenJCEPlusFIPS provider.