### PR TITLE
Use own version of OpenJCEPlus when JDK has another bundled

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ export GSKIT_HOME="$PROJECT_HOME/OCK/jgsk_sdk"
 mvn '-Dock.library.path=$PROJECT_HOME/OCK/' test
 ```
 
+**NOTE**: When using a JDK that doesn't have `OpenJCEPlus` bundled with it, you might notice a few warnings like `WARNING: Unknown module: openjceplus specified to --add-exports`. There is no need to worry as they do not affect execution of tests or the build itself.
+
 ### Run single test
 
 On AIX you must set an additional setting for the `LIBPATH` environment variable:

--- a/pom.xml
+++ b/pom.xml
@@ -347,14 +347,22 @@
                   <artifactId>maven-surefire-plugin</artifactId>
                   <version>3.2.2</version>
                   <configuration>
+                    <useModulePath>false</useModulePath>
                     <!-- Could add -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0.0.0.0:8787 for debug -->
                     <argLine>
                       @{argLine}
+                      --patch-module openjceplus="target${file.separator}classes${path.separator}target${file.separator}test-classes"
                       --add-exports=java.base/sun.security.internal.spec=openjceplus
                       --add-exports=java.base/sun.security.util=openjceplus
                       --add-exports=java.base/sun.security.internal.interfaces=openjceplus
                       --add-exports=java.base/sun.security.x509=openjceplus
                       --add-exports=java.base/sun.security.pkcs=openjceplus
+                      --add-exports=java.base/sun.security.internal.spec=ALL-UNNAMED
+                      --add-exports=java.base/sun.security.util=ALL-UNNAMED
+                      --add-exports=java.base/sun.security.internal.interfaces=ALL-UNNAMED
+                      --add-exports=java.base/sun.security.x509=ALL-UNNAMED
+                      --add-exports=java.base/sun.security.pkcs=ALL-UNNAMED
+                      --add-exports=openjceplus/ibm.jceplus.junit=ALL-UNNAMED
                       --add-exports=openjceplus/ibm.jceplus.junit.base=ALL-UNNAMED
                       --add-exports=openjceplus/ibm.jceplus.junit.base.memstress=ALL-UNNAMED
                       --add-exports=openjceplus/ibm.jceplus.junit.openjceplus=ALL-UNNAMED


### PR DESCRIPTION
When trying to execute tests, the OpenJCEPlus already bundled with the JDK is used, if available. These changes allow maven to actually test one's own version.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/31

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com) 