### PR TITLE
Rename initialize method to ockInitialize

### DIFF
--- a/src/main/native/StaticStub.c
+++ b/src/main/native/StaticStub.c
@@ -33,7 +33,7 @@ JNIEXPORT jlong JNICALL Java_com_ibm_crypto_plus_provider_ock_NativeInterface_in
     int retcode = ICC_OK;
     ICC_STATUS status;
 
-    initialize();
+    ockInitialize();
 
     if( debug ) {
       gslogFunctionEntry(functionName);

--- a/src/main/native/Utils.c
+++ b/src/main/native/Utils.c
@@ -25,7 +25,7 @@ int debug = 0;   // FIXME
 //
 //
 void
-initialize()
+ockInitialize()
 {
   if( !initialized ) {
 #if DEBUG

--- a/src/main/native/Utils.h
+++ b/src/main/native/Utils.h
@@ -38,7 +38,7 @@ free((_ptr)); \
 
 extern int debug;
 
-void initialize();
+void ockInitialize();
 
 int gslogFunctionEntry( const char * functionName );
 int gslogError( const char * formatString, ...);


### PR DESCRIPTION
The method name `initialize` is too generic and may cause conflicts with other libraries who have the same symbol name loaded globally.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>