### PR TITLE
Fix the encoding formats for X25519 and X448

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
@@ -22,6 +22,8 @@ public abstract class OpenJCEPlusProvider extends java.security.Provider {
 
     private static final String PROVIDER_VER = System.getProperty("java.specification.version");
 
+    private static final String JAVA_VER = System.getProperty("java.specification.version");
+
     // Are we debugging? -- for developers
     static final boolean debug2 = false;
 
@@ -65,6 +67,12 @@ public abstract class OpenJCEPlusProvider extends java.security.Provider {
     //
     boolean isFIPS() {
         return getOCKContext().isFIPS();
+    }
+
+    // Return the Java version.
+    //
+    String getJavaVersionStr() {
+        return JAVA_VER;
     }
 
     abstract ProviderException providerException(String message, Throwable ockException);

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
@@ -411,7 +411,7 @@ final class XDHPublicKeyImpl extends X509Key implements XECPublicKey, Destroyabl
                 oidSeq.putOID(this.algid.getOID());
                 if ((oidSubSeq != null)) {
                     oidSeq.write(DerValue.tag_Sequence, oidSubSeq);
-                } else {
+                } else if (Integer.parseInt(provider.getJavaVersionStr()) <= 11) {
                     // Encode as old J8 format
                     // Sun old versions, 11 and before, are not supporting new XDH format,
                     // otherwise, it causes interop issue -> Ex. J11#1834

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyImport.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyImport.java
@@ -185,7 +185,7 @@ public class BaseTestXDHKeyImport extends ibm.jceplus.junit.base.BaseTest {
         }
 
         NamedParameterSpec paramSpec = new NamedParameterSpec(alg);
-        KeyFactory kf = KeyFactory.getInstance("XDH");
+        KeyFactory kf = KeyFactory.getInstance("XDH", providerName);
 
         XECPublicKeySpec xdhPublic = new XECPublicKeySpec(paramSpec, u);
         XECPrivateKeySpec xdhPrivate = new XECPrivateKeySpec(paramSpec, scalar);
@@ -206,7 +206,7 @@ public class BaseTestXDHKeyImport extends ibm.jceplus.junit.base.BaseTest {
      * @throws Exception
      */
     void createKeyPairLocalParamImport(String alg) throws Exception {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance(alg);
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(alg, providerName);
         //        KeyPairGenerator kpg = KeyPairGenerator.getInstance("XDH");
         NamedParameterSpec paramSpec = new NamedParameterSpec(alg);
         System.out.println("Alg = " + alg);
@@ -216,7 +216,7 @@ public class BaseTestXDHKeyImport extends ibm.jceplus.junit.base.BaseTest {
         PrivateKey pvk = kp.getPrivate();
         PublicKey pbk = kp.getPublic();
 
-        KeyFactory kf = KeyFactory.getInstance(alg);
+        KeyFactory kf = KeyFactory.getInstance(alg, providerName);
         //        KeyFactory kf = KeyFactory.getInstance("XDH");
         XECPublicKeySpec xdhPublic = kf.getKeySpec(kp.getPublic(), XECPublicKeySpec.class);
         XECPrivateKeySpec xdhPrivate = kf.getKeySpec(kp.getPrivate(), XECPrivateKeySpec.class);
@@ -232,7 +232,7 @@ public class BaseTestXDHKeyImport extends ibm.jceplus.junit.base.BaseTest {
         PublicKey pbk2 = kf.generatePublic(xdhPublic);
         PrivateKey pvk2 = kf.generatePrivate(xdhPrivate);
 
-        System.out.println(" pbk =" + BaseUtils.bytesToHex(pbk2.getEncoded()));
+        System.out.println(" pbk = " + BaseUtils.bytesToHex(pbk2.getEncoded()));
         System.out.println(" pbk2 = " + BaseUtils.bytesToHex(pbk.getEncoded()));
 
         // Verify that keys match

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAll.java
@@ -47,7 +47,7 @@ import junit.framework.TestSuite;
         TestSHA512_224.class, TestSHA512_256.class, TestSHA3_224.class, TestSHA3_256.class,
         TestSHA3_384.class, TestSHA3_512.class, TestRSAKeyInterop.class, TestRSAKeyInteropBC.class,
         TestEdDSASignature.class, TestEdDSASignatureInterop.class, TestXDH.class,
-        TestXDHInterop.class, TestXDHMultiParty.class, TestXDHKeyPairGenerator.class,
+        TestXDHInterop.class, TestXDHInteropBC.class, TestXDHMultiParty.class, TestXDHKeyPairGenerator.class,
         TestXDHKeyImport.class, TestIsAssignableFromOrder.class
 
 })

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestXDHInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestXDHInteropBC.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright IBM Corp. 2023
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution.
+ */
+
+package ibm.jceplus.junit.openjceplus;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+public class TestXDHInteropBC extends ibm.jceplus.junit.base.BaseTestXDHInterop {
+
+    // --------------------------------------------------------------------------
+    //
+    //
+    static {
+        Utils.loadProviderTestSuite();
+
+        try {
+            Utils.loadProviderBC();
+        } catch (Exception e) {
+            e.printStackTrace(System.out);
+            System.exit(1);
+        }
+    }
+
+    // --------------------------------------------------------------------------
+    //
+    //
+    public TestXDHInteropBC() {
+        super(Utils.TEST_SUITE_PROVIDER_NAME, Utils.PROVIDER_BC);
+    }
+
+    // --------------------------------------------------------------------------
+    //
+    //
+    public static void main(String[] args) throws Exception {
+        junit.textui.TestRunner.run(suite());
+    }
+
+    // --------------------------------------------------------------------------
+    //
+    //
+    public static Test suite() {
+        TestSuite suite = new TestSuite(TestXDHInteropBC.class);
+        return suite;
+    }
+}


### PR DESCRIPTION
This PR fixes the XDH Private Key and Public Key encoding formats issues.

According to the PKCS#8 Private-Key Specification, the new format privateKey is an octet string whose contents are the value of the private key. So, adding the octet string before the private key when passing the private key object to its parent class PKCS8Key key object for 17 and after version.

According to Sun old versions, 11 and before, the new XDH format is not supported. So, adding a DER "null" value on the OID sequence only for 11 and before versions.