### PR TITLE
Update initialize function name

### DIFF
--- a/src/main/native/StaticStub.c
+++ b/src/main/native/StaticStub.c
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2024
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy

--- a/src/main/native/StaticStub.c
+++ b/src/main/native/StaticStub.c
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -33,7 +33,7 @@ JNIEXPORT jlong JNICALL Java_com_ibm_crypto_plus_provider_ock_NativeInterface_in
     int retcode = ICC_OK;
     ICC_STATUS status;
 
-    initialize();
+    com_ibm_crypto_plus_provider_initialize();
 
     if( debug ) {
       gslogFunctionEntry(functionName);

--- a/src/main/native/Utils.c
+++ b/src/main/native/Utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2024
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy

--- a/src/main/native/Utils.c
+++ b/src/main/native/Utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -25,7 +25,7 @@ int debug = 0;   // FIXME
 //
 //
 void
-initialize()
+com_ibm_crypto_plus_provider_initialize()
 {
   if( !initialized ) {
 #if DEBUG

--- a/src/main/native/Utils.h
+++ b/src/main/native/Utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2024
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy

--- a/src/main/native/Utils.h
+++ b/src/main/native/Utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -38,7 +38,7 @@ free((_ptr)); \
 
 extern int debug;
 
-void initialize();
+void com_ibm_crypto_plus_provider_initialize();
 
 int gslogFunctionEntry( const char * functionName );
 int gslogError( const char * formatString, ...);


### PR DESCRIPTION
Updates the initialize function to include package name to be unique. Other functions look to be okay and not likely for a collision.

Tested winx64

Fixes: https://github.com/IBM/OpenJCEPlus/issues/76

Signed-off-by: John Peck <johnpeck@us.ibm.com>