### PR TITLE
Address Java compilation warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,7 @@
                     <source>${jdk.build.target}</source>   
                     <target>${jdk.build.target}</target>
                     <compilerArgs>
+                        <arg>-XDignore.symbol.file</arg>
                         <arg>-Xlint:all</arg> 
                         <arg>--add-exports </arg> 
                         <arg>java.base/sun.security.internal.spec=openjceplus</arg>
@@ -230,6 +231,7 @@
                         <arg>--add-exports </arg>
                         <arg>java.base/jdk.internal.logger=openjceplus</arg>
                     </compilerArgs>
+                    <fork>true</fork>
                     <debug>true</debug>  
                 </configuration>
             </plugin>
@@ -545,6 +547,16 @@
             <artifactId>bcprov-jdk18on</artifactId>
             <version>1.78.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.78.1</version>
+        </dependency>
+        <dependency>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-ext-jdk18on</artifactId>
+          <version>1.78.1</version>
+      </dependency>
         <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>

--- a/src/main/java/com/ibm/crypto/plus/provider/AESCCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESCCMCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -103,7 +103,7 @@ public final class AESCCMCipher extends CipherSpi implements AESConstants, CCMCo
 
     public AESCCMCipher(OpenJCEPlusProvider provider) {
 
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
 
@@ -569,7 +569,7 @@ public final class AESCCMCipher extends CipherSpi implements AESConstants, CCMCo
         if (params != null) {
             CCMParameterSpec ivSpec = null;
             try {
-                ivSpec = (CCMParameterSpec) params.getParameterSpec(CCMParameterSpec.class);
+                ivSpec = params.getParameterSpec(CCMParameterSpec.class);
             } catch (InvalidParameterSpecException ipse) {
                 throw new InvalidAlgorithmParameterException(
                         "Wrong parameter " + "type: CCM " + "expected");

--- a/src/main/java/com/ibm/crypto/plus/provider/AESCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -43,7 +43,7 @@ public final class AESCipher extends CipherSpi implements AESConstants {
     private static int isHardwareSupport = 0;
 
     public AESCipher(OpenJCEPlusProvider provider) {
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
         buffer = new byte[engineGetBlockSize() * 3];
@@ -264,7 +264,7 @@ public final class AESCipher extends CipherSpi implements AESConstants {
 
         if (params != null) {
             try {
-                ivSpec = (IvParameterSpec) params.getParameterSpec(IvParameterSpec.class);
+                ivSpec = params.getParameterSpec(IvParameterSpec.class);
             } catch (InvalidParameterSpecException ipse) {
                 throw new InvalidAlgorithmParameterException("Wrong parameter type: IV expected");
             }

--- a/src/main/java/com/ibm/crypto/plus/provider/AESGCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESGCMCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -138,7 +138,7 @@ public final class AESGCMCipher extends CipherSpi implements AESConstants, GCMCo
     private byte[] lastEncIv = null;
 
     public AESGCMCipher(OpenJCEPlusProvider provider) {
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
 
@@ -441,7 +441,7 @@ public final class AESGCMCipher extends CipherSpi implements AESConstants, GCMCo
 
 
 
-    protected int doFinalForUpdates(byte[] input, int inputOffset, int inputLen, byte[] output,
+    private int doFinalForUpdates(byte[] input, int inputOffset, int inputLen, byte[] output,
             int outputOffset) throws ShortBufferException, IllegalBlockSizeException,
             BadPaddingException, AEADBadTagException, IllegalStateException, OCKException {
         //final String methodName = "doFinalForUpdates";
@@ -700,7 +700,7 @@ public final class AESGCMCipher extends CipherSpi implements AESConstants, GCMCo
         if (params != null) {
             GCMParameterSpec ivSpec = null;
             try {
-                ivSpec = (GCMParameterSpec) params.getParameterSpec(GCMParameterSpec.class);
+                ivSpec = params.getParameterSpec(GCMParameterSpec.class);
             } catch (InvalidParameterSpecException ipse) {
                 throw new InvalidAlgorithmParameterException(
                         "Wrong parameter " + "type: GCM " + "expected");

--- a/src/main/java/com/ibm/crypto/plus/provider/AESKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -13,12 +13,11 @@ import java.security.KeyRep;
 import java.util.Arrays;
 import javax.crypto.SecretKey;
 import javax.security.auth.DestroyFailedException;
-import javax.security.auth.Destroyable;
 
 /**
  * This class represents an AES key.
  */
-final class AESKey implements SecretKey, Destroyable {
+final class AESKey implements SecretKey {
 
     static final long serialVersionUID = -8899864838936117258L;
 
@@ -35,7 +34,7 @@ final class AESKey implements SecretKey, Destroyable {
      * @exception InvalidKeyException
      *                if the given key has wrong size
      */
-    public AESKey(byte[] key) throws InvalidKeyException {
+    AESKey(byte[] key) throws InvalidKeyException {
         if ((key == null) || !AESUtils.isKeySizeValid(key.length)) {
             throw new InvalidKeyException("Wrong key size");
         }
@@ -62,7 +61,7 @@ final class AESKey implements SecretKey, Destroyable {
 
         // Return a copy of the key, rather than a reference,
         // so that the key data cannot be modified from outside
-        return (byte[]) this.key.clone();
+        return this.key.clone();
     }
 
     /**

--- a/src/main/java/com/ibm/crypto/plus/provider/AESKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -26,7 +26,7 @@ public final class AESKeyFactory extends SecretKeyFactorySpi {
      * Empty constructor
      */
     public AESKeyFactory(OpenJCEPlusProvider provider) {
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
         this.provider = provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/AESKeyGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -31,7 +31,7 @@ public final class AESKeyGenerator extends KeyGeneratorSpi {
      * Empty constructor
      */
     public AESKeyGenerator(OpenJCEPlusProvider provider) {
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/AESParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -27,12 +27,10 @@ import sun.security.util.HexDumpEncoder;
  */
 public final class AESParameters extends AlgorithmParametersSpi {
 
-    private OpenJCEPlusProvider provider = null;
-
     private byte[] iv;
 
-    public AESParameters(OpenJCEPlusProvider provider) {
-        this.provider = provider;
+    public AESParameters() {
+        super();
     }
 
     @Override
@@ -47,7 +45,7 @@ public final class AESParameters extends AlgorithmParametersSpi {
                 iv.length != 4) { // KWP mode
             throw new InvalidParameterSpecException("IV not 16, 8 or 4 bytes long");
         }
-        this.iv = (byte[]) iv.clone();
+        this.iv = iv.clone();
     }
 
     @Override

--- a/src/main/java/com/ibm/crypto/plus/provider/CCMParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/CCMParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -76,7 +76,7 @@ public final class CCMParameters extends AlgorithmParametersSpi
                     "CCM parameter parsing error:  The number of IV bytes in the CCMParameterSpec must be between 7 and 13 inclusive.");
         }
 
-        this.iv = (byte[]) iv.clone();
+        this.iv = iv.clone();
 
         initialized = true;
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Key.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -13,12 +13,11 @@ import java.security.KeyRep;
 import java.util.Arrays;
 import javax.crypto.SecretKey;
 import javax.security.auth.DestroyFailedException;
-import javax.security.auth.Destroyable;
 
 /**
  * This class represents an ChaCha20 key.
  */
-final class ChaCha20Key implements SecretKey, Destroyable, ChaCha20Constants {
+final class ChaCha20Key implements SecretKey, ChaCha20Constants {
 
     static final long serialVersionUID = -8899864838936117258L;
 
@@ -35,7 +34,7 @@ final class ChaCha20Key implements SecretKey, Destroyable, ChaCha20Constants {
      * @exception InvalidKeyException
      *                if the given key has wrong size
      */
-    public ChaCha20Key(byte[] key) throws InvalidKeyException {
+    ChaCha20Key(byte[] key) throws InvalidKeyException {
 
         if ((key == null) || (key.length != ChaCha20_KEY_SIZE)) {
             throw new InvalidKeyException("Wrong key size");
@@ -63,7 +62,7 @@ final class ChaCha20Key implements SecretKey, Destroyable, ChaCha20Constants {
 
         // Return a copy of the key, rather than a reference,
         // so that the key data cannot be modified from outside
-        return (byte[]) this.key.clone();
+        return this.key.clone();
     }
 
     /**

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -26,7 +26,7 @@ public final class ChaCha20KeyFactory extends SecretKeyFactorySpi {
      * Empty constructor
      */
     public ChaCha20KeyFactory(OpenJCEPlusProvider provider) {
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
         this.provider = provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -31,7 +31,7 @@ public final class ChaCha20KeyGenerator extends KeyGeneratorSpi implements ChaCh
      * Empty constructor
      */
     public ChaCha20KeyGenerator(OpenJCEPlusProvider provider) {
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Parameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -19,13 +19,11 @@ import javax.crypto.spec.ChaCha20ParameterSpec;
  */
 public final class ChaCha20Parameters extends AlgorithmParametersSpi implements ChaCha20Constants {
 
-    private OpenJCEPlusProvider provider = null;
-
     private byte[] nonce;
     int counter;
 
-    public ChaCha20Parameters(OpenJCEPlusProvider provider) {
-        this.provider = provider;
+    public ChaCha20Parameters() {
+        super();
     }
 
     @Override
@@ -39,7 +37,7 @@ public final class ChaCha20Parameters extends AlgorithmParametersSpi implements 
             throw new InvalidParameterSpecException(
                     "Nonce not " + ChaCha20_NONCE_SIZE + " bytes long");
         }
-        this.nonce = (byte[]) nonce.clone();
+        this.nonce = nonce.clone();
 
         this.counter = ((ChaCha20ParameterSpec) paramSpec).getCounter();
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Poly1305Cipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Poly1305Cipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -73,7 +73,7 @@ public final class ChaCha20Poly1305Cipher extends CipherSpi
     SecureRandom random;
 
     public ChaCha20Poly1305Cipher(OpenJCEPlusProvider provider) {
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
         this.provider = provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Poly1305Parameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Poly1305Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -22,12 +22,10 @@ import sun.security.util.DerValue;
 public final class ChaCha20Poly1305Parameters extends AlgorithmParametersSpi
         implements ChaCha20Constants {
 
-    private OpenJCEPlusProvider provider = null;
-
     private byte[] nonce;
 
-    public ChaCha20Poly1305Parameters(OpenJCEPlusProvider provider) {
-        this.provider = provider;
+    public ChaCha20Poly1305Parameters() {
+        super();
     }
 
     @Override
@@ -41,7 +39,7 @@ public final class ChaCha20Poly1305Parameters extends AlgorithmParametersSpi
             throw new InvalidParameterSpecException(
                     "Nonce not " + ChaCha20_NONCE_SIZE + " bytes long");
         }
-        this.nonce = (byte[]) nonce.clone();
+        this.nonce = nonce.clone();
     }
 
     /*

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -40,7 +40,7 @@ public final class DESedeCipher extends CipherSpi implements DESConstants {
 
     public DESedeCipher(OpenJCEPlusProvider provider) {
 
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
 
@@ -202,7 +202,7 @@ public final class DESedeCipher extends CipherSpi implements DESConstants {
 
         if (params != null) {
             try {
-                ivSpec = (IvParameterSpec) params.getParameterSpec(IvParameterSpec.class);
+                ivSpec = params.getParameterSpec(IvParameterSpec.class);
             } catch (InvalidParameterSpecException ipse) {
                 throw new InvalidAlgorithmParameterException("Wrong parameter type: IV expected");
             }

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -34,7 +34,7 @@ final class DESedeKey implements SecretKey, Destroyable {
      *
      * @exception InvalidKeyException if the given key has a wrong size
      */
-    public DESedeKey(byte[] key) throws InvalidKeyException {
+    DESedeKey(byte[] key) throws InvalidKeyException {
         if ((key == null) || (key.length < DESedeKeySpec.DES_EDE_KEY_LEN)) {
             throw new InvalidKeyException("Wrong key size");
         }
@@ -64,7 +64,7 @@ final class DESedeKey implements SecretKey, Destroyable {
 
         // Return a copy of the key, rather than a reference,
         // so that the key data cannot be modified from outside
-        return (byte[]) this.key.clone();
+        return this.key.clone();
     }
 
     /**

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -28,7 +28,7 @@ public final class DESedeKeyFactory extends SecretKeyFactorySpi {
      */
     public DESedeKeyFactory(OpenJCEPlusProvider provider) {
 
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeKeyGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeKeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -37,7 +37,7 @@ public final class DESedeKeyGenerator extends KeyGeneratorSpi {
      */
     public DESedeKeyGenerator(OpenJCEPlusProvider provider) {
 
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -26,6 +26,9 @@ import sun.security.util.HexDumpEncoder;
  * </pre>
  */
 public final class DESedeParameters extends AlgorithmParametersSpi {
+    public DESedeParameters() {
+        super();
+    }
 
     private byte[] iv;
 
@@ -38,7 +41,7 @@ public final class DESedeParameters extends AlgorithmParametersSpi {
         if (iv.length != 8) {
             throw new InvalidParameterSpecException("IV not 8 bytes long");
         }
-        this.iv = (byte[]) iv.clone();
+        this.iv = iv.clone();
     }
 
     protected void engineInit(byte[] encoded) throws IOException {

--- a/src/main/java/com/ibm/crypto/plus/provider/DHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHKeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,12 +10,10 @@ package com.ibm.crypto.plus.provider;
 
 import java.io.IOException;
 import java.math.BigInteger;
-import java.security.AccessController;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivilegedAction;
 import java.security.SecureRandom;
 import java.security.spec.AlgorithmParameterSpec;
 import javax.crypto.KeyAgreementSpi;
@@ -27,7 +25,6 @@ import com.ibm.crypto.plus.provider.ock.DHKey;
 import com.ibm.crypto.plus.provider.ock.OCKException;
 import sun.security.util.KeyUtil;
 
-@SuppressWarnings({"removal", "deprecation"})
 public final class DHKeyAgreement extends KeyAgreementSpi {
 
     private OpenJCEPlusProvider provider = null;
@@ -47,14 +44,14 @@ public final class DHKeyAgreement extends KeyAgreementSpi {
         private static final boolean VALUE = getValue();
 
         private static boolean getValue() {
-            return AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean
-                    .getBoolean("jdk.crypto.KeyAgreement.legacyKDF"));
+            return Boolean.parseBoolean(
+                System.getProperty("jdk.crypto.KeyAgreement.legacyKDF", "false"));
         }
     }
 
     public DHKeyAgreement(OpenJCEPlusProvider provider) {
 
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/DHKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -136,8 +136,8 @@ public final class DHKeyFactory extends KeyFactorySpi {
             if (key instanceof javax.crypto.interfaces.DHPublicKey) {
 
                 // Determine valid key specs
-                Class dhPubKeySpec = Class.forName("javax.crypto.spec.DHPublicKeySpec");
-                Class x509KeySpec = Class.forName("java.security.spec.X509EncodedKeySpec");
+                Class<?> dhPubKeySpec = Class.forName("javax.crypto.spec.DHPublicKeySpec");
+                Class<?> x509KeySpec = Class.forName("java.security.spec.X509EncodedKeySpec");
 
                 if (dhPubKeySpec.isAssignableFrom(keySpec)) {
                     javax.crypto.interfaces.DHPublicKey dhPubKey = (javax.crypto.interfaces.DHPublicKey) key;
@@ -155,8 +155,8 @@ public final class DHKeyFactory extends KeyFactorySpi {
             } else if (key instanceof javax.crypto.interfaces.DHPrivateKey) {
 
                 // Determine valid key specs
-                Class dhPrivKeySpec = Class.forName("javax.crypto.spec.DHPrivateKeySpec");
-                Class pkcs8KeySpec = Class.forName("java.security.spec.PKCS8EncodedKeySpec");
+                Class<?> dhPrivKeySpec = Class.forName("javax.crypto.spec.DHPrivateKeySpec");
+                Class<?> pkcs8KeySpec = Class.forName("java.security.spec.PKCS8EncodedKeySpec");
 
                 if (dhPrivKeySpec.isAssignableFrom(keySpec)) {
                     javax.crypto.interfaces.DHPrivateKey dhPrivKey = (javax.crypto.interfaces.DHPrivateKey) key;
@@ -201,7 +201,7 @@ public final class DHKeyFactory extends KeyFactorySpi {
                     return key;
                 }
                 // Convert key to spec
-                DHPublicKeySpec dhPubKeySpec = (DHPublicKeySpec) engineGetKeySpec(key,
+                DHPublicKeySpec dhPubKeySpec = engineGetKeySpec(key,
                         DHPublicKeySpec.class);
                 // Create key from spec, and return it
                 return engineGeneratePublic(dhPubKeySpec);
@@ -212,7 +212,7 @@ public final class DHKeyFactory extends KeyFactorySpi {
                     return key;
                 }
                 // Convert key to spec
-                DHPrivateKeySpec dhPrivKeySpec = (DHPrivateKeySpec) engineGetKeySpec(key,
+                DHPrivateKeySpec dhPrivKeySpec = engineGetKeySpec(key,
                         DHPrivateKeySpec.class);
                 // Create key from spec, and return it
                 return engineGeneratePrivate(dhPrivKeySpec);

--- a/src/main/java/com/ibm/crypto/plus/provider/DHKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHKeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -28,7 +28,7 @@ public final class DHKeyPairGenerator extends KeyPairGeneratorSpi {
     public DHKeyPairGenerator(OpenJCEPlusProvider provider) {
 
 
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
 
@@ -150,7 +150,7 @@ public final class DHKeyPairGenerator extends KeyPairGeneratorSpi {
                         .getInstance("DH", provider);
                 algParmGen.init(this.keySize);
                 AlgorithmParameters algParams = algParmGen.generateParameters();
-                this.params = (DHParameterSpec) algParams.getParameterSpec(DHParameterSpec.class);
+                this.params = algParams.getParameterSpec(DHParameterSpec.class);
 
                 dhKey = DHKey.generateKeyPair(provider.getOCKContext(), algParams.getEncoded());
             } else {

--- a/src/main/java/com/ibm/crypto/plus/provider/DHParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -21,7 +21,8 @@ import sun.security.util.DerValue;
  * This class implements the parameter set used by the Diffie-Hellman key
  * agreement as defined in the PKCS #3 standard.
  */
-public final class DHParameters extends AlgorithmParametersSpi {
+public final class DHParameters extends AlgorithmParametersSpi implements java.io.Serializable {
+    private static final long serialVersionUID = 7137508373627164657L;
 
     private OpenJCEPlusProvider provider;
 

--- a/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -51,12 +51,12 @@ final class DHPrivateKey extends PKCS8Key implements javax.crypto.interfaces.DHP
     private transient DHKey dhKey = null; // Transient per tag [SERIALIZATION] in DesignNotes.txt
 
 
-    public DHPrivateKey(OpenJCEPlusProvider provider, BigInteger x, BigInteger p, BigInteger g)
+    DHPrivateKey(OpenJCEPlusProvider provider, BigInteger x, BigInteger p, BigInteger g)
             throws InvalidKeyException, IOException {
         initDHPrivateKey(provider, x, null, p, g, 0);
     }
 
-    public DHPrivateKey(OpenJCEPlusProvider provider, BigInteger x, BigInteger p, BigInteger g,
+    DHPrivateKey(OpenJCEPlusProvider provider, BigInteger x, BigInteger p, BigInteger g,
             int l) throws InvalidKeyException, IOException {
         initDHPrivateKey(provider, x, null, p, g, l);
     }
@@ -70,7 +70,7 @@ final class DHPrivateKey extends PKCS8Key implements javax.crypto.interfaces.DHP
      * @throws InvalidKeyException if the key cannot be encoded
      * @throws IOException
      */
-    public DHPrivateKey(OpenJCEPlusProvider provider, BigInteger x, DHParameters params)
+    DHPrivateKey(OpenJCEPlusProvider provider, BigInteger x, DHParameters params)
             throws InvalidKeyException, IOException {
         initDHPrivateKey(provider, x, params, null, null, 0);
     }
@@ -102,7 +102,7 @@ final class DHPrivateKey extends PKCS8Key implements javax.crypto.interfaces.DHP
         }
     }
 
-    public DHPrivateKey(OpenJCEPlusProvider provider, DHKey dhKey) throws InvalidKeyException, OCKException {
+    DHPrivateKey(OpenJCEPlusProvider provider, DHKey dhKey) throws InvalidKeyException, OCKException {
         
         try {
 
@@ -122,7 +122,7 @@ final class DHPrivateKey extends PKCS8Key implements javax.crypto.interfaces.DHP
         }
     }
 
-    public DHPrivateKey(OpenJCEPlusProvider provider, byte[] encoded)
+    DHPrivateKey(OpenJCEPlusProvider provider, byte[] encoded)
             throws InvalidKeyException, IOException {
         this.provider = provider;
 
@@ -210,7 +210,7 @@ final class DHPrivateKey extends PKCS8Key implements javax.crypto.interfaces.DHP
 
             // ignore OPTIONAL attributes
 
-            this.encodedKey = (byte[]) encodedKey.clone();
+            this.encodedKey = encodedKey.clone();
 
             DerValue outputValue = new DerValue(DerValue.tag_Integer, key);
             return outputValue.toByteArray();
@@ -336,7 +336,7 @@ final class DHPrivateKey extends PKCS8Key implements javax.crypto.interfaces.DHP
                 }
             }
         }
-        return (byte[]) this.encodedKey.clone();
+        return this.encodedKey.clone();
 
         //return super.getEncoded();
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/DHPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -11,17 +11,18 @@ package com.ibm.crypto.plus.provider;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Serializable;
 import java.math.BigInteger;
 import java.security.InvalidKeyException;
 import java.security.KeyRep;
-import java.security.PublicKey;
 import java.security.spec.InvalidParameterSpecException;
-import java.util.Arrays;
+
 import javax.crypto.spec.DHParameterSpec;
 import javax.security.auth.DestroyFailedException;
 import javax.security.auth.Destroyable;
+
 import com.ibm.crypto.plus.provider.ock.DHKey;
+
+import sun.security.util.BitArray;
 import sun.security.util.DerInputStream;
 import sun.security.util.DerOutputStream;
 import sun.security.util.DerValue;
@@ -30,7 +31,7 @@ import sun.security.x509.X509Key;
 
 @SuppressWarnings("restriction")
 final class DHPublicKey extends X509Key
-        implements javax.crypto.interfaces.DHPublicKey, PublicKey, Serializable, Destroyable {
+        implements javax.crypto.interfaces.DHPublicKey, Destroyable {
 
     /**
      * 
@@ -49,19 +50,20 @@ final class DHPublicKey extends X509Key
     private transient boolean destroyed = false;
     private transient DHKey dhKey = null; // Transient per tag [SERIALIZATION] in DesignNotes.txt
 
-    public DHPublicKey(OpenJCEPlusProvider provider, BigInteger y, BigInteger p, BigInteger g)
+    DHPublicKey(OpenJCEPlusProvider provider, BigInteger y, BigInteger p, BigInteger g)
             throws InvalidKeyException {
         this(provider, y, p, g, 0);
     }
 
-    public DHPublicKey(OpenJCEPlusProvider provider, BigInteger y, BigInteger p, BigInteger g,
+    DHPublicKey(OpenJCEPlusProvider provider, BigInteger y, BigInteger p, BigInteger g,
             int l) throws InvalidKeyException {
         this.provider = provider;
         this.y = y;
         dhParams = new DHParameters(provider);
         try {
             dhParams.engineInit(new DHParameterSpec(p, g, l));
-            this.key = new DerValue(DerValue.tag_Integer, this.y.toByteArray()).toByteArray();
+            byte[] keyArray = new DerValue(DerValue.tag_Integer, this.y.toByteArray()).toByteArray();
+            setKey(new BitArray(keyArray.length * 8, keyArray));
             this.encodedKey = getEncoded();
         } catch (IOException e) {
             throw new InvalidKeyException("Cannot produce ASN.1 encoding");
@@ -93,7 +95,8 @@ final class DHPublicKey extends X509Key
         this.y = y;
         this.dhParams = params;
         try {
-            this.key = new DerValue(DerValue.tag_Integer, this.y.toByteArray()).toByteArray();
+            byte[] keyArray = new DerValue(DerValue.tag_Integer, this.y.toByteArray()).toByteArray();
+            setKey(new BitArray(keyArray.length * 8, keyArray));
             this.encodedKey = getEncoded();
         } catch (IOException e) {
             throw new InvalidKeyException("Cannot produce ASN.1 encoding");
@@ -196,7 +199,8 @@ final class DHPublicKey extends X509Key
              * Parse the key
              */
 
-            this.key = derKeyVal.getData().getBitString();
+            byte[] keyArray = derKeyVal.getData().getBitString();
+            setKey(new BitArray(keyArray.length * 8, keyArray));
 
             //customParseKeyBits();
             parseKeyBits();
@@ -208,9 +212,9 @@ final class DHPublicKey extends X509Key
             dhParams.engineInit((l == -1) ? new DHParameterSpec(p, g, y.bitLength())
                     : new DHParameterSpec(p, g, l));
 
-            this.encodedKey = (byte[]) encodedKey.clone();
+            this.encodedKey = encodedKey.clone();
 
-            DerValue outputValue = new DerValue(DerValue.tag_Integer, this.key);
+            DerValue outputValue = new DerValue(DerValue.tag_Integer, getKey().toByteArray());
 
             return outputValue.toByteArray();
 
@@ -248,7 +252,7 @@ final class DHPublicKey extends X509Key
 
         try {
 
-            DerInputStream in = new DerInputStream(this.key);
+            DerInputStream in = new DerInputStream(getKey().toByteArray());
             this.y = in.getBigInteger();
 
         } catch (IOException e) {
@@ -327,7 +331,7 @@ final class DHPublicKey extends X509Key
                 tmpDerKey.write(DerValue.tag_Sequence, algid);
 
                 // store key data
-                tmpDerKey.putBitString(this.key);
+                tmpDerKey.putBitString(getKey().toByteArray());
 
                 // wrap algid and key into SEQUENCE
                 derKey = new DerOutputStream();
@@ -343,7 +347,7 @@ final class DHPublicKey extends X509Key
 
             }
         }
-        return (byte[]) this.encodedKey.clone();
+        return this.encodedKey.clone();
     }
 
     /**
@@ -372,9 +376,7 @@ final class DHPublicKey extends X509Key
     public void destroy() throws DestroyFailedException {
         if (!destroyed) {
             destroyed = true;
-            if (this.key != null) {
-                Arrays.fill(this.key, (byte) 0x00);
-            }
+            setKey(new BitArray(0));
             this.dhKey = null;
             this.y = null;
             this.dhParams = null;

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -172,7 +172,7 @@ public final class DSAKeyFactory extends KeyFactorySpi {
                     return key;
                 }
                 // Convert key to spec
-                DSAPublicKeySpec dsaPubKeySpec = (DSAPublicKeySpec) engineGetKeySpec(key,
+                DSAPublicKeySpec dsaPubKeySpec = engineGetKeySpec(key,
                         DSAPublicKeySpec.class);
                 // Create key from spec, and return it
                 return engineGeneratePublic(dsaPubKeySpec);
@@ -183,7 +183,7 @@ public final class DSAKeyFactory extends KeyFactorySpi {
                     return key;
                 }
                 // Convert key to spec
-                DSAPrivateKeySpec dsaPrivKeySpec = (DSAPrivateKeySpec) engineGetKeySpec(key,
+                DSAPrivateKeySpec dsaPrivKeySpec = engineGetKeySpec(key,
                         DSAPrivateKeySpec.class);
                 // Create key from spec, and return it
                 return engineGeneratePrivate(dsaPrivKeySpec);

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAKeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -143,7 +143,7 @@ public final class DSAKeyPairGenerator extends KeyPairGenerator
                         .getInstance("DSA", provider);
                 algParmGen.init(this.keySize);
                 AlgorithmParameters algParams = algParmGen.generateParameters();
-                this.params = (DSAParameterSpec) algParams.getParameterSpec(DSAParameterSpec.class);
+                this.params = algParams.getParameterSpec(DSAParameterSpec.class);
 
                 dsaKey = DSAKey.generateKeyPair(provider.getOCKContext(), algParams.getEncoded());
             } else {

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -55,7 +55,7 @@ final class DSAPrivateKey extends PKCS8Key
      * @param g
      *            the number g
      */
-    public DSAPrivateKey(OpenJCEPlusProvider provider, BigInteger x, BigInteger p, BigInteger q,
+    DSAPrivateKey(OpenJCEPlusProvider provider, BigInteger x, BigInteger p, BigInteger q,
             BigInteger g) throws InvalidKeyException {
 
         this.algid = new AlgIdDSA(p, q, g);
@@ -85,7 +85,7 @@ final class DSAPrivateKey extends PKCS8Key
      * @param encoded
      *            the encoded parameters.
      */
-    public DSAPrivateKey(OpenJCEPlusProvider provider, byte[] encoded) throws InvalidKeyException {
+    DSAPrivateKey(OpenJCEPlusProvider provider, byte[] encoded) throws InvalidKeyException {
         decode(encoded);
         this.provider = provider;
 
@@ -101,7 +101,7 @@ final class DSAPrivateKey extends PKCS8Key
         }
     }
 
-    public DSAPrivateKey(OpenJCEPlusProvider provider, DSAKey dsaKey) throws InvalidKeyException {
+    DSAPrivateKey(OpenJCEPlusProvider provider, DSAKey dsaKey) throws InvalidKeyException {
         try {
             this.provider = provider;
 
@@ -141,7 +141,7 @@ final class DSAPrivateKey extends PKCS8Key
                 if (algParams == null) {
                     return null;
                 }
-                paramSpec = (DSAParameterSpec) algParams.getParameterSpec(DSAParameterSpec.class);
+                paramSpec = algParams.getParameterSpec(DSAParameterSpec.class);
                 return (DSAParams) paramSpec;
             }
         } catch (InvalidParameterSpecException e) {
@@ -281,7 +281,7 @@ final class DSAPrivateKey extends PKCS8Key
                 return true;
             }
             if (object instanceof Key) {
-                if (this.x.equals(i) && equals((DSAParams) this.getParams(), (DSAParams) (object
+                if (this.x.equals(i) && equals(this.getParams(), (DSAParams) (object
                         .getClass().getDeclaredMethod("getParams").invoke(object)))) {
                     return true;
                 }

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -17,7 +17,7 @@ import java.security.KeyRep;
 import java.security.interfaces.DSAParams;
 import java.security.spec.DSAParameterSpec;
 import java.security.spec.InvalidParameterSpecException;
-import java.util.Arrays;
+
 import javax.security.auth.DestroyFailedException;
 import javax.security.auth.Destroyable;
 import com.ibm.crypto.plus.provider.ock.DSAKey;
@@ -56,7 +56,7 @@ final class DSAPublicKey extends X509Key
      * @param g
      *            the number g
      */
-    public DSAPublicKey(OpenJCEPlusProvider provider, BigInteger y, BigInteger p, BigInteger q,
+    DSAPublicKey(OpenJCEPlusProvider provider, BigInteger y, BigInteger p, BigInteger q,
             BigInteger g) throws InvalidKeyException {
         this.algid = new AlgIdDSA(p, q, g);
         this.provider = provider;
@@ -86,7 +86,7 @@ final class DSAPublicKey extends X509Key
      * @param encoded
      *            the encoded bytes of the public key
      */
-    public DSAPublicKey(OpenJCEPlusProvider provider, byte[] encoded) throws InvalidKeyException {
+    DSAPublicKey(OpenJCEPlusProvider provider, byte[] encoded) throws InvalidKeyException {
         this.provider = provider;
 
         decode(encoded);
@@ -101,7 +101,7 @@ final class DSAPublicKey extends X509Key
         }
     }
 
-    public DSAPublicKey(OpenJCEPlusProvider provider, DSAKey dsaKey) throws InvalidKeyException {
+    DSAPublicKey(OpenJCEPlusProvider provider, DSAKey dsaKey) throws InvalidKeyException {
         this.provider = provider;
 
         try {
@@ -144,7 +144,7 @@ final class DSAPublicKey extends X509Key
 
                     return null;
                 }
-                paramSpec = (DSAParameterSpec) algParams.getParameterSpec(DSAParameterSpec.class);
+                paramSpec = algParams.getParameterSpec(DSAParameterSpec.class);
                 return (DSAParams) paramSpec;
             }
         } catch (InvalidParameterSpecException e) {
@@ -254,9 +254,7 @@ final class DSAPublicKey extends X509Key
     public void destroy() throws DestroyFailedException {
         if (!destroyed) {
             destroyed = true;
-            if (this.key != null) {
-                Arrays.fill(this.key, (byte) 0x00);
-            }
+            setKey(new BitArray(0));
             this.dsaKey = null;
             this.y = null;
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/ECDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECDHKeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -46,7 +46,7 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi { // implements
 
     public ECDHKeyAgreement(OpenJCEPlusProvider provider) {
 
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/ECDSASignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECDSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -15,7 +15,6 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SignatureException;
 import java.security.SignatureSpi;
-import java.security.spec.ECParameterSpec;
 import com.ibm.crypto.plus.provider.ock.Signature;
 import sun.security.util.ObjectIdentifier;
 
@@ -51,7 +50,7 @@ abstract class ECDSASignature extends SignatureSpi {
 
         if (this.provider.isFIPS()) {
             ECNamedCurve ecNamedCurve = ECParameters
-                    .getNamedCurve(((ECParameterSpec) ecPrivate.getParams()));
+                    .getNamedCurve(ecPrivate.getParams());
             ObjectIdentifier oid = null;
 
             oid = ECNamedCurve.getOIDFromName(ecNamedCurve.getName());

--- a/src/main/java/com/ibm/crypto/plus/provider/ECKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -148,7 +148,7 @@ public final class ECKeyFactory extends KeyFactorySpi {
                     return key;
                 }
                 // Convert key to spec
-                ECPublicKeySpec ecPubKeySpec = (ECPublicKeySpec) engineGetKeySpec(key,
+                ECPublicKeySpec ecPubKeySpec = engineGetKeySpec(key,
                         ECPublicKeySpec.class);
                 // Create key from spec, and return it
                 return engineGeneratePublic(ecPubKeySpec);
@@ -159,7 +159,7 @@ public final class ECKeyFactory extends KeyFactorySpi {
                     return key;
                 }
                 // Convert key to spec
-                ECPrivateKeySpec ecPrivKeySpec = (ECPrivateKeySpec) engineGetKeySpec(key,
+                ECPrivateKeySpec ecPrivKeySpec = engineGetKeySpec(key,
                         ECPrivateKeySpec.class);
                 // Create key from spec, and return it
                 return engineGeneratePrivate(ecPrivKeySpec);

--- a/src/main/java/com/ibm/crypto/plus/provider/ECParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -25,7 +25,9 @@ import java.security.spec.EllipticCurve;
 import java.security.spec.InvalidParameterSpecException;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
+
 import sun.security.util.DerInputStream;
 import sun.security.util.DerOutputStream;
 import sun.security.util.DerValue;
@@ -86,7 +88,6 @@ public final class ECParameters extends AlgorithmParametersSpi {
     protected EllipticCurve curve;
     protected ECPoint generator;
     protected BigInteger order;
-    private OpenJCEPlusProvider provider = null;
 
     /*
      * The parameters these AlgorithmParameters object represents.
@@ -94,10 +95,12 @@ public final class ECParameters extends AlgorithmParametersSpi {
      */
     private NamedCurve namedCurve;
 
-
+    public ECParameters() {
+        super();
+    }
 
     // used by ECPublicKeyImpl and ECPrivateKeyImpl
-    protected static AlgorithmParameters getAlgorithmParameters(OpenJCEPlusProvider provider,
+    static AlgorithmParameters getAlgorithmParameters(OpenJCEPlusProvider provider,
             ECParameterSpec spec) throws InvalidKeyException {
         try {
             AlgorithmParameters params = AlgorithmParameters.getInstance("EC", provider);
@@ -213,16 +216,6 @@ public final class ECParameters extends AlgorithmParametersSpi {
 
         return namedCurve.toString();
     }
-
-    /**
-     *
-     */
-    public ECParameters(OpenJCEPlusProvider provider) {
-        super();
-        this.provider = provider;
-    }
-
-
 
     // COPIED FROM PKCS60 ECParameters.java
     // Used by SunPKCS11 and SunJSSE.
@@ -685,17 +678,17 @@ public final class ECParameters extends AlgorithmParametersSpi {
             // name string,
             // and
             // the value is an ECParameterSpec of the associated ECNamedCurve
-            Map nameMap = ECNamedCurve.getNameMap();
-            Set myEntrySet = nameMap.entrySet();
+            Map<String, ECParameterSpec> nameMap = ECNamedCurve.getNameMap();
+            Set<Entry<String, ECParameterSpec>> myEntrySet = nameMap.entrySet();
 
             // Scan the entries of the nameMap for an ECParameterSpec value that
             // matches the
             // one passed in.
-            for (Iterator myIter = myEntrySet.iterator(); myIter.hasNext();) {
-                Map.Entry myMapEntry = (Map.Entry) myIter.next();
-                String curveNameFromNameMap = (String) (myMapEntry.getKey());
-                ECParameterSpec ecParameterSpecFromNameMap = (ECParameterSpec) (myMapEntry
-                        .getValue());
+            for (Iterator<Entry<String, ECParameterSpec>> myIter = myEntrySet.iterator(); myIter.hasNext();) {
+                Entry<String, ECParameterSpec> myMapEntry = myIter.next();
+                String curveNameFromNameMap = myMapEntry.getKey();
+                ECParameterSpec ecParameterSpecFromNameMap = myMapEntry
+                        .getValue();
 
                 // Does ecParameterSpecFromNameMap match the one passed in?
                 // The ECParameterSpec class does not define equals, so I'll

--- a/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -9,7 +9,6 @@
 package com.ibm.crypto.plus.provider;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.math.BigInteger;
 import java.security.AlgorithmParameters;
 import java.security.InvalidKeyException;
@@ -18,7 +17,6 @@ import java.security.spec.ECParameterSpec;
 import java.security.spec.InvalidParameterSpecException;
 import java.util.Arrays;
 import javax.security.auth.DestroyFailedException;
-import javax.security.auth.Destroyable;
 import com.ibm.crypto.plus.provider.ock.ECKey;
 
 import sun.security.pkcs.PKCS8Key;
@@ -28,8 +26,7 @@ import sun.security.util.DerValue;
 import sun.security.util.ObjectIdentifier;
 import sun.security.x509.AlgorithmId;
 
-final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.ECPrivateKey,
-        java.security.interfaces.ECKey, Serializable, Destroyable {
+final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.ECPrivateKey {
 
     /**
      * 
@@ -39,7 +36,7 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
 
     private OpenJCEPlusProvider provider = null;
     private BigInteger s;
-    private ECParameterSpec params;
+    private transient ECParameterSpec params;
 
     private ECPublicKey publicKey = null;
     private byte[] privateKeyBytesEncoded = null;
@@ -61,7 +58,7 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
      * @param params
      * @param publicKey
      */
-    public ECPrivateKey(OpenJCEPlusProvider provider, BigInteger s, ECParameterSpec params)
+    ECPrivateKey(OpenJCEPlusProvider provider, BigInteger s, ECParameterSpec params)
             throws InvalidKeyException, InvalidParameterSpecException {
 
         // The ECParameterSpec object contains:
@@ -155,7 +152,7 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
      * @param encoded
      *            the encoded parameters.
      */
-    public ECPrivateKey(OpenJCEPlusProvider provider, byte[] encoded) throws InvalidKeyException {
+    ECPrivateKey(OpenJCEPlusProvider provider, byte[] encoded) throws InvalidKeyException {
         decode(encoded);
         this.provider = provider;
 
@@ -194,7 +191,7 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
         }
     }
 
-    public ECPrivateKey(OpenJCEPlusProvider provider, ECKey ecKey) throws InvalidKeyException {
+    ECPrivateKey(OpenJCEPlusProvider provider, ECKey ecKey) throws InvalidKeyException {
 
         // System.out.println("ECPrivateKey=" + ecKey.toString());
         this.provider = provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/GCMParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/GCMParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -50,7 +50,7 @@ public final class GCMParameters extends AlgorithmParametersSpi
 
         byte[] iv = ((GCMParameterSpec) paramSpec).getIV();
 
-        this.iv = (byte[]) iv.clone();
+        this.iv = iv.clone();
     }
 
     /*

--- a/src/main/java/com/ibm/crypto/plus/provider/HKDFGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/HKDFGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -27,8 +27,7 @@ import ibm.security.internal.spec.HKDFParameterSpec;
 /**
  * KeyGenerator implementation for the SSL/TLS master secret derivation.
  */
-@SuppressWarnings("deprecation")
-class HKDFGenerator extends KeyGeneratorSpi {
+public class HKDFGenerator extends KeyGeneratorSpi {
 
     private final static String MSG = "HKDFGenerator must be "
             + "initialized using a HKDFExtractParameterSpec or a HKDFExpandParameterSpec or a HKDFParameterSpec ";

--- a/src/main/java/com/ibm/crypto/plus/provider/HmacCore.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/HmacCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -24,7 +24,7 @@ abstract class HmacCore extends MacSpi {
 
     HmacCore(OpenJCEPlusProvider provider, String ockDigestAlgo, int blockLength) {
 
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/HmacKeyGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/HmacKeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -25,7 +25,7 @@ abstract class HmacKeyGenerator extends KeyGeneratorSpi {
 
     HmacKeyGenerator(OpenJCEPlusProvider provider, String algo, int keysize) {
 
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -794,7 +794,7 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
                 // available
                 //
                 try {
-                    Class<?>[] parameters = new Class[1];
+                    Class<?>[] parameters = new Class<?>[1];
                     parameters[0] = Class
                             .forName("com.ibm.crypto.plus.provider.OpenJCEPlusProvider");
                     Constructor<?> constr = cls.getConstructor(parameters);

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -628,7 +628,7 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
                 // available
                 //
                 try {
-                    Class<?>[] parameters = new Class[1];
+                    Class<?>[] parameters = new Class<?>[1];
                     parameters[0] = Class
                             .forName("com.ibm.crypto.plus.provider.OpenJCEPlusProvider");
                     Constructor<?> constr = cls.getConstructor(parameters);

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -17,14 +17,10 @@ import com.ibm.crypto.plus.provider.ock.OCKContext;
 // Code is not implemented in this class to ensure that any thread call
 // stacks show it originating in the specific provider class.
 //
-@SuppressWarnings({"serial", "removal", "deprecation"})
-abstract class OpenJCEPlusProvider extends java.security.Provider {
-    private static final String PROVIDER_VER = java.security.AccessController
-                .doPrivileged(new java.security.PrivilegedAction<String>() {
-                    public String run() {
-                        return (System.getProperty("java.specification.version"));
-                    }
-                });
+public abstract class OpenJCEPlusProvider extends java.security.Provider {
+    private static final long serialVersionUID = 1L;
+
+    private static final String PROVIDER_VER = System.getProperty("java.specification.version");
 
     // Are we debugging? -- for developers
     static final boolean debug2 = false;
@@ -36,7 +32,7 @@ abstract class OpenJCEPlusProvider extends java.security.Provider {
         super(name, PROVIDER_VER, info);
     }
 
-    static final boolean verifySelfIntegrity(Class c) {
+    static final boolean verifySelfIntegrity(Object c) {
         if (verifiedSelfIntegrity) {
             return true;
         }
@@ -44,7 +40,7 @@ abstract class OpenJCEPlusProvider extends java.security.Provider {
         return doSelfVerification(c);
     }
 
-    private static final synchronized boolean doSelfVerification(Class c) {
+    private static final synchronized boolean doSelfVerification(Object c) {
         return true;
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAKeyFactory.java
@@ -9,12 +9,10 @@
 package com.ibm.crypto.plus.provider;
 
 import java.math.BigInteger;
-import java.security.AccessController;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.KeyFactorySpi;
 import java.security.PrivateKey;
-import java.security.PrivilegedAction;
 import java.security.ProviderException;
 import java.security.PublicKey;
 import java.security.interfaces.RSAKey;
@@ -30,8 +28,7 @@ import java.util.List;
 
 import com.ibm.crypto.plus.provider.RSAUtil.KeyType;
 
-@SuppressWarnings({"removal", "deprecation"})
-class RSAKeyFactory extends KeyFactorySpi {
+public class RSAKeyFactory extends KeyFactorySpi {
 
     public final static int MIN_MODLEN_NONFIPS = 512;
     public final static int MIN_MODLEN_FIPS = 2048;
@@ -50,17 +47,11 @@ class RSAKeyFactory extends KeyFactorySpi {
     public final static int MAX_MODLEN_RESTRICT_EXP = 3072;
     public final static int MAX_RESTRICTED_EXPLEN = 64;
 
-    private static final boolean restrictExpLen = "true".equalsIgnoreCase(
-            (String) AccessController.doPrivileged((PrivilegedAction<String>) () -> System
-                    .getProperty("com.ibm.crypto.provider.restrictRSAExponent", "true")));
+    private static final boolean restrictExpLen = Boolean.parseBoolean(
+            System.getProperty("com.ibm.crypto.provider.restrictRSAExponent", "false"));
 
     private OpenJCEPlusProvider provider;
     private KeyType type = KeyType.RSA;
-
-
-    public static RSAKeyFactory getInstance(OpenJCEPlusProvider provider, KeyType type) {
-        return new RSAKeyFactory(provider, type);
-    }
 
     static RSAKey toRSAKey(OpenJCEPlusProvider provider, Key key) throws InvalidKeyException {
         // FIXME
@@ -188,7 +179,7 @@ class RSAKeyFactory extends KeyFactorySpi {
         this.type = KeyType.RSA;
     }
 
-    public RSAKeyFactory(OpenJCEPlusProvider provider, KeyType type) {
+    private RSAKeyFactory(OpenJCEPlusProvider provider, KeyType type) {
         this.provider = provider;
         this.type = type;
     }
@@ -333,7 +324,7 @@ class RSAKeyFactory extends KeyFactorySpi {
                     return key;
                 }
                 // Convert key to spec
-                RSAPublicKeySpec rsaPubKeySpec = (RSAPublicKeySpec) engineGetKeySpec(key,
+                RSAPublicKeySpec rsaPubKeySpec = engineGetKeySpec(key,
                         RSAPublicKeySpec.class);
                 // Create key from spec, and return it
                 return engineGeneratePublic(rsaPubKeySpec);
@@ -353,7 +344,7 @@ class RSAKeyFactory extends KeyFactorySpi {
                     return key;
                 }
                 // Convert key to spec
-                RSAPrivateKeySpec rsaPrivKeySpec = (RSAPrivateKeySpec) engineGetKeySpec(key,
+                RSAPrivateKeySpec rsaPrivKeySpec = engineGetKeySpec(key,
                         RSAPrivateKeySpec.class);
                 // Create key from spec, and return it
                 return engineGeneratePrivate(rsaPrivKeySpec);

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAKeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -31,24 +31,7 @@ abstract class RSAKeyPairGenerator extends KeyPairGeneratorSpi {
     private KeyType type = RSAUtil.KeyType.RSA;
     private AlgorithmId rsaId;
 
-
-    public RSAKeyPairGenerator(OpenJCEPlusProvider provider) {
-        this.provider = provider;
-        this.type = KeyType.RSA;
-        this.keysize = DEF_RSA_KEY_SIZE;
-    }
-
-    public RSAKeyPairGenerator(OpenJCEPlusProvider provider, KeyType type) {
-        this.provider = provider;
-        this.type = type;
-        if (type == KeyType.RSA) {
-            this.keysize = DEF_RSA_KEY_SIZE;
-        } else {
-            this.keysize = DEF_RSASSA_PSS_KEY_SIZE;
-        }
-    }
-
-    public RSAKeyPairGenerator(OpenJCEPlusProvider provider, KeyType type, int keySize) {
+    RSAKeyPairGenerator(OpenJCEPlusProvider provider, KeyType type, int keySize) {
         this.provider = provider;
         this.type = type;
         this.keysize = keySize;

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPSSSignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPSSSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -71,7 +71,7 @@ public final class RSAPSSSignature extends SignatureSpi {
     // public key, if initialized for verifying
     private java.security.interfaces.RSAPublicKey publicKey;
 
-    RSAPSSSignature(OpenJCEPlusProvider provider, PSSParameterSpec pssParameterSpec) {
+    public RSAPSSSignature(OpenJCEPlusProvider provider, PSSParameterSpec pssParameterSpec) {
         this.provider = provider;
         try {
             if (pssParameterSpec == null) {
@@ -113,7 +113,7 @@ public final class RSAPSSSignature extends SignatureSpi {
         this(provider, (PSSParameterSpec) null);
     }
 
-    RSAPSSSignature(OpenJCEPlusProvider provider, String ockDigestAlgo) {
+    public RSAPSSSignature(OpenJCEPlusProvider provider, String ockDigestAlgo) {
         // PSSParameterSpec pssParameterSpec = null;
         try {
             this.provider = provider;
@@ -362,14 +362,14 @@ public final class RSAPSSSignature extends SignatureSpi {
         }
 
         //Thread.dumpStack();
-        pssParameterSpec = (PSSParameterSpec) validateSigParams(params);
+        pssParameterSpec = validateSigParams(params);
         MGF1ParameterSpec mgf1ParamSpec = (MGF1ParameterSpec) pssParameterSpec.getMGFParameters();
 
         // If the message digest specified within the params is not the same as the MGF message digest
         // then throw an InvalidAlgorithmParameterException.
         String messageDigest = pssParameterSpec.getDigestAlgorithm();
         if ((messageDigest != null) && (mgf1ParamSpec != null)) {
-            String mgfMessageDigest = ((MGF1ParameterSpec) mgf1ParamSpec).getDigestAlgorithm();
+            String mgfMessageDigest = mgf1ParamSpec.getDigestAlgorithm();
 
             if (mgfMessageDigest != null) {
                 boolean throwException = true;

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateCrtKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateCrtKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -40,7 +40,7 @@ final class RSAPrivateCrtKey extends PKCS8Key
     private BigInteger primeExponentP;
     private BigInteger primeExponentQ;
     private BigInteger crtCoefficient;
-    private AlgorithmParameterSpec keyParams;
+    private transient AlgorithmParameterSpec keyParams;
 
     private transient boolean destroyed = false;
     private transient RSAKey rsaKey = null; // Transient per tag [SERIALIZATION] in DesignNotes.txt

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -42,7 +42,7 @@ final class RSAPrivateKey extends PKCS8Key
 
     private transient boolean destroyed = false;
     private transient RSAKey rsaKey = null; // Transient per tag [SERIALIZATION] in DesignNotes.txt
-    private AlgorithmParameterSpec keyParams;
+    private transient AlgorithmParameterSpec keyParams;
 
     public RSAPrivateKey(OpenJCEPlusProvider provider, BigInteger m, BigInteger privEx)
             throws InvalidKeyException, IOException {

--- a/src/main/java/com/ibm/crypto/plus/provider/TlsKeyMaterialGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/TlsKeyMaterialGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -33,7 +33,6 @@ import sun.security.internal.spec.TlsKeyMaterialSpec;
 /**
  * KeyGenerator implementation for the SSL/TLS master secret derivation.
  */
-@SuppressWarnings("deprecation")
 public final class TlsKeyMaterialGenerator extends KeyGeneratorSpi {
 
     private final static String MSG = "TlsKeyMaterialGenerator must be "
@@ -52,7 +51,7 @@ public final class TlsKeyMaterialGenerator extends KeyGeneratorSpi {
      */
     public TlsKeyMaterialGenerator(OpenJCEPlusProvider provider) {
 
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/TlsMasterSecretGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/TlsMasterSecretGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -29,7 +29,6 @@ import javax.crypto.SecretKey;
 /**
  * KeyGenerator implementation for the SSL/TLS master secret derivation.
  */
-@SuppressWarnings("deprecation")
 public final class TlsMasterSecretGenerator extends KeyGeneratorSpi {
 
     private final static String MSG = "TlsMasterSecretGenerator must be "
@@ -42,7 +41,7 @@ public final class TlsMasterSecretGenerator extends KeyGeneratorSpi {
 
     public TlsMasterSecretGenerator(OpenJCEPlusProvider provider) {
 
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/TlsPrfGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/TlsPrfGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -30,7 +30,6 @@ import sun.security.internal.spec.TlsPrfParameterSpec;
  * optimizations (e.g. XOR'ing keys with padding doesn't need to be redone for
  * each HMAC operation).
  */
-@SuppressWarnings("deprecation")
 abstract class TlsPrfGenerator extends KeyGeneratorSpi {
 
     // magic constants and utility functions, also used by other files
@@ -109,9 +108,9 @@ abstract class TlsPrfGenerator extends KeyGeneratorSpi {
     private OpenJCEPlusProvider provider = null;
     private TlsPrfParameterSpec spec;
 
-    protected TlsPrfGenerator(OpenJCEPlusProvider provider) {
+    TlsPrfGenerator(OpenJCEPlusProvider provider) {
 
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/TlsRsaPremasterSecretGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/TlsRsaPremasterSecretGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -21,7 +21,6 @@ import javax.crypto.spec.SecretKeySpec;
 /**
  * KeyGenerator implementation for the SSL/TLS RSA premaster secret.
  */
-@SuppressWarnings("deprecation")
 public final class TlsRsaPremasterSecretGenerator extends KeyGeneratorSpi {
 
     private final static String MSG = "TlsRsaPremasterSecretGenerator must be "
@@ -33,7 +32,7 @@ public final class TlsRsaPremasterSecretGenerator extends KeyGeneratorSpi {
 
     public TlsRsaPremasterSecretGenerator(OpenJCEPlusProvider provider) {
 
-        if (!provider.verifySelfIntegrity(this.getClass())) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
         }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -26,7 +26,7 @@ import javax.crypto.spec.SecretKeySpec;
 import com.ibm.crypto.plus.provider.ock.OCKException;
 import com.ibm.crypto.plus.provider.ock.XECKey;
 
-public class XDHKeyAgreement extends KeyAgreementSpi {
+abstract class XDHKeyAgreement extends KeyAgreementSpi {
 
     private static final int SECRET_BUFFER_SIZE_X25519 = 32;
     private static final int SECRET_BUFFER_SIZE_X448 = 56;
@@ -38,17 +38,17 @@ public class XDHKeyAgreement extends KeyAgreementSpi {
     private byte[] secret = null;
     private String alg = null;
 
-    public XDHKeyAgreement(OpenJCEPlusProvider provider) {
+    XDHKeyAgreement(OpenJCEPlusProvider provider) {
 
-        if (!provider.verifySelfIntegrity(this.getClass()))
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this))
             throw new SecurityException("Integrity check failed for: " + provider.getName());
 
         this.provider = provider;
     }
 
-    public XDHKeyAgreement(OpenJCEPlusProvider provider, String Alg) {
+    XDHKeyAgreement(OpenJCEPlusProvider provider, String Alg) {
 
-        if (!provider.verifySelfIntegrity(this.getClass()))
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this))
             throw new SecurityException("Integrity check failed for: " + provider.getName());
 
         this.provider = provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -28,7 +28,7 @@ import java.security.spec.XECPrivateKeySpec;
 import java.security.spec.XECPublicKeySpec;
 import java.util.Optional;
 
-public class XDHKeyFactory extends KeyFactorySpi {
+class XDHKeyFactory extends KeyFactorySpi {
 
     private OpenJCEPlusProvider provider = null;
     private String alg = null;
@@ -189,7 +189,7 @@ public class XDHKeyFactory extends KeyFactorySpi {
                     return key;
 
                 // Convert key to spec
-                XECPublicKeySpec xecPubKeySpec = (XECPublicKeySpec) engineGetKeySpec(key,
+                XECPublicKeySpec xecPubKeySpec = engineGetKeySpec(key,
                         XECPublicKeySpec.class);
 
                 // Create key from spec, and return it
@@ -208,7 +208,7 @@ public class XDHKeyFactory extends KeyFactorySpi {
                     return key;
 
                 // Convert key to spec
-                XECPrivateKeySpec xecPrivKeySpec = (XECPrivateKeySpec) engineGetKeySpec(key,
+                XECPrivateKeySpec xecPrivKeySpec = engineGetKeySpec(key,
                         XECPrivateKeySpec.class);
                 // Create key from spec, and return it
                 return engineGeneratePrivate(xecPrivKeySpec);

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -18,7 +18,7 @@ import java.security.spec.NamedParameterSpec;
 
 import com.ibm.crypto.plus.provider.ock.XECKey;
 
-public class XDHKeyPairGenerator extends KeyPairGeneratorSpi {
+abstract class XDHKeyPairGenerator extends KeyPairGeneratorSpi {
 
     private static final NamedParameterSpec DEFAULT_PARAM_SPEC
         = NamedParameterSpec.X25519;

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -40,8 +40,8 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
     private static final long serialVersionUID = 6034044314589513430L;
 
     private OpenJCEPlusProvider provider = null;
-    private Optional<byte[]> scalar;
-    private NamedParameterSpec params;
+    private transient Optional<byte[]> scalar;
+    private transient NamedParameterSpec params;
     private CURVE curve;
     BigInteger bi1; // parameter used in FFDHE
     BigInteger bi2; // parameter used in FFDHE

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/CCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/CCMCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -9,11 +9,10 @@
 package com.ibm.crypto.plus.provider.ock;
 
 import java.nio.ByteBuffer;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.crypto.AEADBadTagException;
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
@@ -37,12 +36,8 @@ public final class CCMCipher {
     static final int CCM_AUGMENTED_MODE = 768;
 
     static {
-        disableCCMAcceleration = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-            public Boolean run() {
-                return ("true"
-                        .equalsIgnoreCase(System.getProperty(DISABLE_CCM_ACCELERATION, "false")));
-            }
-        });
+        disableCCMAcceleration = Boolean.parseBoolean(
+            System.getProperty(DISABLE_CCM_ACCELERATION, "false"));
     }
 
 

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/Digest.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/Digest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -51,7 +51,7 @@ public final class Digest implements Cloneable {
     static private int runtimeContextNum[];
 
     class ConcurrentLinkedQueueLong extends ConcurrentLinkedQueue<Long> {
-        /* empty */
+        private static final long serialVersionUID = 196745693267521676L;
     }
 
     static {

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/ECKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/ECKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -83,7 +83,7 @@ public final class ECKey implements AsymmetricKey {
         this.ecKeyId = ecKeyId;
         this.pkeyId = 0;
 
-        this.ecSpec = (ECParameterSpec) ecSpec;
+        this.ecSpec = ecSpec;
         // this.isNamedCurve = false;
         // this.curveName = null;
         // this.parameterBytes = convertSpecToBytes(ecSpec);

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/HKDF.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/HKDF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -46,7 +46,7 @@ public final class HKDF {
         //OCKDebug.Msg (debPrefix, methodName,  "saltLen:" + saltLen );
         //OCKDebug.Msg (debPrefix, methodName,  "inpKeyLen:" + inpKeyLen  + " inKey.lenth=" + inKey.length);
         byte[] extractedBytes = NativeInterface.HKDF_extract(ockContext.getId(), hkdfId, salt,
-                (long) (salt.length), inKey, (long) inpKeyLen);
+                (long) (salt.length), inKey, inpKeyLen);
         return extractedBytes;
 
     }
@@ -57,7 +57,7 @@ public final class HKDF {
         //        + "            byte[] info, long infoLen, long okmLen)";
         //OCKDebug.Msg (debPrefix, methodName,  "this.hkdfId :" + this.hkdfId );
         byte[] expandedBytes = NativeInterface.HKDF_expand(ockContext.getId(), hkdfId, prkBytes,
-                (long) (prkBytes.length), info, (long) (info.length), (long) okmLen);
+                (long) (prkBytes.length), info, (long) (info.length), okmLen);
         return expandedBytes;
 
     }
@@ -69,8 +69,7 @@ public final class HKDF {
         //OCKDebug.Msg (debPrefix, methodName,  "saltLen:" + saltLen );
         //OCKDebug.Msg (debPrefix, methodName,  "inpKeyLen:" + inpKeyLen  + " inKey.lenth=" + inKey.length);
         byte[] generateBytes = NativeInterface.HKDF_derive(ockContext.getId(), hkdfId, salt,
-                (long) (salt.length), inKey, (long) inpKeyLen, info, (long) (info.length),
-                (long) okmLen);
+                (long) (salt.length), inKey, inpKeyLen, info, (long) (info.length), okmLen);
         return generateBytes;
 
     }

--- a/src/main/java/com/ibm/misc/Debug.java
+++ b/src/main/java/com/ibm/misc/Debug.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -14,6 +14,7 @@ import java.math.BigInteger;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import jdk.internal.logger.SimpleConsoleLogger;
 import sun.util.logging.PlatformLogger;
 
@@ -46,16 +47,16 @@ public class Debug {
     */
 
     static {
-        args = (String) java.security.AccessController
-                .doPrivileged(new java.security.PrivilegedAction() {
-                    public Object run() {
-                        return (System.getProperty("java.security.debug"));
+        args = java.security.AccessController
+                .doPrivileged(new java.security.PrivilegedAction<String>() {
+                    public String run() {
+                        return System.getProperty("java.security.debug");
                     }
                 });
-        String args2 = (String) java.security.AccessController
-                .doPrivileged(new java.security.PrivilegedAction() {
-                    public Object run() {
-                        return (System.getProperty("java.security.auth.debug"));
+        String args2 = java.security.AccessController
+                .doPrivileged(new java.security.PrivilegedAction<String>() {
+                    public String run() {
+                        return System.getProperty("java.security.auth.debug");
                     }
                 });
         if (args == null) {
@@ -194,7 +195,7 @@ public class Debug {
      *   <code>TYPE_ENTRY_EXIT</code> has been split into
      *   <code>TYPE_ENTRY</code> and <code>TYPE_EXIT</code>.
      */
-
+    @Deprecated
     public static final long TYPE_ENTRY_EXIT = 0x000040;
 
     /**
@@ -862,7 +863,7 @@ public class Debug {
     private static String getDebugDate(String className) {
         String versionDate = "Unknown";
         try {
-            Class thisClass = Class.forName(className);
+            Class<?> thisClass = Class.forName(className);
             Package thisPackage = thisClass.getPackage();
             String versionInfo = thisPackage.getImplementationVersion();
             int index = versionInfo.indexOf("_");

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAES.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAES.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -1194,8 +1194,7 @@ public class BaseTestAES extends BaseTestCipher {
         try {
             java_provider = java.security.Security.getProvider("OpenJCEPlus");
             if (java_provider == null) {
-                java_provider = (java.security.Provider) Class
-                        .forName("com.ibm.crypto.plus.provider.OpenJCEPlus").newInstance();
+                java_provider = new com.ibm.crypto.plus.provider.OpenJCEPlus();
                 java.security.Security.insertProviderAt(java_provider, 1);
             }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCMInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCMInteropBC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -11,11 +11,13 @@ package ibm.jceplus.junit.base;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.util.Random;
+
 import javax.crypto.AEADBadTagException;
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
+
 import org.junit.Assert;
 
 
@@ -544,12 +546,12 @@ public class BaseTestAESCCMInteropBC extends BaseTestInterop {
             if (printJunitTrace)
                 System.out.println(toHexString(plaintext));
 
-            org.bouncycastle.crypto.BlockCipher engine = new org.bouncycastle.crypto.engines.AESEngine();
-            org.bouncycastle.crypto.params.CCMParameters params = new org.bouncycastle.crypto.params.CCMParameters(
+            org.bouncycastle.crypto.MultiBlockCipher engine = org.bouncycastle.crypto.engines.AESEngine.newInstance();
+            org.bouncycastle.crypto.params.AEADParameters params = new org.bouncycastle.crypto.params.AEADParameters(
                     new org.bouncycastle.crypto.params.KeyParameter(aesKeyBytes), ccmTagLength, IV,
                     null);
 
-            org.bouncycastle.crypto.modes.CCMBlockCipher cipher = new org.bouncycastle.crypto.modes.CCMBlockCipher(
+            org.bouncycastle.crypto.modes.CCMModeCipher cipher = org.bouncycastle.crypto.modes.CCMBlockCipher.newInstance(
                     engine);
             cipher.init(true, params); // true for encryption
             byte[] cipherText = new byte[cipher.getOutputSize(plaintext.length)];
@@ -802,12 +804,12 @@ public class BaseTestAESCCMInteropBC extends BaseTestInterop {
             if (printJunitTrace)
                 System.out.println(toHexString(cipherText));
 
-            org.bouncycastle.crypto.BlockCipher engine = new org.bouncycastle.crypto.engines.AESEngine();
-            org.bouncycastle.crypto.params.CCMParameters params = new org.bouncycastle.crypto.params.CCMParameters(
+            org.bouncycastle.crypto.BlockCipher engine = org.bouncycastle.crypto.engines.AESEngine.newInstance();
+            org.bouncycastle.crypto.params.AEADParameters params = new org.bouncycastle.crypto.params.AEADParameters(
                     new org.bouncycastle.crypto.params.KeyParameter(aesKeyBytes), ccmTagLength, IV,
                     null);
 
-            org.bouncycastle.crypto.modes.CCMBlockCipher cipher = new org.bouncycastle.crypto.modes.CCMBlockCipher(
+            org.bouncycastle.crypto.modes.CCMModeCipher cipher = org.bouncycastle.crypto.modes.CCMBlockCipher.newInstance(
                     engine);
             cipher.init(false, params); // false for decryption
             byte[] decryptedText = new byte[cipher.getOutputSize(cipherText.length)];

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCMParameters.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCMParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -303,7 +303,7 @@ public class BaseTestAESCCMParameters extends BaseTest {
         // Obtain a CCMParameterSpec object from the CCMParameters object
         CCMParameterSpec newCCMParameterSpec = null;
         try {
-            newCCMParameterSpec = (CCMParameterSpec) ccmParameters1
+            newCCMParameterSpec = ccmParameters1
                     .getParameterSpec(CCMParameterSpec.class);
         } catch (Exception ex) {
             System.out.println(
@@ -589,7 +589,7 @@ public class BaseTestAESCCMParameters extends BaseTest {
         // Get a CCMParametersSpec object from the generated algorithmParameters (CCMParameters) object
         CCMParameterSpec ccmParameterSpec = null;
         try {
-            ccmParameterSpec = (CCMParameterSpec) algorithmParameters
+            ccmParameterSpec = algorithmParameters
                     .getParameterSpec(CCMParameterSpec.class);
         } catch (Exception ex) {
             System.out.println(
@@ -692,7 +692,7 @@ public class BaseTestAESCCMParameters extends BaseTest {
         // Get a CCMParametersSpec object from the generated algorithmParameters (CCMParameters) object
         ccmParameterSpec = null;
         try {
-            ccmParameterSpec = (CCMParameterSpec) algorithmParameters
+            ccmParameterSpec = algorithmParameters
                     .getParameterSpec(CCMParameterSpec.class);
         } catch (Exception ex) {
             System.out.println(

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -97,7 +97,7 @@ public class BaseTestAESGCM extends BaseTest {
     protected Cipher cp = null;
     protected boolean success = true;
     protected Method methodCipherUpdateAAD = null;
-    protected Constructor ctorGCMParameterSpec = null;
+    protected Constructor<?> ctorGCMParameterSpec = null;
     protected Method methodGCMParameterSpecSetAAD = null;
     protected int specifiedKeySize = 0;
     byte[] ivBytes = "123456".getBytes();
@@ -132,8 +132,8 @@ public class BaseTestAESGCM extends BaseTest {
         key = aesKeyGen.generateKey();
 
         try {
-            Class classCipher = Class.forName("javax.crypto.Cipher");
-            methodCipherUpdateAAD = classCipher.getMethod("updateAAD", new Class[] {byte[].class});
+            Class<?> classCipher = Class.forName("javax.crypto.Cipher");
+            methodCipherUpdateAAD = classCipher.getMethod("updateAAD", new Class<?>[] {byte[].class});
         } catch (Exception e) {
         }
 
@@ -142,9 +142,9 @@ public class BaseTestAESGCM extends BaseTest {
          * 7+)
          */
         try {
-            Class classGCMParameterSpec = Class.forName("javax.crypto.spec.GCMParameterSpec");
+            Class<?> classGCMParameterSpec = Class.forName("javax.crypto.spec.GCMParameterSpec");
             ctorGCMParameterSpec = classGCMParameterSpec
-                    .getConstructor(new Class[] {int.class, byte[].class});
+                    .getConstructor(new Class<?>[] {int.class, byte[].class});
         } catch (Exception ex) {
             /* Differ to calling code in test cases that follow... */
         }
@@ -155,12 +155,12 @@ public class BaseTestAESGCM extends BaseTest {
          */
         if (ctorGCMParameterSpec == null) {
             try {
-                Class classGCMParameterSpec = Class
+                Class<?> classGCMParameterSpec = Class
                         .forName("ibm.security.internal.spec.GCMParameterSpec");
                 ctorGCMParameterSpec = classGCMParameterSpec
-                        .getConstructor(new Class[] {int.class, byte[].class});
+                        .getConstructor(new Class<?>[] {int.class, byte[].class});
                 methodGCMParameterSpecSetAAD = classGCMParameterSpec.getMethod("setAAD",
-                        new Class[] {byte[].class, int.class, int.class});
+                        new Class<?>[] {byte[].class, int.class, int.class});
             } catch (Exception ex) {
                 /* Differ to calling code in test cases that follow... */
             }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM_ExtIV.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM_ExtIV.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -37,12 +37,12 @@ public class BaseTestAESGCM_ExtIV extends BaseTest {
 
     private AlgorithmParameterSpec gcm_param_spec = null;
 
-    private static Class classGCMParameterSpec = null;
-    private static Constructor ctorGCMParameterSpec = null;
+    private static Class<?> classGCMParameterSpec = null;
+    private static Constructor<?> ctorGCMParameterSpec = null;
     private static Method methGCMParameterSpecSetADD = null;
 
-    private static Class classAESGCMCipher = null;
-    private static Constructor ctorAESGCMCipher = null;
+    private static Class<?> classAESGCMCipher = null;
+    private static Constructor<?> ctorAESGCMCipher = null;
     private static Method methAESGCMCipherUpdateAAD = null;
 
     private static Method methCipherGetInstance = null;
@@ -67,10 +67,10 @@ public class BaseTestAESGCM_ExtIV extends BaseTest {
         try {
             classGCMParameterSpec = Class.forName("javax.crypto.spec.GCMParameterSpec");
             ctorGCMParameterSpec = classGCMParameterSpec
-                    .getConstructor(new Class[] {int.class, byte[].class});
+                    .getConstructor(new Class<?>[] {int.class, byte[].class});
             classAESGCMCipher = Class.forName("javax.crypto.Cipher");
             methAESGCMCipherUpdateAAD = classAESGCMCipher.getMethod("updateAAD",
-                    new Class[] {byte[].class});
+                    new Class<?>[] {byte[].class});
         } catch (Exception ex) {
             /* Differ to calling code in test cases that follow... */
         }
@@ -85,9 +85,9 @@ public class BaseTestAESGCM_ExtIV extends BaseTest {
                 classGCMParameterSpec = Class
                         .forName("ibm.security.internal.spec.GCMParameterSpec");
                 ctorGCMParameterSpec = classGCMParameterSpec
-                        .getConstructor(new Class[] {int.class, byte[].class});
+                        .getConstructor(new Class<?>[] {int.class, byte[].class});
                 methGCMParameterSpecSetADD = classGCMParameterSpec.getMethod("setAAD",
-                        new Class[] {byte[].class, int.class, int.class});
+                        new Class<?>[] {byte[].class, int.class, int.class});
             } catch (Exception ex) {
                 /* Differ to calling code in test cases that follow... */
             }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM_IntIV.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM_IntIV.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -12,7 +12,6 @@
 
 package ibm.jceplus.junit.base;
 
-import java.lang.reflect.Constructor;
 import java.math.BigInteger;
 import java.security.AlgorithmParameters;
 import java.security.InvalidAlgorithmParameterException;
@@ -47,8 +46,6 @@ public class BaseTestAESGCM_IntIV extends BaseTest {
     int tagLength = 16;
     AlgorithmParameterSpec aParamSpec = null;
     AlgorithmParameters aParams = null;
-    Class classGCMParameterSpec = null;
-    Constructor ctorGCMParameterSpec = null;
 
     // --------------------------------------------------------------------------
     //
@@ -66,46 +63,11 @@ public class BaseTestAESGCM_IntIV extends BaseTest {
 
         key = aesKeyGen.generateKey();
 
-        /*
-         * Try constructing a javax.crypto.spec.GCMParameterSpec instance (Java
-         * 7+)
-         */
-
-        try {
-            classGCMParameterSpec = Class.forName("javax.crypto.spec.GCMParameterSpec");
-            ctorGCMParameterSpec = classGCMParameterSpec
-                    .getConstructor(new Class[] {int.class, byte[].class});
-        } catch (Exception e) {
-            /*
-             * Differ to "System.out.println("Unexpected exception: ");", below
-             */
-        }
-
-        /*
-         * Try constructing an ibm.security.internal.spec.GCMParameterSpec
-         * instance (IBM Java 6)
-         */
-
-        if (ctorGCMParameterSpec == null) {
-            try {
-                classGCMParameterSpec = Class
-                        .forName("ibm.security.internal.spec.GCMParameterSpec");
-                ctorGCMParameterSpec = classGCMParameterSpec
-                        .getConstructor(new Class[] {int.class, byte[].class});
-            } catch (Exception e) {
-                /*
-                 * Differ to "System.out.println("Unexpected exception: ");",
-                 * below
-                 */
-            }
-        }
-
         byte[] iv = new byte[16];// com.ibm.crypto.plus.provider.AESConstants.AES_BLOCK_SIZE];
         SecureRandom rnd = new java.security.SecureRandom();
         rnd.nextBytes(iv);
 
-        aParamSpec = (AlgorithmParameterSpec) ctorGCMParameterSpec.newInstance(DEFAULT_TAG_LENGTH,
-                iv);
+        aParamSpec = new javax.crypto.spec.GCMParameterSpec(DEFAULT_TAG_LENGTH, iv);
         aParams = AlgorithmParameters.getInstance("AESGCM", providerName);
         aParams.init(aParamSpec);
     }
@@ -232,7 +194,7 @@ public class BaseTestAESGCM_IntIV extends BaseTest {
         /* Save the algorithm parameters used to do the encryption */
 
         AlgorithmParameters ap = cipherEncrypt.getParameters();
-        AlgorithmParameterSpec apSpec = ap.getParameterSpec(classGCMParameterSpec);
+        AlgorithmParameterSpec apSpec = ap.getParameterSpec(aParamSpec.getClass());
 
         /* Do the decryption using the internally generated IV */
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESInterop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -123,8 +123,7 @@ public class BaseTestAESInterop extends BaseTestInterop {
         try {
             java_provider = java.security.Security.getProvider("OpenJCEPlus");
             if (java_provider == null) {
-                java_provider = (java.security.Provider) Class
-                        .forName("com.ibm.crypto.plus.provider.OpenJCEPlus").newInstance();
+                java_provider = new com.ibm.crypto.plus.provider.OpenJCEPlus();
                 java.security.Security.insertProviderAt(java_provider, 1);
             }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -351,7 +351,7 @@ public class BaseTestDH extends BaseTest {
                 providerName);
         algParamGen.init(size);
         AlgorithmParameters algParams = algParamGen.generateParameters();
-        DHParameterSpec dhps = (DHParameterSpec) algParams.getParameterSpec(DHParameterSpec.class);
+        DHParameterSpec dhps = algParams.getParameterSpec(DHParameterSpec.class);
         return dhps;
 
     }
@@ -485,7 +485,7 @@ public class BaseTestDH extends BaseTest {
                 myProviderName);
         algParamGen.init(size);
         AlgorithmParameters algParams = algParamGen.generateParameters();
-        DHParameterSpec dhps = (DHParameterSpec) algParams.getParameterSpec(DHParameterSpec.class);
+        DHParameterSpec dhps = algParams.getParameterSpec(DHParameterSpec.class);
         return dhps;
 
     }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDHInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDHInterop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -65,7 +65,7 @@ public class BaseTestDHInterop extends BaseTestInterop {
 
     public void testDH() throws Exception {
 
-        String idString = (new Integer(this.keySize)).toString();
+        String idString = (Integer.valueOf(this.keySize)).toString();
 
         DHParameterSpec dhps = generateDHParameters(this.keySize);
 
@@ -367,7 +367,7 @@ public class BaseTestDHInterop extends BaseTestInterop {
                 providerName);
         algParamGen.init(size);
         AlgorithmParameters algParams = algParamGen.generateParameters();
-        DHParameterSpec dhps = (DHParameterSpec) algParams.getParameterSpec(DHParameterSpec.class);
+        DHParameterSpec dhps = algParams.getParameterSpec(DHParameterSpec.class);
         return dhps;
 
     }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDSAKey.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDSAKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -83,7 +83,7 @@ public class BaseTestDSAKey extends BaseTest {
     public void testDSAKeyGenFromParams_1024() throws Exception {
         try {
             AlgorithmParameters algParams = generateParameters(1024);
-            DSAParameterSpec dsaParameterSpec = (DSAParameterSpec) algParams
+            DSAParameterSpec dsaParameterSpec = algParams
                     .getParameterSpec(DSAParameterSpec.class);
             KeyPair dsaKeyPair = generateKeyPair(dsaParameterSpec);
             dsaKeyPair.getPublic();
@@ -237,7 +237,7 @@ public class BaseTestDSAKey extends BaseTest {
 
         KeyPair dsaKeyPair = generateKeyPair(size);
 
-        DSAPublicKeySpec dsaPubSpec = (DSAPublicKeySpec) dsaKeyFactory
+        DSAPublicKeySpec dsaPubSpec = dsaKeyFactory
                 .getKeySpec(dsaKeyPair.getPublic(), DSAPublicKeySpec.class);
         DSAPublicKey dsaPub = (DSAPublicKey) dsaKeyFactory.generatePublic(dsaPubSpec);
 
@@ -245,7 +245,7 @@ public class BaseTestDSAKey extends BaseTest {
             fail("DSA public key does not match generated public key");
         }
 
-        DSAPrivateKeySpec dsaPrivateSpec = (DSAPrivateKeySpec) dsaKeyFactory
+        DSAPrivateKeySpec dsaPrivateSpec = dsaKeyFactory
                 .getKeySpec(dsaKeyPair.getPrivate(), DSAPrivateKeySpec.class);
         DSAPrivateKey dsaPriv = (DSAPrivateKey) dsaKeyFactory.generatePrivate(dsaPrivateSpec);
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestInvalidArrayIndex.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestInvalidArrayIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -74,16 +74,16 @@ public class BaseTestInvalidArrayIndex extends BaseTest {
         }
     }
 
-    private static void dotest(int expectedEx, Class specCls, Object... args)
+    private static void dotest(int expectedEx, Class<?> specCls, Object... args)
             throws NoSuchMethodException, InstantiationException, IllegalAccessException,
             IllegalArgumentException, InvocationTargetException {
         System.out.println("Testing " + specCls);
         String exName = (expectedEx == 1) ? "IAE" : "AIOOBE";
-        Class[] argsClz = new Class[args.length];
+        Class<?>[] argsClz = new Class<?>[args.length];
         for (int i = 0; i < argsClz.length; i++) {
             argsClz[i] = (args[i] instanceof Integer ? Integer.TYPE : args[i].getClass());
         }
-        Constructor ctr = specCls.getConstructor(argsClz);
+        Constructor<?> ctr = specCls.getConstructor(argsClz);
         try {
             ctr.newInstance(args);
             throw new RuntimeException("Should throw " + exName);

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPublicMethodsToMakeNonPublic.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPublicMethodsToMakeNonPublic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -12,6 +12,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.net.JarURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.security.Security;
 import java.util.Enumeration;
@@ -76,7 +77,7 @@ abstract public class BaseTestPublicMethodsToMakeNonPublic extends BaseTest {
                 publicMethodNamesString = publicMethodNamesToCheck.toString();
             } else {
                 StringBuffer sb = new StringBuffer();
-                String[] methodNames = (String[]) publicMethodNamesToCheck.toArray(new String[0]);
+                String[] methodNames = publicMethodNamesToCheck.toArray(new String[0]);
                 for (int methodIndex = 0; methodIndex < methodNames.length; ++methodIndex) {
                     sb.append("\n");
                     sb.append(methodNames[methodIndex]);
@@ -116,7 +117,7 @@ abstract public class BaseTestPublicMethodsToMakeNonPublic extends BaseTest {
             e.printStackTrace(System.out);
         }
 
-        return (String[]) v.toArray(new String[0]);
+        return v.toArray(new String[0]);
     }
 
     // --------------------------------------------------------------------------
@@ -130,7 +131,8 @@ abstract public class BaseTestPublicMethodsToMakeNonPublic extends BaseTest {
 
             int indexOfBang = url.toString().lastIndexOf(".jar!/");
             if (indexOfBang > 0) {
-                URL jarURL = new URL(url.toString().substring(0, indexOfBang + 6));
+                URI jarURI = new URI(url.toString().substring(0, indexOfBang + 6));
+                URL jarURL = jarURI.toURL();
                 JarFile jarFile = ((JarURLConnection) jarURL.openConnection()).getJarFile();
                 return jarFile;
             }
@@ -150,7 +152,7 @@ abstract public class BaseTestPublicMethodsToMakeNonPublic extends BaseTest {
         try {
             Enumeration<JarEntry> jarEntries = jarFile.entries();
             while (jarEntries.hasMoreElements()) {
-                JarEntry jarEntry = (JarEntry) jarEntries.nextElement();
+                JarEntry jarEntry = jarEntries.nextElement();
                 String jarEntryName = jarEntry.getName();
                 if (jarEntryName.endsWith(".class")) {
                     String className = jarEntryName.substring(0, jarEntryName.length() - 6)
@@ -162,7 +164,7 @@ abstract public class BaseTestPublicMethodsToMakeNonPublic extends BaseTest {
             e.printStackTrace(System.out);
         }
 
-        return (String[]) v.toArray(new String[0]);
+        return v.toArray(new String[0]);
     }
 
     // --------------------------------------------------------------------------
@@ -270,7 +272,7 @@ abstract public class BaseTestPublicMethodsToMakeNonPublic extends BaseTest {
             e.printStackTrace(System.out);
         }
 
-        return (Method[]) v.toArray(new Method[0]);
+        return v.toArray(new Method[0]);
     }
 
     // --------------------------------------------------------------------------

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSA.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSA.java
@@ -753,7 +753,10 @@ public class BaseTestRSA extends BaseTestCipher {
     //
     public void testRSACipher_init_key_algparmspec() throws Exception {
         String transformation = "RSA/ECB/OAEPPadding";
-        AlgorithmParameterSpec algParams = OAEPParameterSpec.DEFAULT;
+        AlgorithmParameterSpec algParams = new OAEPParameterSpec("SHA-1",
+                                                                 "MGF1",
+                                                                 MGF1ParameterSpec.SHA1,
+                                                                 PSource.PSpecified.DEFAULT);
 
         byte[] message = getMessage_OAEP_SHA1();
         if (message != null) {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKey.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -230,7 +230,7 @@ public class BaseTestRSAKey extends BaseTest {
 
         KeyPair rsaKeyPair = generateKeyPair(size);
 
-        RSAPublicKeySpec rsaPubSpec = (RSAPublicKeySpec) rsaKeyFactory
+        RSAPublicKeySpec rsaPubSpec = rsaKeyFactory
                 .getKeySpec(rsaKeyPair.getPublic(), RSAPublicKeySpec.class);
         RSAPublicKey rsaPub = (RSAPublicKey) rsaKeyFactory.generatePublic(rsaPubSpec);
 
@@ -239,7 +239,7 @@ public class BaseTestRSAKey extends BaseTest {
         }
 
         if (rsaKeyPair.getPrivate() instanceof RSAPrivateCrtKey) {
-            RSAPrivateCrtKeySpec rsaPrivateCrtSpec = (RSAPrivateCrtKeySpec) rsaKeyFactory
+            RSAPrivateCrtKeySpec rsaPrivateCrtSpec = rsaKeyFactory
                     .getKeySpec(rsaKeyPair.getPrivate(), RSAPrivateCrtKeySpec.class);
             RSAPrivateCrtKey rsaPrivCrt = (RSAPrivateCrtKey) rsaKeyFactory
                     .generatePrivate(rsaPrivateCrtSpec);
@@ -248,7 +248,7 @@ public class BaseTestRSAKey extends BaseTest {
                 fail("RSA private CRT key does not match generated private key");
             }
 
-            RSAPrivateKeySpec rsaPrivateSpec = (RSAPrivateKeySpec) rsaKeyFactory
+            RSAPrivateKeySpec rsaPrivateSpec = rsaKeyFactory
                     .getKeySpec(rsaKeyPair.getPrivate(), RSAPrivateKeySpec.class);
             try {
                 //JCEPlus does not support RSAPrivateKeySpec
@@ -259,7 +259,7 @@ public class BaseTestRSAKey extends BaseTest {
                 assertTrue("JCEPlus InvalidKeySpeccException = " + ikse.getMessage(), false);
             }
         } else {
-            RSAPrivateKeySpec rsaPrivateSpec = (RSAPrivateKeySpec) rsaKeyFactory
+            RSAPrivateKeySpec rsaPrivateSpec = rsaKeyFactory
                     .getKeySpec(rsaKeyPair.getPrivate(), RSAPrivateKeySpec.class);
             RSAPrivateKey rsaPriv = (RSAPrivateKey) rsaKeyFactory.generatePrivate(rsaPrivateSpec);
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInterop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -310,7 +310,7 @@ public class BaseTestRSAKeyInterop extends BaseTestInterop {
 
         KeyPair rsaKeyPairJCE = generateKeyPair(rsaKeyPairGenJCE, size);
 
-        RSAPublicKeySpec rsaPubSpecJCE = (RSAPublicKeySpec) rsaKeyFactoryJCE
+        RSAPublicKeySpec rsaPubSpecJCE = rsaKeyFactoryJCE
                 .getKeySpec(rsaKeyPairJCE.getPublic(), RSAPublicKeySpec.class);
         RSAPublicKey rsaPubJCE = (RSAPublicKey) rsaKeyFactoryJCE.generatePublic(rsaPubSpecJCE);
 
@@ -319,7 +319,7 @@ public class BaseTestRSAKeyInterop extends BaseTestInterop {
         }
 
         if (rsaKeyPairJCE.getPrivate() instanceof RSAPrivateCrtKey) {
-            RSAPrivateCrtKeySpec rsaPrivateCrtSpecJCE = (RSAPrivateCrtKeySpec) rsaKeyFactoryJCE
+            RSAPrivateCrtKeySpec rsaPrivateCrtSpecJCE = rsaKeyFactoryJCE
                     .getKeySpec(rsaKeyPairJCE.getPrivate(), RSAPrivateCrtKeySpec.class);
             RSAPrivateCrtKey rsaPrivCrtJCE = (RSAPrivateCrtKey) rsaKeyFactoryJCE
                     .generatePrivate(rsaPrivateCrtSpecJCE);
@@ -328,7 +328,7 @@ public class BaseTestRSAKeyInterop extends BaseTestInterop {
                 fail("RSA private CRT key does not match generated private key");
             }
 
-            RSAPrivateKeySpec rsaPrivateSpecJCE = (RSAPrivateKeySpec) rsaKeyFactoryJCE
+            RSAPrivateKeySpec rsaPrivateSpecJCE = rsaKeyFactoryJCE
                     .getKeySpec(rsaPrivCrtJCE, RSAPrivateKeySpec.class);
             try {
                 rsaKeyFactoryJCE.generatePrivate(rsaPrivateSpecJCE);
@@ -336,7 +336,7 @@ public class BaseTestRSAKeyInterop extends BaseTestInterop {
                 assertTrue("JCEPlus InvalidKeySpeccException = " + ikse.getMessage(), false);
             }
         } else {
-            RSAPrivateKeySpec rsaPrivateSpecJCE = (RSAPrivateKeySpec) rsaKeyFactoryJCE
+            RSAPrivateKeySpec rsaPrivateSpecJCE = rsaKeyFactoryJCE
                     .getKeySpec(rsaKeyPairJCE.getPrivate(), RSAPrivateKeySpec.class);
             RSAPrivateKey rsaPrivJCE = (RSAPrivateKey) rsaKeyFactoryJCE
                     .generatePrivate(rsaPrivateSpecJCE);
@@ -351,7 +351,7 @@ public class BaseTestRSAKeyInterop extends BaseTestInterop {
 
         KeyPair rsaKeyPairPlus = generateKeyPair(rsaKeyPairGenPlus, size);
 
-        RSAPublicKeySpec rsaPubSpecPlus = (RSAPublicKeySpec) rsaKeyFactoryPlus
+        RSAPublicKeySpec rsaPubSpecPlus = rsaKeyFactoryPlus
                 .getKeySpec(rsaKeyPairPlus.getPublic(), RSAPublicKeySpec.class);
         RSAPublicKey rsaPubPlus = (RSAPublicKey) rsaKeyFactoryPlus.generatePublic(rsaPubSpecPlus);
 
@@ -360,7 +360,7 @@ public class BaseTestRSAKeyInterop extends BaseTestInterop {
         }
 
         if (rsaKeyPairPlus.getPrivate() instanceof RSAPrivateCrtKey) {
-            RSAPrivateCrtKeySpec rsaPrivateCrtSpecPlus = (RSAPrivateCrtKeySpec) rsaKeyFactoryPlus
+            RSAPrivateCrtKeySpec rsaPrivateCrtSpecPlus = rsaKeyFactoryPlus
                     .getKeySpec(rsaKeyPairPlus.getPrivate(), RSAPrivateCrtKeySpec.class);
             RSAPrivateCrtKey rsaPrivCrtPlus = (RSAPrivateCrtKey) rsaKeyFactoryPlus
                     .generatePrivate(rsaPrivateCrtSpecPlus);
@@ -370,7 +370,7 @@ public class BaseTestRSAKeyInterop extends BaseTestInterop {
                 fail("RSA private CRT key does not match generated private key");
             }
 
-            RSAPrivateKeySpec rsaPrivateSpecPlus = (RSAPrivateKeySpec) rsaKeyFactoryPlus
+            RSAPrivateKeySpec rsaPrivateSpecPlus = rsaKeyFactoryPlus
                     .getKeySpec(rsaKeyPairPlus.getPrivate(), RSAPrivateKeySpec.class);
             try {
 
@@ -380,7 +380,7 @@ public class BaseTestRSAKeyInterop extends BaseTestInterop {
                 assertTrue("JCEPlus InvalidKeySpeccException = " + ikse.getMessage(), false);
             }
         } else {
-            RSAPrivateKeySpec rsaPrivateSpecPlus = (RSAPrivateKeySpec) rsaKeyFactoryPlus
+            RSAPrivateKeySpec rsaPrivateSpecPlus = rsaKeyFactoryPlus
                     .getKeySpec(rsaKeyPairPlus.getPrivate(), RSAPrivateKeySpec.class);
             RSAPrivateKey rsaPrivPlus = (RSAPrivateKey) rsaKeyFactoryPlus
                     .generatePrivate(rsaPrivateSpecPlus);

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInteropBC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -315,7 +315,7 @@ public class BaseTestRSAKeyInteropBC extends BaseTestInterop {
 
         KeyPair rsaKeyPairBC = generateKeyPair(rsaKeyPairGenBC, size);
 
-        RSAPublicKeySpec rsaPubSpecBC = (RSAPublicKeySpec) rsaKeyFactoryBC
+        RSAPublicKeySpec rsaPubSpecBC = rsaKeyFactoryBC
                 .getKeySpec(rsaKeyPairBC.getPublic(), RSAPublicKeySpec.class);
         RSAPublicKey rsaPubBC = (RSAPublicKey) rsaKeyFactoryBC.generatePublic(rsaPubSpecBC);
 
@@ -324,7 +324,7 @@ public class BaseTestRSAKeyInteropBC extends BaseTestInterop {
         }
 
         if (rsaKeyPairBC.getPrivate() instanceof RSAPrivateCrtKey) {
-            RSAPrivateCrtKeySpec rsaPrivateCrtSpecBC = (RSAPrivateCrtKeySpec) rsaKeyFactoryBC
+            RSAPrivateCrtKeySpec rsaPrivateCrtSpecBC = rsaKeyFactoryBC
                     .getKeySpec(rsaKeyPairBC.getPrivate(), RSAPrivateCrtKeySpec.class);
             RSAPrivateCrtKey rsaPrivCrtBC = (RSAPrivateCrtKey) rsaKeyFactoryBC
                     .generatePrivate(rsaPrivateCrtSpecBC);
@@ -333,7 +333,7 @@ public class BaseTestRSAKeyInteropBC extends BaseTestInterop {
                 fail("RSA private CRT key does not match generated private key");
             }
 
-            RSAPrivateKeySpec rsaPrivateSpecBC = (RSAPrivateKeySpec) rsaKeyFactoryBC
+            RSAPrivateKeySpec rsaPrivateSpecBC = rsaKeyFactoryBC
                     .getKeySpec(rsaPrivCrtBC, RSAPrivateKeySpec.class);
             try {
                 rsaKeyFactoryBC.generatePrivate(rsaPrivateSpecBC);
@@ -341,7 +341,7 @@ public class BaseTestRSAKeyInteropBC extends BaseTestInterop {
                 assertTrue("BCPlus InvalidKeySpeccException = " + ikse.getMessage(), false);
             }
         } else {
-            RSAPrivateKeySpec rsaPrivateSpecBC = (RSAPrivateKeySpec) rsaKeyFactoryBC
+            RSAPrivateKeySpec rsaPrivateSpecBC = rsaKeyFactoryBC
                     .getKeySpec(rsaKeyPairBC.getPrivate(), RSAPrivateKeySpec.class);
             RSAPrivateKey rsaPrivBC = (RSAPrivateKey) rsaKeyFactoryBC
                     .generatePrivate(rsaPrivateSpecBC);
@@ -356,7 +356,7 @@ public class BaseTestRSAKeyInteropBC extends BaseTestInterop {
 
         KeyPair rsaKeyPairPlus = generateKeyPair(rsaKeyPairGenPlus, size);
 
-        RSAPublicKeySpec rsaPubSpecPlus = (RSAPublicKeySpec) rsaKeyFactoryPlus
+        RSAPublicKeySpec rsaPubSpecPlus = rsaKeyFactoryPlus
                 .getKeySpec(rsaKeyPairPlus.getPublic(), RSAPublicKeySpec.class);
         RSAPublicKey rsaPubPlus = (RSAPublicKey) rsaKeyFactoryPlus.generatePublic(rsaPubSpecPlus);
 
@@ -365,7 +365,7 @@ public class BaseTestRSAKeyInteropBC extends BaseTestInterop {
         }
 
         if (rsaKeyPairPlus.getPrivate() instanceof RSAPrivateCrtKey) {
-            RSAPrivateCrtKeySpec rsaPrivateCrtSpecPlus = (RSAPrivateCrtKeySpec) rsaKeyFactoryPlus
+            RSAPrivateCrtKeySpec rsaPrivateCrtSpecPlus = rsaKeyFactoryPlus
                     .getKeySpec(rsaKeyPairPlus.getPrivate(), RSAPrivateCrtKeySpec.class);
             RSAPrivateCrtKey rsaPrivCrtPlus = (RSAPrivateCrtKey) rsaKeyFactoryPlus
                     .generatePrivate(rsaPrivateCrtSpecPlus);
@@ -375,7 +375,7 @@ public class BaseTestRSAKeyInteropBC extends BaseTestInterop {
                 fail("RSA private CRT key does not match generated private key");
             }
 
-            RSAPrivateKeySpec rsaPrivateSpecPlus = (RSAPrivateKeySpec) rsaKeyFactoryPlus
+            RSAPrivateKeySpec rsaPrivateSpecPlus = rsaKeyFactoryPlus
                     .getKeySpec(rsaKeyPairPlus.getPrivate(), RSAPrivateKeySpec.class);
             try {
                 rsaKeyFactoryPlus.generatePrivate(rsaPrivateSpecPlus);
@@ -384,7 +384,7 @@ public class BaseTestRSAKeyInteropBC extends BaseTestInterop {
                 assertTrue("BCPlus InvalidKeySpeccException = " + ikse.getMessage(), false);
             }
         } else {
-            RSAPrivateKeySpec rsaPrivateSpecPlus = (RSAPrivateKeySpec) rsaKeyFactoryPlus
+            RSAPrivateKeySpec rsaPrivateSpecPlus = rsaKeyFactoryPlus
                     .getKeySpec(rsaKeyPairPlus.getPrivate(), RSAPrivateKeySpec.class);
             RSAPrivateKey rsaPrivPlus = (RSAPrivateKey) rsaKeyFactoryPlus
                     .generatePrivate(rsaPrivateSpecPlus);

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSS.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -457,7 +457,8 @@ public class BaseTestRSAPSS extends BaseTest {
 
         Signature sig = Signature.getInstance(algorithm, providerName);
         // Set salt length
-        PSSParameterSpec pss = new PSSParameterSpec(20);
+        PSSParameterSpec pss = new PSSParameterSpec("SHA-1", "MGF1",
+                MGF1ParameterSpec.SHA1, 20, 1);
         sig.setParameter(pss);
         sig.initSign(keyPair.getPrivate());
         sig.update(content);
@@ -541,7 +542,7 @@ public class BaseTestRSAPSS extends BaseTest {
             RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
 
             KeyFactory kf = KeyFactory.getInstance("RSASSA-PSS", providerName);
-            X509EncodedKeySpec x509KeySpec = (X509EncodedKeySpec) kf.getKeySpec(publicKey,
+            X509EncodedKeySpec x509KeySpec = kf.getKeySpec(publicKey,
                     X509EncodedKeySpec.class);
             byte[] encodedKey = x509KeySpec.getEncoded();
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop.java
@@ -482,7 +482,8 @@ public class BaseTestRSAPSSInterop extends BaseTestInterop {
             algParams.getParameterSpec(PSSParameterSpec.class);
             //System.out.println("parameters=" + algParams.toString());
         } else if (providerA.equals("SunRsaSign")) {
-            sig.setParameter(PSSParameterSpec.DEFAULT);
+            sig.setParameter(new PSSParameterSpec("SHA-1", "MGF1",
+                    MGF1ParameterSpec.SHA1, 20, 1));
             AlgorithmParameters algParams = sig.getParameters();
             algParams.getParameterSpec(PSSParameterSpec.class);
         }
@@ -503,7 +504,8 @@ public class BaseTestRSAPSSInterop extends BaseTestInterop {
             if (pssParameterSpec != null) {
                 sig1.setParameter(pssParameterSpec);
             } else if (providerB.equalsIgnoreCase("SunRsaSign")) {
-                sig1.setParameter(PSSParameterSpec.DEFAULT);
+                sig1.setParameter(new PSSParameterSpec("SHA-1", "MGF1",
+                        MGF1ParameterSpec.SHA1, 20, 1));
                 AlgorithmParameters algParams = sig.getParameters();
                 algParams.getParameterSpec(PSSParameterSpec.class);
             }
@@ -552,7 +554,8 @@ public class BaseTestRSAPSSInterop extends BaseTestInterop {
             if (pssParameterSpec != null) {
                 sigB.setParameter(pssParameterSpec);
             } else {
-                sigB.setParameter(PSSParameterSpec.DEFAULT);
+                sigB.setParameter(new PSSParameterSpec("SHA-1", "MGF1",
+                        MGF1ParameterSpec.SHA1, 20, 1));
             }
 
         }
@@ -618,7 +621,8 @@ public class BaseTestRSAPSSInterop extends BaseTestInterop {
         // Generate Signature
         PSSParameterSpec pssParameterSpec = null;
         if (saltSize != -1) {
-            pssParameterSpec = new PSSParameterSpec(saltSize);
+            pssParameterSpec = new PSSParameterSpec("SHA-1", "MGF1",
+                    MGF1ParameterSpec.SHA1, saltSize, 1);
         }
 
 
@@ -734,7 +738,8 @@ public class BaseTestRSAPSSInterop extends BaseTestInterop {
 
         // Generate Signature
         if (saltsize != -1) {
-            pssParameterSpec = new PSSParameterSpec(saltsize);
+            pssParameterSpec = new PSSParameterSpec("SHA-1", "MGF1",
+                    MGF1ParameterSpec.SHA1, saltsize, 1);
         }
 
         // Signature sig = Signature.getInstance(algorithm, JCE_PROVIDER);

--- a/src/test/java/ibm/jceplus/junit/base/BaseUtils.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,8 +8,6 @@
 
 package ibm.jceplus.junit.base;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
 import java.security.Provider;
 
 abstract public class BaseUtils {
@@ -56,55 +54,6 @@ abstract public class BaseUtils {
     //--------------------------------------------------------------------------
     //
     //
-    public static Provider createIBMPKCS11Provider(String configFile) throws Exception {
-        return createIBMPKCS11Provider(configFile, true);
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static Provider createIBMPKCS11Provider(String configFile, boolean addToProviderList)
-            throws Exception {
-        Class cls = Class.forName("com.ibm.crypto.pkcs11impl.provider.IBMPKCS11Impl");
-        Constructor ctor = cls.getConstructor(new Class[] {String.class});
-        Provider provider = (Provider) ctor.newInstance(configFile);
-
-        if (addToProviderList) {
-            java.security.Security.addProvider(provider);
-        }
-
-        return provider;
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static Provider createIBMPKCS11Provider(String configFile, char[] password)
-            throws Exception {
-        return createIBMPKCS11Provider(configFile, password, true);
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static Provider createIBMPKCS11Provider(String configFile, char[] password,
-            boolean addToProviderList) throws Exception {
-        Class cls = Class.forName("com.ibm.crypto.pkcs11impl.provider.IBMPKCS11Impl");
-        Provider provider = (Provider) cls.newInstance();
-        Method method = cls.getMethod("Init", new Class[] {String.class, char[].class});
-
-        method.invoke(provider, configFile, password);
-
-        if (addToProviderList) {
-            java.security.Security.addProvider(provider);
-        }
-
-        return provider;
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
     public static byte[] hexStringToByteArray(String string) {
         String s = string.trim().replaceAll(" +", ""); // remove all spaces
 
@@ -132,7 +81,7 @@ abstract public class BaseUtils {
             boolean addToProviderList) throws Exception {
         Provider provider = java.security.Security.getProvider(providerName);
         if (provider == null) {
-            provider = (Provider) Class.forName(providerClassName).newInstance();
+            provider = (Provider) Class.forName(providerClassName).getDeclaredConstructor().newInstance();
             if (addToProviderList) {
                 java.security.Security.addProvider(provider);
             }

--- a/src/test/java/ibm/jceplus/junit/base/certificateutils/CertificationRequest.java
+++ b/src/test/java/ibm/jceplus/junit/base/certificateutils/CertificationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -652,7 +652,7 @@ public final class CertificationRequest extends PKCSDerObject implements Cloneab
         if (debug != null) {
             debug.exit(Debug.TYPE_PUBLIC, className, "getSignature", this.signature.clone());
         }
-        return (byte[]) this.signature.clone();
+        return this.signature.clone();
     }
 
     /**

--- a/src/test/java/ibm/jceplus/junit/base/certificateutils/X500Signer.java
+++ b/src/test/java/ibm/jceplus/junit/base/certificateutils/X500Signer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -37,8 +37,8 @@ public class X500Signer extends Signer {
 
     static final long serialVersionUID = -7949587785526204490L;
 
-    private Signature sig;
-    private X500Name agent; // XXX should be X509CertChain
+    private transient Signature sig;
+    private transient X500Name agent; // XXX should be X509CertChain
     private AlgorithmId algid;
 
     private static Debug debug = Debug.getInstance("jceplus");
@@ -125,7 +125,7 @@ public class X500Signer extends Signer {
         this.agent = agent;
 
         try {
-            this.algid = AlgorithmId.getAlgorithmId(sig.getAlgorithm());
+            this.algid = AlgorithmId.get(sig.getAlgorithm());
 
         } catch (NoSuchAlgorithmException e) {
             if (debug != null) {

--- a/src/test/java/ibm/jceplus/junit/base/integration/BaseTestTLS.java
+++ b/src/test/java/ibm/jceplus/junit/base/integration/BaseTestTLS.java
@@ -39,7 +39,7 @@ public class BaseTestTLS {
     public static void insertProvider(String providerName, String providerClassName, int position) throws Exception{
         Provider provider = java.security.Security.getProvider(providerName);
         if (provider == null) {
-            provider = (Provider) Class.forName(providerClassName).newInstance();
+            provider = (Provider) Class.forName(providerClassName).getDeclaredConstructor().newInstance();
         }
         java.security.Security.insertProviderAt(provider, position);
     }

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressAES.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressAES.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -195,8 +195,7 @@ public class BaseTestMemStressAES extends BaseTestCipher {
         try {
             java_provider = java.security.Security.getProvider("OpenJCEPlus");
             if (java_provider == null) {
-                java_provider = (java.security.Provider) Class
-                        .forName("com.ibm.crypto.plus.provider.OpenJCEPlus").newInstance();
+                java_provider = new com.ibm.crypto.plus.provider.OpenJCEPlus();
                 java.security.Security.insertProviderAt(java_provider, 1);
             }
 

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -216,7 +216,7 @@ public class BaseTestMemStressDH extends BaseTest {
                 providerName);
         algParamGen.init(size);
         AlgorithmParameters algParams = algParamGen.generateParameters();
-        DHParameterSpec dhps = (DHParameterSpec) algParams.getParameterSpec(DHParameterSpec.class);
+        DHParameterSpec dhps = algParams.getParameterSpec(DHParameterSpec.class);
         return dhps;
 
     }

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDSAKeyPair.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDSAKeyPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -137,7 +137,7 @@ public class BaseTestMemStressDSAKeyPair extends BaseTest {
 
         KeyPair dsaKeyPair = generateKeyPair(size);
 
-        DSAPublicKeySpec dsaPubSpec = (DSAPublicKeySpec) dsaKeyFactory
+        DSAPublicKeySpec dsaPubSpec = dsaKeyFactory
                 .getKeySpec(dsaKeyPair.getPublic(), DSAPublicKeySpec.class);
         DSAPublicKey dsaPub = (DSAPublicKey) dsaKeyFactory.generatePublic(dsaPubSpec);
 
@@ -145,7 +145,7 @@ public class BaseTestMemStressDSAKeyPair extends BaseTest {
             fail("DSA public key does not match generated public key");
         }
 
-        DSAPrivateKeySpec dsaPrivateSpec = (DSAPrivateKeySpec) dsaKeyFactory
+        DSAPrivateKeySpec dsaPrivateSpec = dsaKeyFactory
                 .getKeySpec(dsaKeyPair.getPrivate(), DSAPrivateKeySpec.class);
         DSAPrivateKey dsaPriv = (DSAPrivateKey) dsaKeyFactory.generatePrivate(dsaPrivateSpec);
 

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressRSAPSS2.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressRSAPSS2.java
@@ -11,6 +11,7 @@ package ibm.jceplus.junit.base.memstress;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.Signature;
+import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
 import ibm.jceplus.junit.base.BaseTest;
 
@@ -91,7 +92,8 @@ public class BaseTestMemStressRSAPSS2 extends BaseTest {
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA", providerName);
         keyGen.initialize(this.keysize, new java.security.SecureRandom());
         KeyPair keyPair = keyGen.genKeyPair();
-        PSSParameterSpec pssparamSpec = PSSParameterSpec.DEFAULT;
+        PSSParameterSpec pssparamSpec = new PSSParameterSpec("SHA-1", "MGF1",
+                    MGF1ParameterSpec.SHA1, 20, 1);
         try {
             for (int i = 1; i < numTimes; i++) {
                 dotestSignature(content3, IBM_ALG, keyPair, pssparamSpec);


### PR DESCRIPTION
Warnings produced during compilation of both source code and tests are addressed. Those warnings pertain to:
- Redundant casts
- Deprecated APIs that are substituted with the updated alternatives
- Incorrect visibility of classes and methods
- Use of internal proprietary APIs

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/108

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>