### PR TITLE
Check the RSA keysize in Signature

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/RSASignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSASignature.java
@@ -17,6 +17,8 @@ import java.security.PublicKey;
 import java.security.SignatureException;
 import java.security.SignatureSpi;
 import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.RSAKeyGenParameterSpec;
+
 import com.ibm.crypto.plus.provider.RSAUtil.KeyType;
 import com.ibm.crypto.plus.provider.ock.Signature;
 
@@ -82,6 +84,22 @@ abstract class RSASignature extends SignatureSpi {
 
         if (!(privateKey instanceof java.security.interfaces.RSAPrivateKey)) {
             throw new InvalidKeyException("Key is not an RSAPrivateKey");
+        }
+
+        try {
+            if (provider.isFIPS()) {
+                RSAKeyFactory.checkKeyLengths(((java.security.interfaces.RSAPrivateKey) privateKey).getModulus().bitLength(),
+                        RSAKeyGenParameterSpec.F4,
+                        RSAKeyFactory.MIN_MODLEN_FIPS,
+                        64 * 1024);
+            } else {
+                RSAKeyFactory.checkKeyLengths(((java.security.interfaces.RSAPrivateKey) privateKey).getModulus().bitLength(),
+                        RSAKeyGenParameterSpec.F4,
+                        RSAKeyFactory.MIN_MODLEN_NONFIPS,
+                        64 * 1024);
+            }
+        } catch (InvalidKeyException e) {
+            throw new InvalidParameterException(e.getMessage());
         }
 
         //RSAPrivateCrtKey rsaPrivate = (RSAPrivateCrtKey) RSAKeyFactory.toRSAKey(provider, privateKey);

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAll.java
@@ -39,7 +39,7 @@ import junit.framework.Test;
         TestSHA384.class, TestSHA512.class, TestRSAPSSInterop2.class, TestRSAPSSInterop3.class,
         TestSHA3_224.class, TestSHA3_256.class, TestSHA3_384.class, TestSHA3_512.class,
         TestRSAKeyInterop.class, TestRSAKeyInteropBC.class, TestRSAPSS2.class,
-        TestFIPSVerifyOnlyTest.class})
+        TestFIPSVerifyOnlyTest.class, TestRSASignatureInteropNonFIPS.class})
 
 public class TestAll {
 

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSASignatureInteropNonFIPS.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSASignatureInteropNonFIPS.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright IBM Corp. 2023
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution.
+ */
+package ibm.jceplus.junit.openjceplusfips;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+public class TestRSASignatureInteropNonFIPS 
+    extends ibm.jceplus.junit.base.BaseTestRSASignatureInterop {
+
+    //--------------------------------------------------------------------------
+    //
+    //
+    static {
+        Utils.loadProviderTestSuite();
+    }
+
+    //--------------------------------------------------------------------------
+    //
+    //
+    public TestRSASignatureInteropNonFIPS() {
+        super(Utils.TEST_SUITE_PROVIDER_NAME, Utils.PROVIDER_SunRsaSign, 1024);
+    }
+
+    // RSA signature allows at least 2048 bits of RSA key to be used for sign a signature.
+    @Override
+    protected void doSignVerify(String sigAlgo, byte[] message, PrivateKey privateKey,
+            PublicKey publicKey) throws Exception {
+        Signature signing = Signature.getInstance(sigAlgo, Utils.TEST_SUITE_PROVIDER_NAME);
+        try {
+            signing.initSign(privateKey);
+        } catch (java.security.InvalidParameterException ipe) {
+            if (providerName.equals("OpenJCEPlusFIPS")) {
+                assertEquals("RSA keys must be at least 2048 bits long", ipe.getMessage());
+                return;
+            } else {
+                throw ipe;
+            }
+        }
+        signing.update(message);
+        byte[] signedBytes = signing.sign();
+
+        Signature verifying = Signature.getInstance(sigAlgo, Utils.TEST_SUITE_PROVIDER_NAME);
+        verifying.initVerify(publicKey);
+        verifying.update(message);
+        assertTrue("Signature verification failed", verifying.verify(signedBytes));
+    }
+
+    // Use a non FIPS provider to get a 1024 bits of RSA key.
+    @Override
+    protected KeyPair generateKeyPair(int keysize) throws Exception {
+        KeyPairGenerator rsaKeyPairGen = KeyPairGenerator.getInstance("RSA", Utils.PROVIDER_SunRsaSign);
+        rsaKeyPairGen.initialize(keysize);
+        return rsaKeyPairGen.generateKeyPair();
+    }
+
+    //--------------------------------------------------------------------------
+    //
+    //
+    public static void main(String[] args) throws Exception {
+        junit.textui.TestRunner.run(suite());
+    }
+
+    //--------------------------------------------------------------------------
+    //
+    //
+    public static Test suite() {
+        TestSuite suite = new TestSuite(TestRSASignatureInteropNonFIPS.class);
+        return suite;
+    }
+}

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSASignature.java
@@ -24,7 +24,7 @@ public class TestRSASignature extends BaseTestRSASignature {
     //
     //
     public TestRSASignature() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME);
+        super(Utils.TEST_SUITE_PROVIDER_NAME, 2048);
     }
 
     public void testRSASignature() throws Exception {


### PR DESCRIPTION
At least 2048 bits of RSA key can be
used for Sign in Signature. However,
current openjceplusfips provider can
accept a RSA key which size is smaller
than 1024.

Add a check in the engineInitSign()
function to filter the keysize.