### PR TITLE
Use Semeru 22

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Setup Semeru JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '21.0.2+13.0.LTS'
+          java-version: '22.0.1+8'
           distribution: 'semeru'
           architecture: 'x64'
       # Uncomment to capture all files in the runner for debugging purposes.          

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can test your installation by issuing `mvn --version`. For example:
     $ mvn --version
     Apache Maven 3.9.2 (c9616018c7a021c1c39be70fb2843d6f5f9b8a1c)
     Maven home: /tools/apache-maven-3.9.2
-    Java version: 1.8.0_361, vendor: IBM Corporation, runtime: /opt/ibm/sdks/jdk-21.0.2+13
+    Java version: 1.8.0_361, vendor: IBM Corporation, runtime: /opt/ibm/sdks/jdk-22.0.1+8
     Default locale: en_US, platform encoding: ISO8859-1
     OS name: "aix", version: "7.2", arch: "ppc64", family: "unix"
     ```
@@ -100,7 +100,7 @@ You can test your installation by issuing `mvn --version`. For example:
 1. Set your `JAVA_HOME` environment variable. This will be the SDK used to compile the project. You must set your JAVA_HOME value to Java version 22 when using code located in the `java22` branch.
 
     ```console
-    export JAVA_HOME="/opt/ibm/sdks/jdk-21.0.2+13"
+    export JAVA_HOME="/opt/ibm/sdks/jdk-22.0.1+8"
     ```
 
 1. Set the location of the variable `GSKIT_SDK` to the directory extracted in the above steps.
@@ -156,7 +156,7 @@ export LIBPATH="$PROJECT_HOME/OCK/:$PROJECT_HOME/OCK/jgsk_sdk"
 On all platforms set the following environment variables and execute all the tests using `mvn`. You must set your JAVA_HOME value to Java version 22 when using code located in the `java22` branch.
 
 ```console
-export JAVA_HOME="$JAVA_INSTALL_DIRECTORY/jdk-21.0.2+13"
+export JAVA_HOME="$JAVA_INSTALL_DIRECTORY/jdk-22.0.1+8"
 export GSKIT_HOME="$PROJECT_HOME/OCK/jgsk_sdk"
 mvn '-Dock.library.path=$PROJECT_HOME/OCK/' test
 ```
@@ -175,7 +175,7 @@ On all platforms change to the OpenJCEPlus directory and set the following envir
 
 ```console
 cd OpenJCEPlus
-export JAVA_HOME="$JAVA_INSTALL_DIRECTORY/jdk-21.0.2+13"
+export JAVA_HOME="$JAVA_INSTALL_DIRECTORY/jdk-22.0.1+8"
 export GSKIT_HOME="$PROJECT_HOME/OCK/jgsk_sdk"
 mvn '-Dock.library.path=$PROJECT_HOME/OCK/' test -Dtest=TestClassname
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>OpenJCEPlus</artifactId>
-    <version>21</version>
+    <version>22</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -106,12 +106,12 @@
             </properties>
           </profile>
           <profile>
-            <id>Profile for JDK 21 Build</id>
+            <id>Profile for JDK 22 Build</id>
             <activation>
-              <jdk>21</jdk>
+              <jdk>22</jdk>
             </activation>
             <properties>
-                <jdk.build.target>21</jdk.build.target>
+                <jdk.build.target>22</jdk.build.target>
             </properties>
           </profile>
         </profiles>
@@ -147,8 +147,8 @@
                         <message>"Property ock.library.path is not set, perhaps this required property is missing from the command line?"</message>
                       </requireProperty>
                       <requireJavaVersion>
-                        <version>x = 21</version>
-                        <message>"Java 21 required to build OpenJCEPlus."</message>
+                        <version>x = 22</version>
+                        <message>"Java 22 required to build OpenJCEPlus."</message>
                       </requireJavaVersion>
                       <requireEnvironmentVariable>
                         <variableName>JAVA_HOME</variableName>


### PR DESCRIPTION
This change is made to use the latest Semeru 22 build, as part of the github actions, and update the Java version requirements in the pom.xml

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/67

Signed-off-by: Kostas Tsiounis<kostas.tsiounis@ibm.com>