### PR TITLE
Revert "Remove RSA Cipher from OpenJCEPlusFIPS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Cipher                      | AES/GCM/NoPadding          |X                |X   
 Cipher                      | ChaCha20                   |                 |X             |
 Cipher                      | ChaCha20-Poly1305          |                 |X             |
 Cipher                      | DESede                     |                 |X             |
-Cipher                      | RSA                        |                 |X             |
+Cipher                      | RSA                        |X                |X             |
 KeyAgreement                | DiffieHellman              |X                |X             |
 KeyAgreement                | ECDH                       |X                |X             |
 KeyAgreement                | X25519                     |                 |X             |

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -195,6 +195,10 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
         putService(new OpenJCEPlusService(jce, "Cipher", "AES",
                 "com.ibm.crypto.plus.provider.AESCipher", aliases));
 
+        aliases = null;
+        putService(new OpenJCEPlusService(jce, "Cipher", "RSA", "com.ibm.crypto.plus.provider.RSA",
+                aliases));
+
         /* =======================================================================
          * Key agreement
          * =======================================================================

--- a/src/test/java/ibm/jceplus/junit/TestMultithreadFIPS.java
+++ b/src/test/java/ibm/jceplus/junit/TestMultithreadFIPS.java
@@ -52,6 +52,7 @@ public class TestMultithreadFIPS extends TestCase {
             "ibm.jceplus.junit.openjceplusfips.multithread.TestSHA512",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestSHA256Clone_SharedMD",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestRSASignature",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestRSA_2048",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestRSAKey",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestRSASignatureInteropSunRsaSign",
             /*"ibm.jceplus.junit.openjceplusfips.multithread.TestHKDF",*/

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSA.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSA.java
@@ -1181,6 +1181,36 @@ public class BaseTestRSA extends BaseTestCipher {
         }
     }
 
+    // --------------------------------------------------------------------------
+    // This method is to check whether an algorithm is valid for the cipher
+    // but not supported by a given provider.
+    //
+    @Override
+    public boolean isAlgorithmValidButUnsupported(String algorithm) {
+        if (algorithm.equalsIgnoreCase("RSAwithNoPad") || algorithm.equalsIgnoreCase("RSAforSSL")) {
+            return true;
+        }
+
+        return super.isAlgorithmValidButUnsupported(algorithm);
+    }
+
+    // --------------------------------------------------------------------------
+    // This method is to check whether a padidng is valid for the cipher
+    // but not supported by a given provider.
+    //
+    @Override
+    public boolean isPaddingValidButUnsupported(String padding) {
+        if (padding.equalsIgnoreCase("ZeroPadding")
+                || padding.equalsIgnoreCase("OAEPWithSHA-224AndMGF1Padding")
+                || padding.equalsIgnoreCase("OAEPWithSHA-256AndMGF1Padding")
+                || padding.equalsIgnoreCase("OAEPWithSHA-384AndMGF1Padding")
+                || padding.equalsIgnoreCase("OAEPWithSHA-512AndMGF1Padding")) {
+            return true;
+        }
+
+        return super.isPaddingValidButUnsupported(padding);
+    }
+
     //--------------------------------------------------------------------------
     //
     //

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInterop.java
@@ -11,7 +11,6 @@ package ibm.jceplus.junit.base;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
@@ -537,17 +536,7 @@ public class BaseTestRSAKeyInterop extends BaseTestInterop {
 
             RSAPublicKey rsaPubPlus = (RSAPublicKey) rsaKeyPairPlus.getPublic();
             rsaKeyPairPlus.getPrivate();
-            Cipher cipherPlus = null;
-            try {
-                cipherPlus = Cipher.getInstance("RSA/ECB/PKCS1Padding", providerName);
-            } catch (NoSuchAlgorithmException nsae) {
-                if (providerName.equals("OpenJCEPlusFIPS")) {
-                    assertEquals("No such algorithm: RSA/ECB/PKCS1Padding", nsae.getMessage());
-                    return;
-                } else {
-                    throw nsae;
-                }
-            }
+            Cipher cipherPlus = Cipher.getInstance("RSA/ECB/PKCS1Padding", providerName);
             cipherPlus.init(Cipher.ENCRYPT_MODE, rsaPubPlus);
             cipherText = cipherPlus.doFinal(msgBytes);
 
@@ -560,17 +549,7 @@ public class BaseTestRSAKeyInterop extends BaseTestInterop {
             RSAPrivateCrtKey rsaPrivJCE = (RSAPrivateCrtKey) rsaKeyFactoryJCE
                     .generatePrivate(pkcs8SpecPlus);
 
-            Cipher cipherJCE = null;
-            try {
-                cipherJCE = Cipher.getInstance("RSA/ECB/PKCS1Padding", providerName);
-            } catch (NoSuchAlgorithmException nsae) {
-                if (providerName.equals("OpenJCEPlusFIPS")) {
-                    assertEquals("No such algorithm: RSA/ECB/PKCS1Padding", nsae.getMessage());
-                    return;
-                } else {
-                    throw nsae;
-                }
-            }
+            Cipher cipherJCE = Cipher.getInstance("RSA/ECB/PKCS1Padding", providerName);
             cipherJCE.init(Cipher.DECRYPT_MODE, rsaPrivJCE);
             byte[] decryptedBytes = cipherJCE.doFinal(cipherText);
             System.out.println("msgBytes = " + toHex(msgBytes));
@@ -588,24 +567,13 @@ public class BaseTestRSAKeyInterop extends BaseTestInterop {
         //        "encrypt with JCE and decrypt with JCEPlus and vice versa").getBytes();
 
         try {
-            byte[] cipherText = null;
+            byte[] cipherText;
             rsaKeyPairGenJCE.initialize(this.keySize);
             KeyPair rsaKeyPairJCE = rsaKeyPairGenJCE.generateKeyPair();
 
             RSAPublicKey rsaPubJCE = (RSAPublicKey) rsaKeyPairJCE.getPublic();
             rsaKeyPairJCE.getPrivate();
-            Cipher cipherJCE = null;
-            try {
-                cipherJCE = Cipher.getInstance("RSA/ECB/PKCS1Padding", providerName);
-            } catch (NoSuchAlgorithmException nsae) {
-                if (providerName.equals("OpenJCEPlusFIPS")) {
-                    assertEquals("No such algorithm: RSA/ECB/PKCS1Padding", nsae.getMessage());
-                    return;
-                } else {
-                    throw nsae;
-                }
-            }
-            
+            Cipher cipherJCE = Cipher.getInstance("RSA/ECB/PKCS1Padding", providerName);
             cipherJCE.init(Cipher.ENCRYPT_MODE, rsaPubJCE);
             cipherText = cipherJCE.doFinal(msgBytes);
 
@@ -618,18 +586,7 @@ public class BaseTestRSAKeyInterop extends BaseTestInterop {
             RSAPrivateCrtKey rsaPrivPlus = (RSAPrivateCrtKey) rsaKeyFactoryPlus
                     .generatePrivate(pkcs8SpecJCE);
 
-            Cipher cipherPlus = null;
-            try {
-                cipherPlus = Cipher.getInstance("RSA/ECB/PKCS1Padding", providerName);
-            } catch (NoSuchAlgorithmException nsae) {
-                if (providerName.equals("OpenJCEPlusFIPS")) {
-                    assertEquals("No such algorithm: RSA/ECB/PKCS1Padding", nsae.getMessage());
-                    return;
-                } else {
-                    throw nsae;
-                }
-            }
-
+            Cipher cipherPlus = Cipher.getInstance("RSA/ECB/PKCS1Padding", providerName);
             cipherPlus.init(Cipher.DECRYPT_MODE, rsaPrivPlus);
             byte[] decryptedBytes = cipherPlus.doFinal(cipherText);
             System.out.println("msgBytes = " + toHex(msgBytes));

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInteropBC.java
@@ -11,7 +11,6 @@ package ibm.jceplus.junit.base;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
@@ -561,18 +560,7 @@ public class BaseTestRSAKeyInteropBC extends BaseTestInterop {
 
             RSAPublicKey rsaPubPlus = (RSAPublicKey) rsaKeyPairPlus.getPublic();
             rsaKeyPairPlus.getPrivate();
-            Cipher cipherPlus = null;
-            try {
-                cipherPlus = Cipher.getInstance("RSA/ECB/PKCS1Padding", providerName);
-            } catch (NoSuchAlgorithmException nsae) {
-                if (providerName.equals("OpenJCEPlusFIPS")) {
-                    assertEquals("No such algorithm: RSA/ECB/PKCS1Padding", nsae.getMessage());
-                    return;
-                } else {
-                    throw nsae;
-                }
-            }
-
+            Cipher cipherPlus = Cipher.getInstance("RSA/ECB/PKCS1Padding", providerName);
             cipherPlus.init(Cipher.ENCRYPT_MODE, rsaPubPlus);
             cipherText = cipherPlus.doFinal(msgBytes);
 
@@ -585,18 +573,7 @@ public class BaseTestRSAKeyInteropBC extends BaseTestInterop {
             RSAPrivateCrtKey rsaPrivBC = (RSAPrivateCrtKey) rsaKeyFactoryBC
                     .generatePrivate(pkcs8SpecPlus);
 
-            Cipher cipherBC = null;
-            try {
-                cipherBC = Cipher.getInstance("RSA/ECB/PKCS1Padding", providerName);
-            } catch (NoSuchAlgorithmException nsae) {
-                if (providerName.equals("OpenJCEPlusFIPS")) {
-                    assertEquals("No such algorithm: RSA/ECB/PKCS1Padding", nsae.getMessage());
-                    return;
-                } else {
-                    throw nsae;
-                }
-            }
-
+            Cipher cipherBC = Cipher.getInstance("RSA/ECB/PKCS1Padding", providerName);
             cipherBC.init(Cipher.DECRYPT_MODE, rsaPrivBC);
             byte[] decryptedBytes = cipherBC.doFinal(cipherText);
             System.out.println("msgBytes = " + toHex(msgBytes));
@@ -624,18 +601,7 @@ public class BaseTestRSAKeyInteropBC extends BaseTestInterop {
 
             RSAPublicKey rsaPubBC = (RSAPublicKey) rsaKeyPairBC.getPublic();
             rsaKeyPairBC.getPrivate();
-            Cipher cipherBC = null;
-            try {
-                cipherBC = Cipher.getInstance("RSA/ECB/PKCS1Padding", providerName);
-            } catch (NoSuchAlgorithmException nsae) {
-                if (providerName.equals("OpenJCEPlusFIPS")) {
-                    assertEquals("No such algorithm: RSA/ECB/PKCS1Padding", nsae.getMessage());
-                    return;
-                } else {
-                    throw nsae;
-                }
-            }
-
+            Cipher cipherBC = Cipher.getInstance("RSA/ECB/PKCS1Padding", providerName);
             cipherBC.init(Cipher.ENCRYPT_MODE, rsaPubBC);
             cipherText = cipherBC.doFinal(msgBytes);
 
@@ -648,18 +614,7 @@ public class BaseTestRSAKeyInteropBC extends BaseTestInterop {
             RSAPrivateCrtKey rsaPrivPlus = (RSAPrivateCrtKey) rsaKeyFactoryPlus
                     .generatePrivate(pkcs8SpecBC);
 
-            Cipher cipherPlus = null;
-            try {
-                cipherPlus = Cipher.getInstance("RSA/ECB/PKCS1Padding", providerName);
-            } catch (NoSuchAlgorithmException nsae) {
-                if (providerName.equals("OpenJCEPlusFIPS")) {
-                    assertEquals("No such algorithm: RSA/ECB/PKCS1Padding", nsae.getMessage());
-                    return;
-                } else {
-                    throw nsae;
-                }
-            }
-
+            Cipher cipherPlus = Cipher.getInstance("RSA/ECB/PKCS1Padding", providerName);
             cipherPlus.init(Cipher.DECRYPT_MODE, rsaPrivPlus);
             byte[] decryptedBytes = cipherPlus.doFinal(cipherText);
             System.out.println("msgBytes = " + toHex(msgBytes));

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSATypeCheckDisabled.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSATypeCheckDisabled.java
@@ -9,7 +9,6 @@ package ibm.jceplus.junit.base;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.interfaces.RSAPublicKey;
 import javax.crypto.Cipher;
@@ -50,17 +49,7 @@ public class BaseTestRSATypeCheckDisabled extends BaseTest {
     //
     //
     public void testPrivateKeyEncrypt() throws Exception {
-        Cipher cp = null;
-        try {
-            cp = Cipher.getInstance("RSA", providerName);
-        } catch (NoSuchAlgorithmException nsae) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
-                assertEquals("No such algorithm: RSA", nsae.getMessage());
-                return;
-            } else {
-                throw nsae;
-            }
-        }
+        Cipher cp = Cipher.getInstance("RSA", providerName);
         cp.init(Cipher.ENCRYPT_MODE, rsaPriv);
     }
 
@@ -68,18 +57,8 @@ public class BaseTestRSATypeCheckDisabled extends BaseTest {
     //
     //
     public void testPublicKeyDecrypt() throws Exception {
-        Cipher cp = null;
-        try {
-            cp = Cipher.getInstance("RSA", providerName);
-        } catch (NoSuchAlgorithmException nsae) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
-                assertEquals("No such algorithm: RSA", nsae.getMessage());
-                return;
-            } else {
-                throw nsae;
-            }
-        }
-        cp.init(Cipher.DECRYPT_MODE, rsaPub);        
+        Cipher cp = Cipher.getInstance("RSA", providerName);
+        cp.init(Cipher.DECRYPT_MODE, rsaPub);
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSATypeCheckEnabled.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSATypeCheckEnabled.java
@@ -10,7 +10,6 @@ package ibm.jceplus.junit.base;
 import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.interfaces.RSAPublicKey;
 import javax.crypto.Cipher;
@@ -52,17 +51,7 @@ public class BaseTestRSATypeCheckEnabled extends BaseTest {
     //
     public void testPrivateKeyEncrypt() throws Exception {
         try {
-            Cipher cp = null;
-            try {
-                cp = Cipher.getInstance("RSA", providerName);
-            } catch (NoSuchAlgorithmException nsae) {
-                if (providerName.equals("OpenJCEPlusFIPS")) {
-                    assertEquals("No such algorithm: RSA", nsae.getMessage());
-                    return;
-                } else {
-                    throw nsae;
-                }
-            }
+            Cipher cp = Cipher.getInstance("RSA", providerName);
             cp.init(Cipher.ENCRYPT_MODE, rsaPriv);
             fail("Expected InvalidKeyException did not occur");
         } catch (InvalidKeyException ike) {
@@ -75,17 +64,7 @@ public class BaseTestRSATypeCheckEnabled extends BaseTest {
     //
     public void testPublicKeyDecrypt() throws Exception {
         try {
-            Cipher cp = null;
-            try {
-                cp = Cipher.getInstance("RSA", providerName);
-            } catch (NoSuchAlgorithmException nsae) {
-                if (providerName.equals("OpenJCEPlusFIPS")) {
-                    assertEquals("No such algorithm: RSA", nsae.getMessage());
-                    return;
-                } else {
-                    throw nsae;
-                }
-            }
+            Cipher cp = Cipher.getInstance("RSA", providerName);
             cp.init(Cipher.DECRYPT_MODE, rsaPub);
             fail("Expected InvalidKeyException did not occur");
         } catch (InvalidKeyException ike) {

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAll.java
@@ -33,7 +33,7 @@ import junit.framework.Test;
         TestHmacSHA3_224.class, TestHmacSHA3_256.class, TestHmacSHA3_384.class,
         TestHmacSHA3_512.class, TestImplementationClassesExist.class,
         TestImplementationClassesFinal.class, TestInvalidArrayIndex.class,
-        TestPublicMethodsToMakeNonPublic.class, TestRSA.class, TestRSAKey.class,
+        TestPublicMethodsToMakeNonPublic.class, TestRSA.class, TestRSA_2048.class, TestRSAKey.class,
         TestRSAPSS.class, TestMiniRSAPSS2.class, TestRSASignature.class,
         TestRSASignatureInteropSunRsaSign.class, TestRSASignatureChunkUpdate.class,
         TestRSATypeCheckDefault.class, TestSHA1.class, TestSHA224.class, TestSHA256.class,

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSA.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSA.java
@@ -8,17 +8,11 @@
 
 package ibm.jceplus.junit.openjceplusfips;
 
-import java.security.NoSuchAlgorithmException;
-
-import javax.crypto.Cipher;
-
-import ibm.jceplus.junit.base.BaseTest;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
-public class TestRSA extends BaseTest {
+public class TestRSA extends ibm.jceplus.junit.base.BaseTestRSA {
 
-    protected int specifiedKeySize = 0;
     //--------------------------------------------------------------------------
     //
     //
@@ -37,8 +31,7 @@ public class TestRSA extends BaseTest {
     //
     //
     public TestRSA(int keySize) throws Exception {
-        super(Utils.TEST_SUITE_PROVIDER_NAME);
-        this.specifiedKeySize = keySize;
+        super(Utils.TEST_SUITE_PROVIDER_NAME, keySize);
     }
 
     //--------------------------------------------------------------------------
@@ -54,18 +47,6 @@ public class TestRSA extends BaseTest {
     public static Test suite() {
         TestSuite suite = new TestSuite(TestRSA.class);
         return suite;
-    }
-
-        // --------------------------------------------------------------------------
-    // This method is to check whether OpenJCEPlusFIPS can throw exception with RSA cipher 
-    //
-    public static void testLoadRSACipher() throws Exception{
-        try {
-            Cipher.getInstance("RSA", Utils.TEST_SUITE_PROVIDER_NAME);
-        } catch (NoSuchAlgorithmException nsae) {
-            assertEquals("No such algorithm: RSA", nsae.getMessage());
-            return;
-        }
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSA_1024.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSA_1024.java
@@ -6,12 +6,12 @@
  * in the file LICENSE in the source distribution.
  */
 
-package ibm.jceplus.junit.openjceplus;
+package ibm.jceplus.junit.openjceplusfips;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
-public class TestRSA extends ibm.jceplus.junit.base.BaseTestRSA {
+public class TestRSA_1024 extends TestRSA {
 
     //--------------------------------------------------------------------------
     //
@@ -23,15 +23,13 @@ public class TestRSA extends ibm.jceplus.junit.base.BaseTestRSA {
     //--------------------------------------------------------------------------
     //
     //
-    public TestRSA() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME);
-    }
+    private static final int KEY_SIZE = 1024;
 
     //--------------------------------------------------------------------------
     //
     //
-    public TestRSA(int keySize) throws Exception {
-        super(Utils.TEST_SUITE_PROVIDER_NAME, keySize);
+    public TestRSA_1024() throws Exception {
+        super(KEY_SIZE);
     }
 
     //--------------------------------------------------------------------------
@@ -45,7 +43,7 @@ public class TestRSA extends ibm.jceplus.junit.base.BaseTestRSA {
     //
     //
     public static Test suite() {
-        TestSuite suite = new TestSuite(TestRSA.class);
+        TestSuite suite = new TestSuite(TestRSA_1024.class);
         return suite;
     }
 }

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSA_2048.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSA_2048.java
@@ -6,12 +6,12 @@
  * in the file LICENSE in the source distribution.
  */
 
-package ibm.jceplus.junit.openjceplus;
+package ibm.jceplus.junit.openjceplusfips;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
-public class TestRSA extends ibm.jceplus.junit.base.BaseTestRSA {
+public class TestRSA_2048 extends TestRSA {
 
     //--------------------------------------------------------------------------
     //
@@ -23,15 +23,13 @@ public class TestRSA extends ibm.jceplus.junit.base.BaseTestRSA {
     //--------------------------------------------------------------------------
     //
     //
-    public TestRSA() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME);
-    }
+    private static final int KEY_SIZE = 2048;
 
     //--------------------------------------------------------------------------
     //
     //
-    public TestRSA(int keySize) throws Exception {
-        super(Utils.TEST_SUITE_PROVIDER_NAME, keySize);
+    public TestRSA_2048() throws Exception {
+        super(KEY_SIZE);
     }
 
     //--------------------------------------------------------------------------
@@ -45,7 +43,7 @@ public class TestRSA extends ibm.jceplus.junit.base.BaseTestRSA {
     //
     //
     public static Test suite() {
-        TestSuite suite = new TestSuite(TestRSA.class);
+        TestSuite suite = new TestSuite(TestRSA_2048.class);
         return suite;
     }
 }

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSA_4096.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSA_4096.java
@@ -6,12 +6,12 @@
  * in the file LICENSE in the source distribution.
  */
 
-package ibm.jceplus.junit.openjceplus;
+package ibm.jceplus.junit.openjceplusfips;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
-public class TestRSA extends ibm.jceplus.junit.base.BaseTestRSA {
+public class TestRSA_4096 extends TestRSA {
 
     //--------------------------------------------------------------------------
     //
@@ -23,15 +23,13 @@ public class TestRSA extends ibm.jceplus.junit.base.BaseTestRSA {
     //--------------------------------------------------------------------------
     //
     //
-    public TestRSA() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME);
-    }
+    private static final int KEY_SIZE = 4096;
 
     //--------------------------------------------------------------------------
     //
     //
-    public TestRSA(int keySize) throws Exception {
-        super(Utils.TEST_SUITE_PROVIDER_NAME, keySize);
+    public TestRSA_4096() throws Exception {
+        super(KEY_SIZE);
     }
 
     //--------------------------------------------------------------------------
@@ -45,7 +43,7 @@ public class TestRSA extends ibm.jceplus.junit.base.BaseTestRSA {
     //
     //
     public static Test suite() {
-        TestSuite suite = new TestSuite(TestRSA.class);
+        TestSuite suite = new TestSuite(TestRSA_4096.class);
         return suite;
     }
 }

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSA_2048.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSA_2048.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright IBM Corp. 2023
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution.
+ */
+
+package ibm.jceplus.junit.openjceplusfips.multithread;
+
+import ibm.jceplus.junit.base.BaseTestRSA;
+import ibm.jceplus.junit.openjceplusfips.Utils;
+
+public class TestRSA_2048 extends BaseTestRSA {
+
+    //--------------------------------------------------------------------------
+    //
+    //
+    static {
+        Utils.loadProviderTestSuite();
+    }
+
+    //--------------------------------------------------------------------------
+    //
+    //
+    private static final int KEY_SIZE = 2048;
+
+    //--------------------------------------------------------------------------
+    //
+    //
+    public TestRSA_2048() throws Exception {
+        super(Utils.TEST_SUITE_PROVIDER_NAME, KEY_SIZE);
+    }
+
+    public void testRSA_2048() throws Exception {
+
+        System.out.println("executing testRSA_2048");
+        BaseTestRSA bt = new BaseTestRSA(providerName, KEY_SIZE);
+        bt.run();
+
+    }
+
+    // --------------------------------------------------------------------------
+    //
+    //
+    public static void main(String[] args) throws Exception {
+        String[] nargs = {
+                ibm.jceplus.junit.openjceplusfips.multithread.TestRSA_2048.class.getName()};
+        junit.textui.TestRunner.main(nargs);
+    }
+
+
+}
+


### PR DESCRIPTION
There is value in allowing a FIPS module call a non FIPS algoriothm
with the module so RSA encryption and decryption will be added again
to the FIPS provider.

This reverts commit https://github.com/IBM/OpenJCEPlus/commit/1c30d2888570daa95f214003aa5f8b1db2b4d954.

While reverting this commit the TestRSA_2048 test was being run for the
first time in the openjceplusfips multithread test suite. An adjustment
was needed to make it pass by moving the overrided methods for
isAlgorithmValidButUnsupported and isPaddingValidButUnsupported into the
child BaseTestRSA class.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>