### PR TITLE
Address JNI C compilation warnings

### DIFF
--- a/src/main/native/HKDF.c
+++ b/src/main/native/HKDF.c
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -23,11 +23,6 @@ typedef struct OCKHKDF
   ICC_EVP_PKEY_CTX *pctx;
   const ICC_EVP_MD * md;
 } OCKHKDF;
-
-unsigned char *JCC_HKDF_Extract();
-unsigned char *JCC_HKDF_Expand();
-unsigned char *JCC_HKDF();
-
 
 //============================================================================
 /*

--- a/src/main/native/SymmetricCipher.c
+++ b/src/main/native/SymmetricCipher.c
@@ -1,17 +1,10 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
  * in the file LICENSE in the source distribution.
  */
-
-typedef int (*PFI)();
-
-typedef struct {
-  char *name;
-  PFI func;
-} FUNC;
 
 #include <jni.h>
 #include <stdio.h>
@@ -31,6 +24,7 @@ typedef struct {
 #include "Utils.h"
 #include "ExceptionCodes.h"
 #include <stdint.h>
+#include "zHardwareFunctions.h"
 
 typedef struct OCKCipher
 {
@@ -40,7 +34,8 @@ typedef struct OCKCipher
   int copy_context;
 } OCKCipher;
 
-PFI KMC; // z_kmc_native function pointer; only available on some hardware; might be null
+// Pointers of functions that are only available on some hardware (might be null)
+KMC_FuncPtr KMC; // z_kmc_native function pointer
 
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeInterface
@@ -443,10 +438,6 @@ JNIEXPORT jint JNICALL Java_com_ibm_crypto_plus_provider_ock_NativeInterface_CIP
  * Class:     com_ibm_crypto_plus_provider_ock_NativeInterface
  * Method:    z_kmc_native
  */
-
-typedef size_t				UDATA;
-typedef signed char* arr;
-
 JNIEXPORT int CIPHER_zKMC_internal(unsigned char* input, unsigned char* output, int inputLength, long param, int mode) {
     UDATA  len = inputLength;
     UDATA* len_udata = &len;
@@ -1006,7 +997,7 @@ JNIEXPORT jlong JNICALL Java_com_ibm_crypto_plus_provider_ock_NativeInterface_ch
     return -1;
   }
   
-  KMC = funcPtr[2].func; // z_kmc_native
+  KMC = (KMC_FuncPtr)funcPtr[2].func; // z_kmc_native
   if( debug ) {
     gslogMessage ("KMC %s", funcPtr[2].name); 
     gslogFunctionExit(functionName);

--- a/src/main/native/Utils.c
+++ b/src/main/native/Utils.c
@@ -25,7 +25,7 @@ int debug = 0;   // FIXME
 //
 //
 void
-com_ibm_crypto_plus_provider_initialize()
+com_ibm_crypto_plus_provider_initialize(void)
 {
   if( !initialized ) {
 #if DEBUG

--- a/src/main/native/Utils.h
+++ b/src/main/native/Utils.h
@@ -38,7 +38,7 @@ free((_ptr)); \
 
 extern int debug;
 
-void com_ibm_crypto_plus_provider_initialize();
+void com_ibm_crypto_plus_provider_initialize(void);
 
 int gslogFunctionEntry( const char * functionName );
 int gslogError( const char * formatString, ...);

--- a/src/main/native/jgskit.mak
+++ b/src/main/native/jgskit.mak
@@ -1,7 +1,7 @@
 
 ###############################################################################
 #
-# Copyright IBM Corp. 2023
+# Copyright IBM Corp. 2023, 2024
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -32,7 +32,7 @@ AIX_LIBPATH = /usr/lib:/lib
 
 ifeq ($(PLATFORM),x86-linux64)
       PLAT=xa
-      CFLAGS+= -DLINUX -std=gnu99 -pedantic -Werror -Wall -fstack-protector
+      CFLAGS+= -DLINUX -Werror -std=gnu99 -pedantic -Wall -fstack-protector
       LDFLAGS+= -m64
       IS64SYSTEM=64
       OSINCLUDEDIR=linux
@@ -47,7 +47,7 @@ endif
 ifeq ($(PLATFORM),s390-linux64)
       PLAT=xz
       LDFLAGS+= -m64
-      CFLAGS+= -DS390_PLATFORM -DLINUX
+      CFLAGS+= -DS390_PLATFORM -DLINUX -Werror
       IS64SYSTEM=64
       OSINCLUDEDIR=linux
 endif
@@ -103,7 +103,7 @@ endif
 
 ifeq ($(PLATFORM),ppcle-linux64)
       PLAT=xl
-      CFLAGS+= -DLINUX
+      CFLAGS+= -DLINUX -Werror 
       LDFLAGS+= -m64
       IS64SYSTEM=64
       OSINCLUDEDIR=linux
@@ -112,7 +112,7 @@ endif
 ifeq ($(PLATFORM),ppc-aix64)
       PLAT=ap
       CC=xlc
-      CFLAGS= -qcpluscmt -q64  -qpic -DAIX
+      CFLAGS= -qcpluscmt -q64  -qpic -DAIX -Werror
       LDFLAGS= -G -q64 -blibpath:$(AIX_LIBPATH)
       IS64SYSTEM=64
       OSINCLUDEDIR=aix

--- a/src/main/native/zHardwareFunctions.h
+++ b/src/main/native/zHardwareFunctions.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright IBM Corp. 2024
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution.
+ */
+
+typedef size_t UDATA;
+
+typedef int ( *PFI)(void);
+
+typedef struct {
+  char *name;
+  PFI func;
+} FUNC;
+
+// Function pointers for z specific hardware instructions.
+typedef void (*ECB_FuncPtr)(signed char *, signed char *, UDATA *, signed char *, UDATA *);
+typedef void (*GHASH_FuncPtr)(signed char *, UDATA *, signed char *, UDATA *);
+typedef void (*zS390_FuncPtr)(unsigned char *, unsigned char *, unsigned char *, long *, long *, unsigned char *, long *);
+typedef void (*KMC_FuncPtr)(unsigned char *, unsigned char *, UDATA *, long, UDATA *);


### PR DESCRIPTION
There are currently numerous JNI C compilation warnings present. This update addresses each of the warnings including the following changes:

1. Various methods needed a void argument instead of empty parentheses.

1. Prototypes were added for various methods. Specifically function pointers in use needed to have associated function pointer prototypes.

1. A mixture of unsigned long and signed long values were present. Output lengths changed are output lengths and are believed to be unsigned.

1. A few method are not in use such as `JCC_HKDF_Extract`, `JCC_HKDF_Expand`, and `JCC_HKDF` are not in use and were removed.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>