### PR TITLE
Ensure AES related tests are using a deterministic provider

### DIFF
--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMBufferIV.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMBufferIV.java
@@ -26,7 +26,7 @@ public class BaseTestAESGCMBufferIV extends BaseTest {
 
     protected void setUp() throws Exception {
         keySpec = new SecretKeySpec(new byte[16], "AES");
-        cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        cipher = Cipher.getInstance("AES/GCM/NoPadding", providerName);
         plaintext = new byte[51];
     }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMCipherInputStreamExceptions.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMCipherInputStreamExceptions.java
@@ -358,18 +358,18 @@ public class BaseTestAESGCMCipherInputStreamExceptions extends BaseTest {
     }
 
     /* Generic method to create encrypted text */
-    static byte[] encryptedText(String mode, int length) throws Exception {
+    byte[] encryptedText(String mode, int length) throws Exception {
         return encryptedText(mode, new byte[length]);
     }
 
     /* Generic method to create encrypted text */
-    static byte[] encryptedText(String mode, byte[] pt) throws Exception {
+    byte[] encryptedText(String mode, byte[] pt) throws Exception {
         Cipher c;
         if (mode.compareTo("GCM") == 0) {
-            c = Cipher.getInstance("AES/GCM/NoPadding", "OpenJCEPlus");
+            c = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             c.init(Cipher.ENCRYPT_MODE, key, gcmspec);
         } else if (mode.compareTo("CBC") == 0) {
-            c = Cipher.getInstance("AES/CBC/NoPadding", "OpenJCEPlus");
+            c = Cipher.getInstance("AES/CBC/NoPadding", providerName);
             c.init(Cipher.ENCRYPT_MODE, key, iv);
         } else {
             return null;
@@ -379,19 +379,19 @@ public class BaseTestAESGCMCipherInputStreamExceptions extends BaseTest {
     }
 
     /* Generic method to get a properly setup CipherInputStream */
-    static CipherInputStream getStream(String mode, byte[] ct) throws Exception {
+    CipherInputStream getStream(String mode, byte[] ct) throws Exception {
         return getStream(mode, ct, ct.length);
     }
 
     /* Generic method to get a properly setup CipherInputStream */
-    static CipherInputStream getStream(String mode, byte[] ct, int length) throws Exception {
+    CipherInputStream getStream(String mode, byte[] ct, int length) throws Exception {
         Cipher c;
 
         if (mode.compareTo("GCM") == 0) {
-            c = Cipher.getInstance("AES/GCM/NoPadding", "OpenJCEPlus");
+            c = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             c.init(Cipher.DECRYPT_MODE, key, gcmspec);
         } else if (mode.compareTo("CBC") == 0) {
-            c = Cipher.getInstance("AES/CBC/NoPadding", "OpenJCEPlus");
+            c = Cipher.getInstance("AES/CBC/NoPadding", providerName);
             c.init(Cipher.DECRYPT_MODE, key, iv);
         } else {
             return null;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMNonExpanding.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMNonExpanding.java
@@ -31,7 +31,6 @@ import org.junit.Assume;
 public class BaseTestAESGCMNonExpanding extends BaseTest {
 
     private static final String ALGORITHM = "AES";
-    private static final String PROVIDER = "OpenJCEPlus"; //"SunJCE";
     private static final String[] MODES = {"GCM"};
     private static final String PADDING = "NoPadding";
     protected int specifiedKeySize = 128;
@@ -64,9 +63,9 @@ public class BaseTestAESGCMNonExpanding extends BaseTest {
             byte[] plainText = new byte[128];
             rdm.nextBytes(plainText);
 
-            ci = Cipher.getInstance(algo + "/" + mo + "/" + pad, PROVIDER);
+            ci = Cipher.getInstance(algo + "/" + mo + "/" + pad, providerName);
 
-            KeyGenerator kg = KeyGenerator.getInstance(algo, PROVIDER);
+            KeyGenerator kg = KeyGenerator.getInstance(algo, providerName);
             kg.init(specifiedKeySize);
             key = kg.generateKey();
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMUpdate.java
@@ -1204,7 +1204,7 @@ public class BaseTestAESGCMUpdate extends BaseTest {
 
     public void testMultipleUpdateWithoutAllocatingExternalBuffer19() throws Exception {
 
-        KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
+        KeyGenerator keyGenerator = KeyGenerator.getInstance("AES", providerName);
         keyGenerator.init(16 * 8);
 
         // Generate Key
@@ -1239,7 +1239,7 @@ public class BaseTestAESGCMUpdate extends BaseTest {
         // Get Cipher Instance
         Cipher cipher = null;
         try {
-            cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher = Cipher.getInstance("AES/GCM/NoPadding", providerName);
 
             // Create SecretKeySpec
             SecretKeySpec keySpec = new SecretKeySpec(key.getEncoded(), "AES");
@@ -1287,7 +1287,7 @@ public class BaseTestAESGCMUpdate extends BaseTest {
     public byte[] doMultipleUpdateWithoutAllocatingExternalBufferDecrypt(byte[] cipherText,
             SecretKey key, byte[] IV) throws Exception {
         // Get Cipher Instance
-        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding", providerName);
 
         // Create SecretKeySpec
         SecretKeySpec keySpec = new SecretKeySpec(key.getEncoded(), "AES");


### PR DESCRIPTION
The AES base test cases were reviewed to ensure that the tests are testing a desired provider. Currently there are a few tests missing the provider argument during algorithm instantiation. In this case algorithms tested may or may not match the expected provider used in the constructor of a test depending upon what happens to be first in the JCE provider list at the time of execution.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>
