### PR TITLE
Add build target definition for Java 23 (#182)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,15 @@
                 <jdk.build.target>22</jdk.build.target>
             </properties>
           </profile>
+          <profile>
+            <id>Profile for JDK 23 Build</id>
+            <activation>
+              <jdk>23</jdk>
+            </activation>
+            <properties>
+                <jdk.build.target>23</jdk.build.target>
+            </properties>
+          </profile>
           <!--
           Profile expected to be active most of the time whenever testing what was produced by
           this project. This includes the providers built and local test artifacts.


### PR DESCRIPTION
This update sets the target compiler to Java 23 when using Java 23 as the Java version.

Once JDK 23 is generally available the JDK 22 profile can be removed from both the `java23` and `main` branches of the repository.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>
