### PR TITLE
Update Werror CFLAG in AIX

### DIFF
--- a/src/main/native/jgskit.mak
+++ b/src/main/native/jgskit.mak
@@ -112,7 +112,7 @@ endif
 ifeq ($(PLATFORM),ppc-aix64)
       PLAT=ap
       CC=xlc
-      CFLAGS= -qcpluscmt -q64  -qpic -DAIX -Werror
+      CFLAGS= -qcpluscmt -q64  -qpic -DAIX -qhalt=w
       LDFLAGS= -G -q64 -blibpath:$(AIX_LIBPATH)
       IS64SYSTEM=64
       OSINCLUDEDIR=aix


### PR DESCRIPTION
The `-Werror` flag is not supported by the xlc compiler. Instead, the equivalent `-qhalt=w` can be used.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/189

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>