### PR TITLE
Force chop size between 1 and 4096 in BaseByteArrayOutputDelayTest

### DIFF
--- a/src/test/java/ibm/jceplus/junit/base/BaseByteArrayOutputDelayTest.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseByteArrayOutputDelayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -82,7 +82,7 @@ public class BaseByteArrayOutputDelayTest extends BaseTestPublicMethodsToMakeNon
             byte[] testData = new byte[dataSize];
             random.nextBytes(testData);
 
-            int chopSize = random.nextInt(4096);
+            int chopSize = random.nextInt(4095) + 1; // Generate a random between 1 and 4096.
             int delayByte = random.nextInt(dataSize);
             delayByte = delayByte % ByteArrayOutputDelay.MAX_BYTE_DELAY;
 


### PR DESCRIPTION
Occasionally while executing the test `TestByteArrayOutputDelay` we
observe the following exception:
```
java.lang.IllegalArgumentException: chopSize must be greater than zero; given: 0
	at openjceplus/ibm.jceplus.junit.base.BaseByteArrayOutputDelayTest.testByteArrayOutputDelay(BaseByteArrayOutputDelayTest.java:139)
	at openjceplus/ibm.jceplus.junit.base.BaseByteArrayOutputDelayTest.testRandom(BaseByteArrayOutputDelayTest.java:89)
	at openjceplus/ibm.jceplus.junit.base.BaseByteArrayOutputDelayTest.testRandom(BaseByteArrayOutputDelayTest.java:65)
	at java.base/java.lang.reflect.Method.invoke(Method.java:586)
	at junit.framework.TestCase.runTest(TestCase.java:177)
	at junit.framework.TestCase.runBare(TestCase.java:142)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:130)
	at junit.framework.TestSuite.runTest(TestSuite.java:241)
	at junit.framework.TestSuite.run(TestSuite.java:236)
```
When generating a random number in the BaseByteArrayOutputDelayTest test
numbers can be between 0 and 4096. If 0 is randomly selected this
test can fail with the above error. This update forces the value to be
generated between 1 and 4096.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>