### PR TITLE
Update the isAssignableFrom checks

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/AESKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKeyFactory.java
@@ -84,7 +84,7 @@ public final class AESKeyFactory extends SecretKeyFactorySpi {
                 && (key.getFormat().equalsIgnoreCase("RAW"))) {
 
             // Check if requested key spec is amongst the valid ones
-            if (SecretKeySpec.class.isAssignableFrom(keySpec)) {
+            if (keySpec.isAssignableFrom(SecretKeySpec.class)) {
                 return new SecretKeySpec(key.getEncoded(), key.getAlgorithm());
             } else {
                 throw new InvalidKeySpecException("Inappropriate key specification");

--- a/src/main/java/com/ibm/crypto/plus/provider/AESParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESParameters.java
@@ -79,7 +79,7 @@ public final class AESParameters extends AlgorithmParametersSpi {
             throws InvalidParameterSpecException {
         try {
             Class<?> ivParamSpec = Class.forName("javax.crypto.spec.IvParameterSpec");
-            if (ivParamSpec.isAssignableFrom(paramSpec)) {
+            if (paramSpec.isAssignableFrom(ivParamSpec)) {
                 return paramSpec.cast(new IvParameterSpec(this.iv));
             } else {
                 throw new InvalidParameterSpecException("Inappropriate parameter specification");

--- a/src/main/java/com/ibm/crypto/plus/provider/CCMParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/CCMParameters.java
@@ -146,7 +146,7 @@ public final class CCMParameters extends AlgorithmParametersSpi
     @Override
     protected <T extends AlgorithmParameterSpec> T engineGetParameterSpec(Class<T> paramSpec)
             throws InvalidParameterSpecException {
-        if (CCMParameterSpec.class.isAssignableFrom(paramSpec)) {
+        if (paramSpec.isAssignableFrom(CCMParameterSpec.class)) {
             if (initialized == true) {
                 CCMParameterSpec tmpSpec = new CCMParameterSpec(this.tagLen, this.iv);
                 return paramSpec.cast(tmpSpec);

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyFactory.java
@@ -84,7 +84,7 @@ public final class ChaCha20KeyFactory extends SecretKeyFactorySpi {
                 && (key.getFormat().equalsIgnoreCase("RAW"))) {
 
             // Check if requested key spec is amongst the valid ones
-            if (SecretKeySpec.class.isAssignableFrom(keySpec)) {
+            if (keySpec.isAssignableFrom(SecretKeySpec.class)) {
                 return new SecretKeySpec(key.getEncoded(), key.getAlgorithm());
             } else {
                 throw new InvalidKeySpecException("Inappropriate key specification");

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Parameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Parameters.java
@@ -63,7 +63,7 @@ public final class ChaCha20Parameters extends AlgorithmParametersSpi implements 
             throws InvalidParameterSpecException {
         try {
             Class<?> chaCha20ParamSpec = Class.forName("javax.crypto.spec.ChaCha20ParameterSpec");
-            if (chaCha20ParamSpec.isAssignableFrom(paramSpec)) {
+            if (paramSpec.isAssignableFrom(chaCha20ParamSpec)) {
                 return paramSpec.cast(new ChaCha20ParameterSpec(this.nonce, this.counter));
             } else {
                 throw new InvalidParameterSpecException("Inappropriate parameter specification");

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Poly1305Parameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Poly1305Parameters.java
@@ -73,7 +73,7 @@ public final class ChaCha20Poly1305Parameters extends AlgorithmParametersSpi
             throws InvalidParameterSpecException {
         try {
             Class<?> ivParamSpec = Class.forName("javax.crypto.spec.IvParameterSpec");
-            if (ivParamSpec.isAssignableFrom(paramSpec)) {
+            if (paramSpec.isAssignableFrom(ivParamSpec)) {
                 return paramSpec.cast(new IvParameterSpec(this.nonce));
             } else {
                 throw new InvalidParameterSpecException("Inappropriate parameter specification");

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeKeyFactory.java
@@ -90,7 +90,7 @@ public final class DESedeKeyFactory extends SecretKeyFactorySpi {
                     && (key.getFormat().equalsIgnoreCase("RAW"))) {
 
                 // Check if requested key spec is amongst the valid ones
-                if (DESedeKeySpec.class.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(DESedeKeySpec.class)) {
                     return new DESedeKeySpec(key.getEncoded());
 
                 } else {

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeParameters.java
@@ -70,7 +70,7 @@ public final class DESedeParameters extends AlgorithmParametersSpi {
             throws InvalidParameterSpecException {
         try {
             Class<?> ivParamSpec = Class.forName("javax.crypto.spec.IvParameterSpec");
-            if (ivParamSpec.isAssignableFrom(paramSpec)) {
+            if (paramSpec.isAssignableFrom(ivParamSpec)) {
                 return paramSpec.cast(new IvParameterSpec(this.iv));
             } else {
                 throw new InvalidParameterSpecException("Inappropriate parameter specification");

--- a/src/main/java/com/ibm/crypto/plus/provider/DHKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHKeyFactory.java
@@ -139,13 +139,13 @@ public final class DHKeyFactory extends KeyFactorySpi {
                 Class<?> dhPubKeySpec = Class.forName("javax.crypto.spec.DHPublicKeySpec");
                 Class<?> x509KeySpec = Class.forName("java.security.spec.X509EncodedKeySpec");
 
-                if (dhPubKeySpec.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(dhPubKeySpec)) {
                     javax.crypto.interfaces.DHPublicKey dhPubKey = (javax.crypto.interfaces.DHPublicKey) key;
                     params = dhPubKey.getParams();
                     return keySpec.cast(
                             new DHPublicKeySpec(dhPubKey.getY(), params.getP(), params.getG()));
 
-                } else if (x509KeySpec.isAssignableFrom(keySpec)) {
+                } else if (keySpec.isAssignableFrom(x509KeySpec)) {
                     return keySpec.cast(new X509EncodedKeySpec(key.getEncoded()));
 
                 } else {
@@ -158,13 +158,13 @@ public final class DHKeyFactory extends KeyFactorySpi {
                 Class<?> dhPrivKeySpec = Class.forName("javax.crypto.spec.DHPrivateKeySpec");
                 Class<?> pkcs8KeySpec = Class.forName("java.security.spec.PKCS8EncodedKeySpec");
 
-                if (dhPrivKeySpec.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(dhPrivKeySpec)) {
                     javax.crypto.interfaces.DHPrivateKey dhPrivKey = (javax.crypto.interfaces.DHPrivateKey) key;
                     params = dhPrivKey.getParams();
                     return keySpec.cast(
                             new DHPrivateKeySpec(dhPrivKey.getX(), params.getP(), params.getG()));
 
-                } else if (pkcs8KeySpec.isAssignableFrom(keySpec)) {
+                } else if (keySpec.isAssignableFrom(pkcs8KeySpec)) {
                     return keySpec.cast(new PKCS8EncodedKeySpec(key.getEncoded()));
 
                 } else {

--- a/src/main/java/com/ibm/crypto/plus/provider/DHParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHParameters.java
@@ -90,7 +90,7 @@ public final class DHParameters extends AlgorithmParametersSpi implements java.i
             throws InvalidParameterSpecException {
         try {
             Class<?> dhParamSpec = Class.forName("javax.crypto.spec.DHParameterSpec");
-            if (dhParamSpec.isAssignableFrom(paramSpec)) {
+            if (paramSpec.isAssignableFrom(dhParamSpec)) {
                 return paramSpec.cast(new DHParameterSpec(this.p, this.g, this.l));
             } else {
                 throw new InvalidParameterSpecException("Inappropriate parameter Specification");

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAKeyFactory.java
@@ -121,13 +121,13 @@ public final class DSAKeyFactory extends KeyFactorySpi {
                 Class<?> dsaPubKeySpec = Class.forName("java.security.spec.DSAPublicKeySpec");
                 Class<?> x509KeySpec = Class.forName("java.security.spec.X509EncodedKeySpec");
 
-                if (dsaPubKeySpec.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(dsaPubKeySpec)) {
                     java.security.interfaces.DSAPublicKey dsaPubKey = (java.security.interfaces.DSAPublicKey) key;
                     params = dsaPubKey.getParams();
                     return keySpec.cast(new DSAPublicKeySpec(dsaPubKey.getY(), params.getP(),
                             params.getQ(), params.getG()));
 
-                } else if (x509KeySpec.isAssignableFrom(keySpec)) {
+                } else if (keySpec.isAssignableFrom(x509KeySpec)) {
                     return keySpec.cast(new X509EncodedKeySpec(key.getEncoded()));
 
                 } else {
@@ -140,13 +140,13 @@ public final class DSAKeyFactory extends KeyFactorySpi {
                 Class<?> dsaPrivKeySpec = Class.forName("java.security.spec.DSAPrivateKeySpec");
                 Class<?> pkcs8KeySpec = Class.forName("java.security.spec.PKCS8EncodedKeySpec");
 
-                if (dsaPrivKeySpec.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(dsaPrivKeySpec)) {
                     java.security.interfaces.DSAPrivateKey dsaPrivKey = (java.security.interfaces.DSAPrivateKey) key;
                     params = dsaPrivKey.getParams();
                     return keySpec.cast(new DSAPrivateKeySpec(dsaPrivKey.getX(), params.getP(),
                             params.getQ(), params.getG()));
 
-                } else if (pkcs8KeySpec.isAssignableFrom(keySpec)) {
+                } else if (keySpec.isAssignableFrom(pkcs8KeySpec)) {
                     return keySpec.cast(new PKCS8EncodedKeySpec(key.getEncoded()));
 
                 } else {

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAParameters.java
@@ -95,7 +95,7 @@ public final class DSAParameters extends AlgorithmParametersSpi {
             throws InvalidParameterSpecException {
         try {
             Class<?> dsaParamSpec = Class.forName("java.security.spec.DSAParameterSpec");
-            if (dsaParamSpec.isAssignableFrom(paramSpec)) {
+            if (paramSpec.isAssignableFrom(dsaParamSpec)) {
                 return paramSpec.cast(new DSAParameterSpec(this.p, this.q, this.g));
             } else {
                 throw new InvalidParameterSpecException("Inappropriate parameter Specification");

--- a/src/main/java/com/ibm/crypto/plus/provider/ECKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECKeyFactory.java
@@ -99,12 +99,12 @@ public final class ECKeyFactory extends KeyFactorySpi {
                 Class<?> ecPubKeySpec = Class.forName("java.security.spec.ECPublicKeySpec");
                 Class<?> x509KeySpec = Class.forName("java.security.spec.X509EncodedKeySpec");
 
-                if (ecPubKeySpec.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(ecPubKeySpec)) {
                     java.security.interfaces.ECPublicKey ecPubKey = (java.security.interfaces.ECPublicKey) key;
 
                     return keySpec.cast(new ECPublicKeySpec(ecPubKey.getW(), ecPubKey.getParams()));
 
-                } else if (x509KeySpec.isAssignableFrom(keySpec)) {
+                } else if (keySpec.isAssignableFrom(x509KeySpec)) {
                     return keySpec.cast(new X509EncodedKeySpec(key.getEncoded()));
 
                 } else {
@@ -117,12 +117,12 @@ public final class ECKeyFactory extends KeyFactorySpi {
                 Class<?> ecPrivKeySpec = Class.forName("java.security.spec.ECPrivateKeySpec");
                 Class<?> pkcs8KeySpec = Class.forName("java.security.spec.PKCS8EncodedKeySpec");
 
-                if (ecPrivKeySpec.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(ecPrivKeySpec)) {
                     java.security.interfaces.ECPrivateKey ecPrivKey = (java.security.interfaces.ECPrivateKey) key;
                     return keySpec
                             .cast(new ECPrivateKeySpec(ecPrivKey.getS(), ecPrivKey.getParams()));
 
-                } else if (pkcs8KeySpec.isAssignableFrom(keySpec)) {
+                } else if (keySpec.isAssignableFrom(pkcs8KeySpec)) {
                     return keySpec.cast(new PKCS8EncodedKeySpec(key.getEncoded()));
 
                 } else {

--- a/src/main/java/com/ibm/crypto/plus/provider/GCMParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/GCMParameters.java
@@ -100,7 +100,7 @@ public final class GCMParameters extends AlgorithmParametersSpi
     @Override
     protected <T extends AlgorithmParameterSpec> T engineGetParameterSpec(Class<T> paramSpec)
             throws InvalidParameterSpecException {
-        if (GCMParameterSpec.class.isAssignableFrom(paramSpec)) {
+        if (paramSpec.isAssignableFrom(GCMParameterSpec.class)) {
             if (authenticationData != null) {
                 // create one with authenticationData
                 if (tagLen != -1) {

--- a/src/main/java/com/ibm/crypto/plus/provider/OAEPParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OAEPParameters.java
@@ -150,7 +150,7 @@ public final class OAEPParameters extends AlgorithmParametersSpi {
 
     protected <T extends AlgorithmParameterSpec> T engineGetParameterSpec(Class<T> paramSpec)
             throws InvalidParameterSpecException {
-        if (OAEPParameterSpec.class.isAssignableFrom(paramSpec)) {
+        if (paramSpec.isAssignableFrom(OAEPParameterSpec.class)) {
             return paramSpec.cast(
                     new OAEPParameterSpec(mdName, "MGF1", mgfSpec, new PSource.PSpecified(p)));
         } else {

--- a/src/main/java/com/ibm/crypto/plus/provider/PSSParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PSSParameters.java
@@ -721,7 +721,7 @@ public final class PSSParameters extends AlgorithmParametersSpi {
      */
     protected <T extends AlgorithmParameterSpec> T engineGetParameterSpec(Class<T> paramSpecClass)
             throws InvalidParameterSpecException {
-        if (java.security.spec.PSSParameterSpec.class.isAssignableFrom(paramSpecClass)) {
+        if (paramSpecClass.isAssignableFrom(java.security.spec.PSSParameterSpec.class)) {
             return paramSpecClass.cast(new PSSParameterSpec(this.hashAlgorithm.getName(),
                                                             this.maskGenAlgorithm.getName(),
                                                             this.mgfParameterSpec,

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAKeyFactory.java
@@ -257,11 +257,11 @@ public class RSAKeyFactory extends KeyFactorySpi {
                 // Determine valid key specs
                 Class<?> rsaPubKeySpec = Class.forName("java.security.spec.RSAPublicKeySpec");
                 Class<?> x509KeySpec = Class.forName("java.security.spec.X509EncodedKeySpec");
-                if (rsaPubKeySpec.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(rsaPubKeySpec)) {
                     java.security.interfaces.RSAPublicKey rsaPubKey = (java.security.interfaces.RSAPublicKey) key;
                     return keySpec.cast(new RSAPublicKeySpec(rsaPubKey.getModulus(),
                             rsaPubKey.getPublicExponent(), rsaPubKey.getParams()));
-                } else if (x509KeySpec.isAssignableFrom(keySpec)) {
+                } else if (keySpec.isAssignableFrom(x509KeySpec)) {
                     return keySpec.cast(new X509EncodedKeySpec(key.getEncoded()));
                 } else {
                     throw new InvalidKeySpecException("Inappropriate key specification");
@@ -278,9 +278,9 @@ public class RSAKeyFactory extends KeyFactorySpi {
                             rsaPrivCrtKey.getPrimeExponentP(), rsaPrivCrtKey.getPrimeExponentQ(),
                             rsaPrivCrtKey.getCrtCoefficient(), rsaPrivCrtKey.getParams()));
 
-                } else if (pkcs8KeySpec.isAssignableFrom(keySpec)) {
+                } else if (keySpec.isAssignableFrom(pkcs8KeySpec)) {
                     return keySpec.cast(new PKCS8EncodedKeySpec(key.getEncoded()));
-                } else if (rsaPrivKeySpec.isAssignableFrom(keySpec)) {
+                } else if (keySpec.isAssignableFrom(rsaPrivKeySpec)) {
                     java.security.interfaces.RSAPrivateKey rsaPrivKey = (java.security.interfaces.RSAPrivateKey) key;
                     return keySpec.cast(new RSAPrivateKeySpec(rsaPrivKey.getModulus(),
                             rsaPrivKey.getPrivateExponent(), rsaPrivKey.getParams()));
@@ -291,11 +291,11 @@ public class RSAKeyFactory extends KeyFactorySpi {
                 // Determine valid key specs
                 Class<?> rsaPrivKeySpec = Class.forName("java.security.spec.RSAPrivateKeySpec");
                 Class<?> pkcs8KeySpec = Class.forName("java.security.spec.PKCS8EncodedKeySpec");
-                if (rsaPrivKeySpec.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(rsaPrivKeySpec)) {
                     java.security.interfaces.RSAPrivateKey rsaPrivKey = (java.security.interfaces.RSAPrivateKey) key;
                     return keySpec.cast(new RSAPrivateKeySpec(rsaPrivKey.getModulus(),
                             rsaPrivKey.getPrivateExponent(), rsaPrivKey.getParams()));
-                } else if (pkcs8KeySpec.isAssignableFrom(keySpec)) {
+                } else if (keySpec.isAssignableFrom(pkcs8KeySpec)) {
                     return keySpec.cast(new PKCS8EncodedKeySpec(key.getEncoded()));
                 } else {
                     throw new InvalidKeySpecException("Inappropriate key specification");

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyFactory.java
@@ -126,7 +126,7 @@ class XDHKeyFactory extends KeyFactorySpi {
                 Class<?> xecPubKeySpec = Class.forName("java.security.spec.XECPublicKeySpec");
                 Class<?> x509KeySpec = Class.forName("java.security.spec.X509EncodedKeySpec");
 
-                if (xecPubKeySpec.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(xecPubKeySpec)) {
                     XECPublicKey xecPubKey = (XECPublicKey) key;
                     params = xecPubKey.getParams();
 
@@ -138,7 +138,7 @@ class XDHKeyFactory extends KeyFactorySpi {
 
                     BigInteger u = xecPubKey.getU();
                     return keySpec.cast(new XECPublicKeySpec(params, u));
-                } else if (x509KeySpec.isAssignableFrom(keySpec))
+                } else if (keySpec.isAssignableFrom(x509KeySpec))
                     return keySpec.cast(new X509EncodedKeySpec(key.getEncoded()));
                 else
                     throw new InvalidKeySpecException("Inappropriate key specification");
@@ -149,7 +149,7 @@ class XDHKeyFactory extends KeyFactorySpi {
                 Class<?> xecPrivKeySpec = Class.forName("java.security.spec.XECPrivateKeySpec");
                 Class<?> pkcs8KeySpec = Class.forName("java.security.spec.PKCS8EncodedKeySpec");
 
-                if (xecPrivKeySpec.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(xecPrivKeySpec)) {
                     XECPrivateKey xecPrivKey = (XECPrivateKey) key;
                     params = xecPrivKey.getParams();
 
@@ -161,7 +161,7 @@ class XDHKeyFactory extends KeyFactorySpi {
 
                     Optional<byte[]> scalar = xecPrivKey.getScalar();
                     return keySpec.cast(new XECPrivateKeySpec(params, scalar.get()));
-                } else if (pkcs8KeySpec.isAssignableFrom(keySpec))
+                } else if (keySpec.isAssignableFrom(pkcs8KeySpec))
                     return keySpec.cast(new PKCS8EncodedKeySpec(key.getEncoded()));
                 else
                     throw new InvalidKeySpecException("Inappropriate key specification");

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestIsAssignableFromOrder.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestIsAssignableFromOrder.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright IBM Corp. 2024
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution.
+ */
+package ibm.jceplus.junit.base;
+
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.DESedeKeySpec;
+import javax.crypto.spec.DHParameterSpec;
+import javax.crypto.spec.DHPrivateKeySpec;
+import javax.crypto.spec.DHPublicKeySpec;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.OAEPParameterSpec;
+import javax.crypto.spec.PSource;
+import javax.crypto.spec.SecretKeySpec;
+
+import ibm.security.internal.spec.CCMParameterSpec;
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+import java.math.BigInteger;
+import java.security.AlgorithmParameters;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.DSAParameterSpec;
+import java.security.spec.DSAPrivateKeySpec;
+import java.security.spec.DSAPublicKeySpec;
+import java.security.spec.ECPrivateKeySpec;
+import java.security.spec.ECPublicKeySpec;
+import java.security.spec.EncodedKeySpec;
+import java.security.spec.KeySpec;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.PSSParameterSpec;
+import java.security.spec.RSAPrivateKeySpec;
+import java.security.spec.RSAPublicKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.security.spec.XECPrivateKeySpec;
+import java.security.spec.XECPublicKeySpec;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BaseTestIsAssignableFromOrder extends BaseTest {
+
+    public static Test suite() {
+        TestSuite suite = new TestSuite(BaseTestIsAssignableFromOrder.class);
+        return suite;
+    }
+
+    public BaseTestIsAssignableFromOrder(String providerName) {
+        super(providerName);
+    }
+
+    public void testIsAssignableFromOrder() throws Exception {
+
+        // AlgorithmParameters
+        testAlgSpec("AES", new IvParameterSpec(new byte[16]));
+        testAlgSpec("CCM", new CCMParameterSpec(128, new byte[12]));
+        testAlgSpec("ChaCha20-Poly1305", new IvParameterSpec(new byte[12]));
+        testAlgSpec("DESede", new IvParameterSpec(new byte[8]));
+        testAlgSpec("DH", new DHParameterSpec(BigInteger.ONE, BigInteger.TWO));
+        testAlgSpec("DSA", new DSAParameterSpec(BigInteger.ONE, BigInteger.TWO, BigInteger.ONE));
+        testAlgSpec("GCM", new GCMParameterSpec(96, new byte[16]));
+        testAlgSpec("OAEP", new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA1, PSource.PSpecified.DEFAULT));
+        testAlgSpec("RSAPSS", new PSSParameterSpec("SHA256", "MGF1", MGF1ParameterSpec.SHA256, 20, 1));
+
+        // SecretKeyFactory
+        testSecretKeySpec("AES", new SecretKeySpec(new byte[16], "AES"), SecretKeySpec.class);
+        testSecretKeySpec("DESede", new SecretKeySpec(new byte[24], "DESede"), DESedeKeySpec.class);
+
+        // KeyFactory DH, DSA, EC, RSA, XDH
+        testKeySpec("DH", 1024, DHPublicKeySpec.class, DHPrivateKeySpec.class);
+        testKeySpec("DSA", 1024, DSAPublicKeySpec.class, DSAPrivateKeySpec.class);
+        testKeySpec("EC", 1024, ECPublicKeySpec.class, ECPrivateKeySpec.class);
+        testKeySpec("RSA", 1024, RSAPublicKeySpec.class, RSAPrivateKeySpec.class);
+        testKeySpec("XDH", 255, XECPublicKeySpec.class, XECPrivateKeySpec.class);
+    }
+
+    // Test Algorithm Parameters Spec
+    private void testAlgSpec(String algorithm, AlgorithmParameterSpec spec) throws Exception {
+        System.out.println("test AlgorithmParametersSpec: " + algorithm);
+
+        AlgorithmParameters ap1 = AlgorithmParameters.getInstance(algorithm, providerName);
+        ap1.init(spec);
+
+        AlgorithmParameters ap2 = AlgorithmParameters.getInstance(algorithm, providerName);
+        ap2.init(ap1.getEncoded());
+
+        List<Class<? extends AlgorithmParameterSpec>> classes = new ArrayList<>();
+        classes.add(spec.getClass());
+        classes.add(AlgorithmParameterSpec.class);
+
+        for (Class<? extends AlgorithmParameterSpec> c : classes) {
+            ap1.getParameterSpec(c);
+            ap2.getParameterSpec(c);
+        }
+    }
+
+    // Test Secret Key Spec
+    private void testSecretKeySpec(String algorithm, KeySpec spec, Class<?> clazz)
+            throws Exception {
+        System.out.println("test SecretKeySpec: " + algorithm);
+
+        SecretKeyFactory kf = SecretKeyFactory.getInstance(algorithm, providerName);
+        SecretKey key = kf.generateSecret(spec);
+
+        kf.getKeySpec(key, KeySpec.class);
+        kf.getKeySpec(key, clazz);
+    }
+
+    // Test Public and Private Key Spec
+    private void testKeySpec(String algorithm, int size, Class<? extends KeySpec> clazz1, Class<? extends KeySpec> clazz2)
+            throws Exception {
+        System.out.println("test KeySpec: " + algorithm);
+
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(algorithm, providerName);
+        kpg.initialize(size);
+        KeyPair kp = kpg.generateKeyPair();
+
+        PublicKey pubk = kp.getPublic();
+        PrivateKey prvk = kp.getPrivate();
+
+        byte[] encodedpubk = pubk.getEncoded();
+        byte[] encodedprvk = prvk.getEncoded();
+
+        EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(encodedpubk);
+        EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(encodedprvk);
+
+        KeyFactory kf = KeyFactory.getInstance(algorithm, providerName);
+        PublicKey publicKey = kf.generatePublic(publicKeySpec);
+        PrivateKey privateKey = kf.generatePrivate(privateKeySpec);
+
+        kf.getKeySpec(publicKey, KeySpec.class);
+        kf.getKeySpec(publicKey, clazz1);
+
+        kf.getKeySpec(privateKey, KeySpec.class);
+        kf.getKeySpec(privateKey, clazz2);
+    }
+}

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAll.java
@@ -48,7 +48,7 @@ import junit.framework.TestSuite;
         TestSHA3_384.class, TestSHA3_512.class, TestRSAKeyInterop.class, TestRSAKeyInteropBC.class,
         TestEdDSASignature.class, TestEdDSASignatureInterop.class, TestXDH.class,
         TestXDHInterop.class, TestXDHMultiParty.class, TestXDHKeyPairGenerator.class,
-        TestXDHKeyImport.class
+        TestXDHKeyImport.class, TestIsAssignableFromOrder.class
 
 })
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestIsAssignableFromOrder.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestIsAssignableFromOrder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright IBM Corp. 2024
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution.
+ */
+
+package ibm.jceplus.junit.openjceplus;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+public class TestIsAssignableFromOrder extends ibm.jceplus.junit.base.BaseTestIsAssignableFromOrder {
+
+    // --------------------------------------------------------------------------
+    //
+    //
+    static {
+        Utils.loadProviderTestSuite();
+    }
+
+    // --------------------------------------------------------------------------
+    //
+    //
+    public TestIsAssignableFromOrder() {
+        super(Utils.TEST_SUITE_PROVIDER_NAME);
+    }
+
+    // --------------------------------------------------------------------------
+    //
+    //
+    public static void main(String[] args) throws Exception {
+        junit.textui.TestRunner.run(suite());
+    }
+
+    // --------------------------------------------------------------------------
+    //
+    //
+    public static Test suite() {
+        TestSuite suite = new TestSuite(TestIsAssignableFromOrder.class);
+        return suite;
+    }
+}


### PR DESCRIPTION
This is a back-port PR from PR https://github.com/IBM/OpenJCEPlus/pull/153

According to https://bugs.openjdk.org/browse/JDK-8279800, isAssignableFrom means is-parent-of and you can only cast an object of a child class to that of a parent class.