### PR TITLE
Build OCKC and execute OpenJCEPlus tests

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -37,70 +37,81 @@ jobs:
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server."
       - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
       - name: List files in the repository
         run: |
           tree ${{ github.workspace }}
-      - name: Set up Visual Studio shell
-        uses: egor-tensin/vs-shell@v2
+#      - name: Set up Visual Studio shell
+#        uses: egor-tensin/vs-shell@v2
+#        with:
+#          arch: x64
+      - name: 'Checkout Open Cryptography Kit C'
+        uses: actions/checkout@v4
         with:
-          arch: x64         
+          repository: IBM/OpenCryptographyKitC
+          ref: a1dcebb20bdc2fed3e40af2eed67fbe899cb1d68 # main branch on March 18th 2024.
+          path: ${{ github.workspace }}/OpenCryptographyKitC
+      - name: Compile Open Cryptography Kit C
+        run: |
+          cd ${{ github.workspace }}/OpenCryptographyKitC/icc
+          make -k OPSYS=AMD64_LINUX CONFIG=release create_all
+          export LD_LIBRARY_PATH=${{ github.workspace }}/OpenCryptographyKitC/openssl-1.1.1/
+          make -k OPSYS=AMD64_LINUX CONFIG=release all
+          make -k OPSYS=AMD64_LINUX CONFIG=release iccpkg
+          make -k OPSYS=AMD64_LINUX CONFIG=release show_config
+          cd ..
+          cd iccpkg
+          make -k OPSYS=AMD64_LINUX CONFIG=release all
+          cd ${{ github.workspace }}
       - name: Extract OCK SDK and Binary Tar File
         run: |
           mkdir ${{ github.workspace }}/OCK
           cd ${{ github.workspace }}/OCK
-          curl -H "Authorization: Bearer ${{ secrets.OCKTARTOKEN }}" -H "Accept: application/octet-stream" -L https://api.github.com/repos/jasonkatonica/OpenICCBinaries/releases/assets/132177365 --output jgsk_crypto.tar
-          curl -H "Authorization: Bearer ${{ secrets.OCKTARTOKEN }}" -H "Accept: application/octet-stream" -L https://api.github.com/repos/jasonkatonica/OpenICCBinaries/releases/assets/132177348 --output jgsk_crypto_sdk.tar
+          cp ${{ github.workspace }}/OpenCryptographyKitC/package/jgsk_crypto.tar .
+          cp ${{ github.workspace }}/OpenCryptographyKitC/package/jgsk_crypto_sdk.tar .
           ls -al
           tree
           tar -xvf jgsk_crypto.tar
           tar -xvf jgsk_crypto_sdk.tar
           mkdir jgsk_sdk/lib64
           cp ${{ matrix.gskit_lib_name }} jgsk_sdk/lib64
-      - name: Setup Semeru JDK 17
-        uses: actions/setup-java@v3
+      - name: Setup Semeru JDK
+        uses: actions/setup-java@v4
         with:
-          java-version: '21.0.2+13'
+          java-version: '21.0.2+13.0.LTS'
           distribution: 'semeru'
           architecture: 'x64'
       # Uncomment to capture all files in the runner for debugging purposes.          
       # - name: List Files In Entire Runner
       #   run: |
       #     tree ${{ matrix.github_actions_runner_root }}
-      - name: Execute Maven Install Target
-        run: mvn --batch-mode '-Dock.library.path=${{ github.workspace }}/OCK/' install
+      - name: Execute Maven Install Target And OpenJCEPlus Provider Tests
+        run: mvn --batch-mode '-Dock.library.path=${{ github.workspace }}/OCK/' -Dtest=ibm.jceplus.junit.openjceplus.TestAll install
         env:
           GSKIT_HOME: ${{ github.workspace }}/OCK/jgsk_sdk
-          #GSKIT_64_HOME: ${{ github.workspace }}\OCK\jgsk_sdk # Used by windows build.
-      - name: List Files In The Entire Workspace
-        run: |
-          tree ${{ github.workspace }}
+      #- name: List Files In The Entire Workspace
+      #  run: |
+      #    tree ${{ github.workspace }}
       - name: Archive openjceplus.jar
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: openjceplus.jar
           path: target/openjceplus.jar
       - name: Archive openjceplus-tests.jar
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: openjceplus-tests.jar
           path: target/openjceplus-tests.jar
       - name: Archive libjgskit.so
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: libjgskit.so
           path: target/${{ matrix.target_lib_bin_dir }}/libjgskit.so 
-      - name: Test Report ${{ matrix.os }}.
+      - name: Archive OpenJCEPlus Assemblies
+        uses: actions/upload-artifact@v4
         with:
-          check_name: Test Report ${{ matrix.os }}
-          fail_on_test_failures: false
-        if: success() || failure()
-        uses: scacap/action-surefire-report@v1
-      - name: Archive Assembly
-        uses: actions/upload-artifact@v3
-        with:
-          name: openjceplus-jacoco.zip
-          path: target/openjceplus-jacoco.zip
+          name: openjceplus-assemblies.zip
+          path: target/openjceplus-assemblies.zip
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ considered FIPS compliant. Achieving certified FIPS cryptography requires the un
 and architectures. Any cryptographic libraries developed must adhere to rigorous FIPS standards and should not be assumed to be available in any environment.
 All environments and binaries must undergo the FIPS certification process with NIST to ensure compliance.**
 
-This github branch can only be used with Java version 21.
+This github branch can only be used with the latest generally available version of Java.
+
+Build Status:
+
+[![GitHub Actions OpenJCEPlus](https://github.com/IBM/OpenJCEPlus/actions/workflows/github-actions.yml/badge.svg?branch=main)](https://github.com/IBM/OpenJCEPlus/actions/workflows/github-actions.yml)
 
 ## How to Build `OpenJCEPlus` and Java Native Interface Library
 
@@ -93,7 +97,7 @@ You can test your installation by issuing `mvn --version`. For example:
     cd OpenJCEPlus
     ```
 
-1. Set your `JAVA_HOME` environment variable. This will be the SDK used to compile the project. You must set your JAVA_HOME value to Java version 21 when using code located in the `main` branch.
+1. Set your `JAVA_HOME` environment variable. This will be the SDK used to compile the project. You must set your JAVA_HOME value to the latest generally available version of Java when using code located in the `main` branch.
 
     ```console
     export JAVA_HOME="/opt/ibm/sdks/jdk-21.0.2+13"
@@ -149,7 +153,7 @@ On AIX you must set an additional setting for the `LIBPATH` environment variable
 export LIBPATH="$PROJECT_HOME/OCK/:$PROJECT_HOME/OCK/jgsk_sdk"
 ```
 
-On all platforms set the following environment variables and execute all the tests using `mvn`. You must set your JAVA_HOME value to Java version 21 when using code located in the `main` branch.
+On all platforms set the following environment variables and execute all the tests using `mvn`. You must set your JAVA_HOME value to the latest generally available version of Java when using code located in the `main` branch.
 
 ```console
 export JAVA_HOME="$JAVA_INSTALL_DIRECTORY/jdk-21.0.2+13"
@@ -167,7 +171,7 @@ On AIX you must set an additional setting for the `LIBPATH` environment variable
 export LIBPATH="$PROJECT_HOME/OCK/:$PROJECT_HOME/OCK/jgsk_sdk"
 ```
 
-On all platforms change to the OpenJCEPlus directory and set the following environment variables and execute a specific test name using `mvn`. You must set your JAVA_HOME value to Java version 21 when using code located in the `main` branch.
+On all platforms change to the OpenJCEPlus directory and set the following environment variables and execute a specific test name using `mvn`. You must set your JAVA_HOME value to the latest generally available version of Java when using code located in the `main` branch.
 
 ```console
 cd OpenJCEPlus

--- a/assembly.xml
+++ b/assembly.xml
@@ -1,21 +1,36 @@
-    <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
-      <id>jacoco</id>
-      <formats>
-        <format>zip</format>
-      </formats>
-      <fileSets>
-        <fileSet>
-          <directory>${project.basedir}</directory>
-          <outputDirectory>/</outputDirectory>
-          <includes>
-            <include>README*</include>
-            <include>LICENSE*</include>
-          </includes>
-        </fileSet>
-        <fileSet>
-          <directory>${project.build.directory}/site/jacoco</directory>
-          <outputDirectory>jacoco</outputDirectory>
-        </fileSet>
-      </fileSets>
-    </assembly>
+<!--
+###############################################################################
+#
+# Copyright IBM Corp. 2024
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution.
+#
+###############################################################################
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <id>assemblies</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <fileSets>
+    <fileSet>
+      <directory>${project.basedir}</directory>
+      <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>README*</include>
+        <include>LICENSE*</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/site/jacoco</directory>
+      <outputDirectory>jacoco</outputDirectory>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/surefire-reports</directory>
+      <outputDirectory>surefire-reports</outputDirectory>
+    </fileSet>
+  </fileSets>
+</assembly>


### PR DESCRIPTION
The github action associated with this repository will now clone code from the OpenCryptographyKitC open source project and build this code as part of the github action.

Given that the OpenCryptographyKitC only builds the libraries associated with the OpenJCEPlus provider we will only run those tests for the time being.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>
