### PR TITLE
Exclude multithread RSA-related tests and increase thread init timeout

### DIFF
--- a/src/test/java/ibm/jceplus/junit/TestMultithread.java
+++ b/src/test/java/ibm/jceplus/junit/TestMultithread.java
@@ -65,15 +65,15 @@ public class TestMultithread extends TestCase {
             "ibm.jceplus.junit.openjceplus.multithread.TestSHA512_256",
             "ibm.jceplus.junit.openjceplus.multithread.TestSHA256Clone_SharedMD",
             "ibm.jceplus.junit.openjceplus.multithread.TestRSASignature",
-            "ibm.jceplus.junit.openjceplus.multithread.TestRSA_2048",
+            /*"ibm.jceplus.junit.openjceplus.multithread.TestRSA_2048",*/
             "ibm.jceplus.junit.openjceplus.multithread.TestRSAKey",
             "ibm.jceplus.junit.openjceplus.multithread.TestRSASignatureInteropSunRsaSign",
             "ibm.jceplus.junit.openjceplus.multithread.TestHKDF",
             "ibm.jceplus.junit.openjceplus.multithread.TestXDH",
             "ibm.jceplus.junit.openjceplus.multithread.TestXDHKeyImport",
             "ibm.jceplus.junit.openjceplus.multithread.TestXDHKeyPairGenerator",
-            "ibm.jceplus.junit.openjceplus.multithread.TestXDHMultiParty",
-            "ibm.jceplus.junit.openjceplus.multithread.TestMiniRSAPSS2"};
+            "ibm.jceplus.junit.openjceplus.multithread.TestXDHMultiParty"/*,
+            "ibm.jceplus.junit.openjceplus.multithread.TestMiniRSAPSS2"*/};
 
     public TestMultithread() {}
 
@@ -103,7 +103,7 @@ public class TestMultithread extends TestCase {
             // wait until all threads are ready
             assertTrue(
                     "Timeout initializing threads! Perform long lasting initializations before passing runnables to assertConcurrent",
-                    allExecutorThreadsReady.await(numThreads * 10, TimeUnit.MILLISECONDS));
+                    allExecutorThreadsReady.await(numThreads * 50, TimeUnit.MILLISECONDS));
             // start all test runners
             afterInitBlocker.countDown();
             assertTrue(message + " timeout! More than " + maxTimeoutSeconds + " seconds",

--- a/src/test/java/ibm/jceplus/junit/TestMultithreadFIPS.java
+++ b/src/test/java/ibm/jceplus/junit/TestMultithreadFIPS.java
@@ -52,18 +52,18 @@ public class TestMultithreadFIPS extends TestCase {
             "ibm.jceplus.junit.openjceplusfips.multithread.TestSHA512",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestSHA256Clone_SharedMD",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestRSASignature",
-            "ibm.jceplus.junit.openjceplusfips.multithread.TestRSA_2048",
+            /*"ibm.jceplus.junit.openjceplusfips.multithread.TestRSA_2048",*/
             "ibm.jceplus.junit.openjceplusfips.multithread.TestRSAKey",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestRSASignatureInteropSunRsaSign",
             /*"ibm.jceplus.junit.openjceplusfips.multithread.TestHKDF",*/
-            "ibm.jceplus.junit.openjceplusfips.multithread.TestMiniRSAPSS2",
+            /*"ibm.jceplus.junit.openjceplusfips.multithread.TestMiniRSAPSS2",*/
             "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMCICOWithGCMAndAAD",
-            "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMNonExpanding",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMNonExpanding"//,
             /*"ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMWithKeyAndIvCheck",*/
-            "ibm.jceplus.junit.openjceplusfips.multithread.TestRSAPSS",
+            /*"ibm.jceplus.junit.openjceplusfips.multithread.TestRSAPSS",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestRSAPSS2",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestRSAPSSInterop2",
-            "ibm.jceplus.junit.openjceplusfips.multithread.TestRSAPSSInterop3"};
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestRSAPSSInterop3"*/};
     public final Object ob = new Object();
 
     public TestMultithreadFIPS() {}
@@ -94,7 +94,7 @@ public class TestMultithreadFIPS extends TestCase {
             // wait until all threads are ready
             assertTrue(
                     "Timeout initializing threads! Perform long lasting initializations before passing runnables to assertConcurrent",
-                    allExecutorThreadsReady.await(numThreads * 10, TimeUnit.MILLISECONDS));
+                    allExecutorThreadsReady.await(numThreads * 50, TimeUnit.MILLISECONDS));
             // start all test runners
             afterInitBlocker.countDown();
             assertTrue(message + " timeout! More than " + maxTimeoutSeconds + " seconds",


### PR DESCRIPTION
The multithreaded versions of `RSAPSS` and `RSA_2048` seem to be hanging, so they are temporarily omitted until a fix is available.

In some platforms, like Windows, the initialization of the threads requires more time, so the timeout is increased to account for that.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/127

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>