### PR TITLE
Change XDH double octet encoding parsing logic

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/CurveUtil.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/CurveUtil.java
@@ -21,38 +21,31 @@ class CurveUtil {
         X25519, X448, FFDHE2048, FFDHE3072, FFDHE4096, FFDHE6144, FFDHE8192, Ed25519, Ed448
     }
 
-    private static HashMap<CURVE, Integer> publicCurveSizes = new HashMap<CURVE, Integer>(); // key sizes of curves in bytes
-    private static HashMap<Integer, CURVE> sizesToPublicCurves = new HashMap<Integer, CURVE>(); // reverse of above
-    private static HashMap<CURVE, Integer> privateCurveSizes = new HashMap<CURVE, Integer>(); // key sizes of curves in bytes
-    private static HashMap<Integer, CURVE> sizesToPrivateCurves = new HashMap<Integer, CURVE>(); // reverse of above
-    private static HashMap<Integer, CURVE> sizesToCurves = new HashMap<Integer, CURVE>(); // maps the total key size (I think?)
+    private static Map<CURVE, Integer> curveSizes = new HashMap<CURVE, Integer>(); // key sizes of curves in bytes
+    private static Map<CURVE, Integer> DEREncodingSizes = new HashMap<CURVE, Integer>(); // key sizes of der encoded private key values.
+    private static Map<Integer, CURVE> sizesToCurves = new HashMap<Integer, CURVE>(); // maps the total key size (I think?)
                                                                                           // to algorithm (used in constructor)
     static {
-        publicCurveSizes.put(CURVE.X25519, 32);
-        publicCurveSizes.put(CURVE.X448, 56);
-        publicCurveSizes.put(CURVE.FFDHE2048, 557);
-        publicCurveSizes.put(CURVE.FFDHE3072, 813);
-        publicCurveSizes.put(CURVE.FFDHE4096, 1069);
-        publicCurveSizes.put(CURVE.FFDHE6144, 1581);
-        publicCurveSizes.put(CURVE.FFDHE8192, 2093);
-        publicCurveSizes.put(CURVE.Ed25519, 32);
-        publicCurveSizes.put(CURVE.Ed448, 57);
 
-        for (Map.Entry<CURVE, Integer> entry : publicCurveSizes.entrySet())
-            sizesToPublicCurves.put(entry.getValue(), entry.getKey());
+        curveSizes.put(CURVE.X25519, 32);
+        curveSizes.put(CURVE.X448, 56);
+        curveSizes.put(CURVE.FFDHE2048, 256);
+        curveSizes.put(CURVE.FFDHE3072, 384);
+        curveSizes.put(CURVE.FFDHE4096, 512);
+        curveSizes.put(CURVE.FFDHE6144, 768);
+        curveSizes.put(CURVE.FFDHE8192, 1024);
+        curveSizes.put(CURVE.Ed25519, 32);
+        curveSizes.put(CURVE.Ed448, 57);
 
-        privateCurveSizes.put(CURVE.X25519, 48);
-        privateCurveSizes.put(CURVE.X448, 72);
-        privateCurveSizes.put(CURVE.FFDHE2048, 327);
-        privateCurveSizes.put(CURVE.FFDHE3072, 461);
-        privateCurveSizes.put(CURVE.FFDHE4096, 595);
-        privateCurveSizes.put(CURVE.FFDHE6144, 857);
-        privateCurveSizes.put(CURVE.FFDHE8192, 1117);
-        privateCurveSizes.put(CURVE.Ed25519, 32);
-        privateCurveSizes.put(CURVE.Ed448, 57);
-
-        for (Map.Entry<CURVE, Integer> entry : privateCurveSizes.entrySet())
-            sizesToPrivateCurves.put(entry.getValue(), entry.getKey());
+        DEREncodingSizes.put(CURVE.X25519, 48);
+        DEREncodingSizes.put(CURVE.X448, 72);
+        //DEREncodingSizes.put(CURVE.FFDHE2048, 327);
+        //DEREncodingSizes.put(CURVE.FFDHE3072, 461);
+        //DEREncodingSizes.put(CURVE.FFDHE4096, 595);
+        //DEREncodingSizes.put(CURVE.FFDHE6144, 857);
+        //DEREncodingSizes.put(CURVE.FFDHE8192, 1117);
+        DEREncodingSizes.put(CURVE.Ed25519, 32);
+        DEREncodingSizes.put(CURVE.Ed448, 57);
 
         sizesToCurves.put(255, CURVE.X25519);
         sizesToCurves.put(448, CURVE.X448);
@@ -63,23 +56,16 @@ class CurveUtil {
         sizesToCurves.put(8192, CURVE.FFDHE8192); // this is my assumption
     }
 
-    public static int getPublicCurveSize(CURVE curve) throws InvalidParameterException {
-        if (!publicCurveSizes.containsKey(curve))
+    public static int getCurveSize(CURVE curve) throws InvalidParameterException {
+        if (!curveSizes.containsKey(curve))
             throw new InvalidParameterException("Curve (" + curve + ") is not supported");
-        return publicCurveSizes.get(curve);
+        return curveSizes.get(curve);
     }
 
-    public static int getPrivateCurveSize(CURVE curve) throws InvalidParameterException {
-        if (!privateCurveSizes.containsKey(curve))
+    public static int getDEREncodingSize(CURVE curve) throws InvalidParameterException {
+        if (!DEREncodingSizes.containsKey(curve))
             throw new InvalidParameterException("Curve (" + curve + ") is not supported");
-        return privateCurveSizes.get(curve);
-    }
-
-    public static CURVE getPublicCurveOfSize(int size) throws InvalidParameterException {
-        if (!sizesToPublicCurves.containsKey(size))
-            throw new InvalidParameterException(
-                    "Public key size (" + size + ") does not correspond to a supported curve");
-        return sizesToPublicCurves.get(size);
+        return DEREncodingSizes.get(curve);
     }
 
     public static CURVE getCurveOfSize(int size) throws InvalidParameterException {

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAKeyPairGenerator.java
@@ -102,9 +102,9 @@ public class EdDSAKeyPairGenerator extends KeyPairGeneratorSpi {
     @Override
     public KeyPair generateKeyPair() {
         try {
-            int pub_size = CurveUtil.getPublicCurveSize(curve);
+            int keySize = CurveUtil.getCurveSize(curve);
             XECKey xecKey = XECKey.generateKeyPair(provider.getOCKContext(),
-                    this.curve.ordinal(), pub_size);
+                    this.curve.ordinal(), keySize);
             EdDSAPublicKeyImpl pubKey = new EdDSAPublicKeyImpl(provider, xecKey,
                     this.curve);
             EdDSAPrivateKeyImpl privKey = new EdDSAPrivateKeyImpl(provider, xecKey);

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAPrivateKeyImpl.java
@@ -90,15 +90,15 @@ public final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKe
             }
 
             if (this.key == null) {
-                int pub_size = CurveUtil.getPublicCurveSize(curve);
+                int keySize = CurveUtil.getCurveSize(curve);
                 this.xecKey = XECKey.generateKeyPair(provider.getOCKContext(),
-                        this.curve.ordinal(), pub_size);
+                        this.curve.ordinal(), keySize);
             } else {
                 this.algid = CurveUtil.getAlgId(this.curve);
                 byte[] der = buildOCKPrivateKeyBytes();
-                int priv_size = CurveUtil.getPrivateCurveSize(curve);
+                int encodingSize = CurveUtil.getDEREncodingSize(curve);
                 this.xecKey = XECKey.createPrivateKey(provider.getOCKContext(), der,
-                        priv_size);
+                        encodingSize);
             }
         } catch (Exception exception) {
             InvalidParameterException ike = new InvalidParameterException(
@@ -118,9 +118,9 @@ public final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKe
             // to fit with GSKit and sets params
 
             checkLength(this.curve);
-            int priv_size = CurveUtil.getPrivateCurveSize(curve);
+            int encodingSize = CurveUtil.getDEREncodingSize(curve);
             this.xecKey = XECKey.createPrivateKey(provider.getOCKContext(), alteredEncoded,
-                    priv_size);
+                    encodingSize);
 
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create XEC private key");
@@ -131,10 +131,10 @@ public final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKe
 
     void checkLength(CURVE curve) throws InvalidKeyException {
 
-        if (CurveUtil.getPrivateCurveSize(curve) != this.h.get().length) {
+        if (CurveUtil.getCurveSize(curve) != this.h.get().length) {
             throw new InvalidKeyException(
                     "key length is " + this.h.get().length + ", key length must be "
-                            + CurveUtil.getPrivateCurveSize(curve));
+                            + CurveUtil.getCurveSize(curve));
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAPublicKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAPublicKeyImpl.java
@@ -105,7 +105,7 @@ public final class EdDSAPublicKeyImpl extends X509Key implements EdECPublicKey {
 
             // array may be too large or too small, depending on the value
             encodedPoint = Arrays.copyOf(encodedPoint,
-                    CurveUtil.getPublicCurveSize(this.curve));
+                    CurveUtil.getCurveSize(this.curve));
             // set the high-order bit of the encoded point
             byte msb = (byte) (point.isXOdd() ? 0x80 : 0);
 
@@ -200,9 +200,9 @@ public final class EdDSAPublicKeyImpl extends X509Key implements EdECPublicKey {
     }
 
     void checkLength(CURVE curve) throws InvalidKeyException {
-        if (CurveUtil.getPublicCurveSize(curve) * 8 != getKey().length()) {
+        if (CurveUtil.getCurveSize(curve) * 8 != getKey().length()) {
             throw new InvalidKeyException("key length must be "
-                    + CurveUtil.getPublicCurveSize(curve));
+                    + CurveUtil.getCurveSize(curve));
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyFactory.java
@@ -143,7 +143,7 @@ public class XDHKeyFactory extends KeyFactorySpi {
                 else
                     throw new InvalidKeySpecException("Inappropriate key specification");
 
-            } else if (key instanceof XDHPrivateKeyImpl) {
+            } else if (key instanceof XECPrivateKey) {
 
                 // Determine valid key specs
                 Class<?> xecPrivKeySpec = Class.forName("java.security.spec.XECPrivateKeySpec");

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyPairGenerator.java
@@ -119,8 +119,8 @@ public class XDHKeyPairGenerator extends KeyPairGeneratorSpi {
     @Override
     public KeyPair generateKeyPair() {
         try {
-            int pub_size = CurveUtil.getPublicCurveSize(serviceCurve);
-            XECKey xecKey = XECKey.generateKeyPair(provider.getOCKContext(), this.serviceCurve.ordinal(), pub_size);
+            int keySize = CurveUtil.getCurveSize(serviceCurve);
+            XECKey xecKey = XECKey.generateKeyPair(provider.getOCKContext(), this.serviceCurve.ordinal(), keySize);
             XDHPrivateKeyImpl privKey = new XDHPrivateKeyImpl(provider, xecKey);
             XDHPublicKeyImpl pubKey = new XDHPublicKeyImpl(provider, xecKey, this.serviceCurve);
             return new KeyPair(pubKey, privKey);

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
@@ -175,8 +175,8 @@ final class XDHPublicKeyImpl extends X509Key implements XECPublicKey, Destroyabl
 
         try {
             if (u == null) {
-                int pub_size = CurveUtil.getPublicCurveSize(curve);
-                this.xecKey = XECKey.generateKeyPair(provider.getOCKContext(), curve.ordinal(), pub_size);
+                int keySize = CurveUtil.getCurveSize(curve);
+                this.xecKey = XECKey.generateKeyPair(provider.getOCKContext(), curve.ordinal(), keySize);
                 setFieldsFromXeckey();
             } else {
 
@@ -202,7 +202,7 @@ final class XDHPublicKeyImpl extends X509Key implements XECPublicKey, Destroyabl
 
                 //Array might be to big our too small
                 uByteA = Arrays.copyOf(uByteA,
-                        CurveUtil.getPublicCurveSize(this.curve));
+                        CurveUtil.getCurveSize(this.curve));
 
                 setKey(new BitArray(uByteA.length * 8, uByteA));
 
@@ -226,9 +226,9 @@ final class XDHPublicKeyImpl extends X509Key implements XECPublicKey, Destroyabl
      * Validate that the key is of the correct size
      */
     private void checkKeySize() throws InvalidKeyException {
-        if ((CurveUtil.getPublicCurveSize(this.curve) * 8) != getKey().length()) {
+        if ((CurveUtil.getCurveSize(this.curve) * 8) != getKey().length()) {
             throw new InvalidKeyException(
-                    "key length must be " + CurveUtil.getPublicCurveSize(this.curve));
+                    "key length must be " + CurveUtil.getCurveSize(this.curve));
         }
     }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDHInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDHInterop.java
@@ -9,12 +9,16 @@
 package ibm.jceplus.junit.base;
 
 import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.EncodedKeySpec;
+import java.security.spec.NamedParameterSpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 
-public class BaseTestXDHInterop extends BaseTest {
+public class BaseTestXDHInterop extends BaseTestInterop {
 
     static final byte[] origMsg = "this is the original message to be signed".getBytes();
     // The below strings are base64 encoded X25519/X448 public/private keys generated using OpenJDK
@@ -24,8 +28,8 @@ public class BaseTestXDHInterop extends BaseTest {
     String openJDK_private_X448 = "MEYCAQAwBwYDK2VvBQAEOOJFsgLYxgAIEWuN1FLAGWDzGQRSataAbPLDc1wv5aky4T8hevyWbYdhggc1OCcqQ93gY8rqVTDb";
     // OpenJDK does not currently support FFDHE hence interop testing for FFDHE is not possible
 
-    public BaseTestXDHInterop(String providerName) {
-        super(providerName);
+    public BaseTestXDHInterop(String providerName, String interopProviderName) {
+        super(providerName, interopProviderName);
     }
 
     public void setUp() throws Exception {}
@@ -44,6 +48,28 @@ public class BaseTestXDHInterop extends BaseTest {
         buildOpenJCEPlusKeys("X448", openJDK_public_bytes, openJDK_private_bytes, providerName);
     }
 
+    public void testXDH_X448_KeyGeneration() throws Exception {
+        System.out.println("Testing XDH key generated with provider " + interopProviderName + " using provider " + providerName);
+
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("XDH", interopProviderName);
+        AlgorithmParameterSpec paramSpec = new NamedParameterSpec("X448");
+        kpg.initialize(paramSpec);
+        KeyPair kp = kpg.generateKeyPair();
+
+        buildOpenJCEPlusKeys("X448", kp.getPublic().getEncoded(), kp.getPrivate().getEncoded(), providerName);
+    }
+
+    public void testXDH_X25519_KeyGeneration() throws Exception {
+        System.out.println("Testing XDH key generated with provider " + interopProviderName + " using provider " + providerName);
+
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("XDH", interopProviderName);
+        AlgorithmParameterSpec paramSpec = new NamedParameterSpec("X25519");
+        kpg.initialize(paramSpec);
+        KeyPair kp = kpg.generateKeyPair();
+
+        buildOpenJCEPlusKeys("X25519", kp.getPublic().getEncoded(), kp.getPrivate().getEncoded(), providerName);
+    }
+
     void buildOpenJCEPlusKeys(String idString, byte[] publicKeyBytes, byte[] privateKeyBytes,
             String provider) throws Exception {
         //final String methodName = "buildOpenJCEPlusKeys" + "_" + idString;
@@ -53,6 +79,5 @@ public class BaseTestXDHInterop extends BaseTest {
         KeyFactory keyFactory = KeyFactory.getInstance("XDH", provider);
         keyFactory.generatePublic(publicKeySpec);
         keyFactory.generatePrivate(privateKeySpec);
-
     }
 }

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestXDHInterop.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestXDHInterop.java
@@ -24,7 +24,7 @@ public class TestXDHInterop extends ibm.jceplus.junit.base.BaseTestXDHInterop {
     //
     //
     public TestXDHInterop() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME);
+        super(Utils.TEST_SUITE_PROVIDER_NAME, Utils.PROVIDER_SunEC);
     }
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
A intermittent problem has been observed as follows:

```
java.security.spec.InvalidKeySpecException: Inappropriate key specification: Failed to create XEC private key
	at openjceplus@11/com.ibm.crypto.plus.provider.XDHKeyFactory.engineGeneratePrivate(XDHKeyFactory.java:112)
	at java.base/java.security.KeyFactory.generatePrivate(KeyFactory.java:384)
	at openjceplus@11/ibm.jceplus.junit.base.BaseTestXDH.runBasicTest(BaseTestXDH.java:246)
	at openjceplus@11/ibm.jceplus.junit.base.BaseTestXDH.runBasicTests(BaseTestXDH.java:205)
	at openjceplus@11/ibm.jceplus.junit.base.BaseTestXDH.testXDH_runBasicTests(BaseTestXDH.java:60)
```

Key encodings that have been encountered for XDH based keys include:

1. [octet-string[octet-string[key-bytes]]]
2. [octet-string[key-bytes]]

Case 1 above occurs when keys are encoding from the SunEC provider on releases older then Java 17.

Case 2 above occurs when keys are generated by OpenJCEPlus or the SunEC provider on Java 17 or higher.

The encoding logic was updated to fix a corner case where a random key value contained a nested octet string just by chance. When this occured a key value was parsed that was not the correct length causing the above bad key specification when the key bytes were formatted for use with the Open Cryptography Kit C library. This update checks that key lengths are correct after parsing a nested octet string. If the length is not correct we will attempt to use a single octet format encoding.

An additional interoperability test was added to perform XDH encoding works with encoding produced by the SunEC provider for X448 and X25519 named curves.

The CurveUtil class was simplified to store known key sizes and known der encoding sizes for a given named curve.