### PR TITLE
Skip native compilation when testing bundled SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,8 @@
             </activation>
             <properties>
               <test.compilation.export.target>ALL-UNNAMED</test.compilation.export.target>
+              <skip.native.compile>true</skip.native.compile>
+              <build.native.file>None_not_really_used_here</build.native.file>
             </properties>
             <build>
               <plugins>
@@ -309,6 +311,7 @@
                     <goal>exec</goal>
                   </goals>
                   <configuration>
+                    <skip>${skip.native.compile}</skip>
                     <environmentVariables>
                       <PLATFORM>${build.platform.value}</PLATFORM>
                     </environmentVariables>


### PR DESCRIPTION
When testing against an `SDK` that already includes `OpenJCEPlus` there is no reason to compile the native libraries as they are already included in the runtime. We should skip the native compilation and make use of the library included in the `SDK` itself.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>
