### PR TITLE
Refactor some signature related tests for Junit5

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -27,6 +27,7 @@
         <module name="EmptyBlock"/>
         <module name="ImportOrder"/>
     </module>
+    <module name="NewlineAtEndOfFile"/>
     <module name="RegexpHeader">
         <property name="fileExtensions" value="java"/>
         <property name="header" value="^\W.*\n^.*Copyright IBM Corp\. \d\d\d\d\n^\W.*\n^\W.*. Licensed under the Apache License 2.0 \(the &quot;License&quot;\).  You may not use\n^\W.* this file except in compliance with the License.  You can obtain a copy\n^\W.* in the file LICENSE in the source distribution.\n^\W"/>

--- a/src/test/java/ibm/jceplus/junit/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/TestAll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,28 +8,12 @@
 
 package ibm.jceplus.junit;
 
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ibm.jceplus.junit.openjceplus.TestAll.class,
-        ibm.jceplus.junit.openjceplusfips.TestAll.class,})
+@SelectClasses({ibm.jceplus.junit.openjceplus.TestAll.class,
+                ibm.jceplus.junit.openjceplusfips.TestAll.class,})
 
+@Suite
 public class TestAll {
-
-    /**
-     * @param args
-     */
-
-    public static Test suite() {
-        return new JUnit4TestAdapter(TestAll.class);
-    }
-
-    public static void main(String[] args) {
-        junit.textui.TestRunner.run(suite());
-    }
-
 }
-

--- a/src/test/java/ibm/jceplus/junit/TestIntegration.java
+++ b/src/test/java/ibm/jceplus/junit/TestIntegration.java
@@ -10,9 +10,8 @@ package ibm.jceplus.junit;
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 
-@Suite
 @SelectClasses({ibm.jceplus.junit.openjceplus.integration.TestAll.class,
                 ibm.jceplus.junit.openjceplusfips.integration.TestAll.class})
+@Suite
 public class TestIntegration {
-    
 }

--- a/src/test/java/ibm/jceplus/junit/TestMemStressAll.java
+++ b/src/test/java/ibm/jceplus/junit/TestMemStressAll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,27 +8,10 @@
 
 package ibm.jceplus.junit;
 
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ibm.jceplus.junit.openjceplus.memstress.TestMemStressAll.class,})
-
+@SelectClasses({ibm.jceplus.junit.openjceplus.memstress.TestMemStressAll.class})
+@Suite
 public class TestMemStressAll {
-
-    /**
-     * @param args
-     */
-
-    public static Test suite() {
-        return new JUnit4TestAdapter(TestMemStressAll.class);
-    }
-
-    public static void main(String[] args) {
-        junit.textui.TestRunner.run(suite());
-    }
-
 }
-

--- a/src/test/java/ibm/jceplus/junit/TestMultithread.java
+++ b/src/test/java/ibm/jceplus/junit/TestMultithread.java
@@ -19,17 +19,18 @@ import java.util.concurrent.TimeUnit;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
-import org.junit.runner.JUnitCore;
-import org.junit.runner.Request;
-import org.junit.runner.Result;
-import org.junit.runner.notification.Failure;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 
 public class TestMultithread extends TestCase {
     private final int numThreads = 10;
     private final int timeoutSec = 1500;
     private final String[] testList = {
-            //"ibm.jceplus.junit.openjceplus.TestAESGCM#testAES_GCM",
-            //"ibm.jceplus.junit.openjceplus.TestAES#testAES", "ibm.jceplus.junit.openjceplus.multithread.TestAliases",
             "ibm.jceplus.junit.openjceplus.multithread.TestAliases",
             "ibm.jceplus.junit.openjceplus.multithread.TestAESGCMUpdate",
             "ibm.jceplus.junit.openjceplus.multithread.TestAESGCMCopySafe",
@@ -80,11 +81,11 @@ public class TestMultithread extends TestCase {
 
     public TestMultithread() {}
 
-    private boolean assertConcurrent(final String message, final Callable<List<Failure>> callable,
+    private boolean assertConcurrent(final String message, final Callable<List<TestExecutionSummary.Failure>> callable,
             final int maxTimeoutSeconds) throws InterruptedException {
         boolean failed = false;
         final List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<Throwable>());
-        final List<Failure> failures = Collections.synchronizedList(new ArrayList<Failure>());
+        final List<TestExecutionSummary.Failure> failures = Collections.synchronizedList(new ArrayList<TestExecutionSummary.Failure>());
         final ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
         try {
             final CountDownLatch allExecutorThreadsReady = new CountDownLatch(numThreads);
@@ -123,7 +124,7 @@ public class TestMultithread extends TestCase {
         }
         failed = !exceptions.isEmpty();
 
-        for (Failure failure : failures) {
+        for (TestExecutionSummary.Failure failure : failures) {
             failure.getException().printStackTrace();
         }
         //failed = !failures.isEmpty();
@@ -131,27 +132,21 @@ public class TestMultithread extends TestCase {
         return failed;
     }
 
-    private Callable<List<Failure>> testToCallable(String classAndMethod) {
-        String[] classAndMethodList = classAndMethod.split("#");
-        try {
-            Request request = null;
-            if (classAndMethodList.length == 2) {
-                request = Request.method(Class.forName(classAndMethodList[0]),
-                        classAndMethodList[1]);
-            } else {
-                request = Request.aClass(Class.forName(classAndMethodList[0]));
+    private Callable<List<TestExecutionSummary.Failure>> testToCallable(String className) {
+        SummaryGeneratingListener listener = new SummaryGeneratingListener();
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request().
+            selectors(selectClass(className)).build();
+        
+        Launcher launcher = LauncherFactory.create();
+        launcher.discover(request);
+        launcher.registerTestExecutionListeners(listener);
+
+        return new Callable<List<TestExecutionSummary.Failure>>() {
+            public List<TestExecutionSummary.Failure> call() {
+                launcher.execute(request);
+                return listener.getSummary().getFailures();
             }
-            final Request myrequest = request;
-            return new Callable<List<Failure>>() {
-                public List<Failure> call() {
-                    Result result = new JUnitCore().run(myrequest);
-                    return result.getFailures();
-                }
-            };
-        } catch (ClassNotFoundException ex) {
-            assertTrue("Class not Found: " + classAndMethod, false);
-        }
-        return null;
+        };
     }
 
     public void testMultithread() {

--- a/src/test/java/ibm/jceplus/junit/TestMultithreadFIPS.java
+++ b/src/test/java/ibm/jceplus/junit/TestMultithreadFIPS.java
@@ -18,10 +18,13 @@ import java.util.concurrent.TimeUnit;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
-import org.junit.runner.JUnitCore;
-import org.junit.runner.Request;
-import org.junit.runner.Result;
-import org.junit.runner.notification.Failure;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 
 public class TestMultithreadFIPS extends TestCase {
     private final int numThreads = 10;
@@ -70,11 +73,11 @@ public class TestMultithreadFIPS extends TestCase {
 
     public TestMultithreadFIPS() {}
 
-    private boolean assertConcurrent(final String message, final Callable<List<Failure>> callable,
+    private boolean assertConcurrent(final String message, final Callable<List<TestExecutionSummary.Failure>> callable,
             final int maxTimeoutSeconds) throws InterruptedException {
         boolean failed = false;
         final List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<Throwable>());
-        final List<Failure> failures = Collections.synchronizedList(new ArrayList<Failure>());
+        final List<TestExecutionSummary.Failure> failures = Collections.synchronizedList(new ArrayList<TestExecutionSummary.Failure>());
         final ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
         try {
             final CountDownLatch allExecutorThreadsReady = new CountDownLatch(numThreads);
@@ -113,7 +116,7 @@ public class TestMultithreadFIPS extends TestCase {
         }
         failed = !exceptions.isEmpty();
 
-        for (Failure failure : failures) {
+        for (TestExecutionSummary.Failure failure : failures) {
             failure.getException().printStackTrace();
         }
         failed = !failures.isEmpty();
@@ -121,27 +124,21 @@ public class TestMultithreadFIPS extends TestCase {
         return failed;
     }
 
-    private Callable<List<Failure>> testToCallable(String classAndMethod) {
-        String[] classAndMethodList = classAndMethod.split("#");
-        try {
-            Request request = null;
-            if (classAndMethodList.length == 2) {
-                request = Request.method(Class.forName(classAndMethodList[0]),
-                        classAndMethodList[1]);
-            } else {
-                request = Request.aClass(Class.forName(classAndMethodList[0]));
+    private Callable<List<TestExecutionSummary.Failure>> testToCallable(String className) {
+        SummaryGeneratingListener listener = new SummaryGeneratingListener();
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request().
+            selectors(selectClass(className)).build();
+        
+        Launcher launcher = LauncherFactory.create();
+        launcher.discover(request);
+        launcher.registerTestExecutionListeners(listener);
+
+        return new Callable<List<TestExecutionSummary.Failure>>() {
+            public List<TestExecutionSummary.Failure> call() {
+                launcher.execute(request);
+                return listener.getSummary().getFailures();
             }
-            final Request myrequest = request;
-            return new Callable<List<Failure>>() {
-                public List<Failure> call() {
-                    Result result = new JUnitCore().run(myrequest);
-                    return result.getFailures();
-                }
-            };
-        } catch (ClassNotFoundException ex) {
-            assertTrue("Class not Found: " + classAndMethod, false);
-        }
-        return null;
+        };
     }
 
     public void testMultithreadFIPS() {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -20,40 +20,21 @@ import java.security.SignatureException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class BaseTestDSASignature extends BaseTestSignature {
 
-    // --------------------------------------------------------------------------
-    //
-    //
     static final byte[] origMsg = "this is the original message to be signed".getBytes();
 
-    // --------------------------------------------------------------------------
-    //
-    //
-    public BaseTestDSASignature(String providerName) {
-        super(providerName);
-    }
-
-    // --------------------------------------------------------------------------
-    //
-    //
-    public void setUp() throws Exception {}
-
-    // --------------------------------------------------------------------------
-    //
-    //
-    public void tearDown() throws Exception {}
-
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA1withDSA_1024() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(1024);
             doSignVerify("SHA1withDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -62,15 +43,13 @@ public class BaseTestDSASignature extends BaseTestSignature {
 
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA224withDSA_1024() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(1024);
             doSignVerify("SHA224withDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -78,15 +57,13 @@ public class BaseTestDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA256withDSA_1024() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(1024);
             doSignVerify("SHA256withDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -94,15 +71,13 @@ public class BaseTestDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_224withDSA_1024() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(1024);
             doSignVerify("SHA3-224withDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -110,15 +85,13 @@ public class BaseTestDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_2564withDSA_1024() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(1024);
             doSignVerify("SHA3-256withDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -126,15 +99,13 @@ public class BaseTestDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_384withDSA_1024() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(1024);
             doSignVerify("SHA3-384withDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -142,15 +113,13 @@ public class BaseTestDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_512withDSA_1024() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(1024);
             doSignVerify("SHA3-512withDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -158,15 +127,13 @@ public class BaseTestDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testDSAforSSL_1024_hash1() throws Exception {
         KeyPair keyPair = null;
         try {
             keyPair = generateKeyPair(1024);
         } catch (InvalidParameterException | InvalidKeyException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
                 return;
             } else {
@@ -184,15 +151,13 @@ public class BaseTestDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testDSAforSSL_1024_hash19() throws Exception {
         KeyPair keyPair = null;
         try {
             keyPair = generateKeyPair(1024);
         } catch (InvalidParameterException | InvalidKeyException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
                 return;
             } else {
@@ -210,16 +175,14 @@ public class BaseTestDSASignature extends BaseTestSignature {
 
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testDSAforSSL_1024_hash20() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(1024);
             byte[] sslHash = Arrays.copyOf(origMsg, 20);
             doSignVerify("DSAforSSL", sslHash, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -228,16 +191,14 @@ public class BaseTestDSASignature extends BaseTestSignature {
 
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testDSAforSSL_1024_hash21() throws Exception {
         KeyPair keyPair = null;
         try {
 
             keyPair = generateKeyPair(1024);
         } catch (InvalidParameterException | InvalidKeyException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
                 return;
             } else {
@@ -255,16 +216,14 @@ public class BaseTestDSASignature extends BaseTestSignature {
 
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testNONEwithDSA_1024_hash20() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(1024);
             byte[] sslHash = Arrays.copyOf(origMsg, 20);
             doSignVerify("NONEwithDSA", sslHash, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -273,13 +232,14 @@ public class BaseTestDSASignature extends BaseTestSignature {
 
     }
 
+    @Test
     public void testDSASignatureUpdates() throws Exception {
         for (int updBufferSize = 64; updBufferSize <= 512;) {
-            KeyPairGenerator keyPairGen = KeyPairGenerator.getInstance("DSA", providerName);
+            KeyPairGenerator keyPairGen = KeyPairGenerator.getInstance("DSA", getProviderName());
             keyPairGen.initialize(2048);
             KeyPair pair = keyPairGen.generateKeyPair();
             PrivateKey privKey = pair.getPrivate();
-            Signature signature = Signature.getInstance("SHA256withDSA", providerName);
+            Signature signature = Signature.getInstance("SHA256withDSA", getProviderName());
             signature.initSign(privKey);
             doDSASignatureUpdates(signature, updBufferSize);
             signature.sign();
@@ -287,7 +247,7 @@ public class BaseTestDSASignature extends BaseTestSignature {
         }
     }
 
-    public void doDSASignatureUpdates(Signature sign, int updBufferSize) throws SignatureException {
+    protected void doDSASignatureUpdates(Signature sign, int updBufferSize) throws SignatureException {
         if (updBufferSize < 128) {
             sign.update((byte) updBufferSize);
         } else {
@@ -306,36 +266,27 @@ public class BaseTestDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     protected KeyPair generateKeyPair(int keysize) throws Exception {
-        KeyPairGenerator dsaKeyPairGen = KeyPairGenerator.getInstance("DSA", providerName);
+        KeyPairGenerator dsaKeyPairGen = KeyPairGenerator.getInstance("DSA", getProviderName());
         dsaKeyPairGen.initialize(keysize);
         return dsaKeyPairGen.generateKeyPair();
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     protected KeyPair generateKeyPairFromEncoded(int keysize) throws Exception {
-        KeyPairGenerator dsaKeyPairGen = KeyPairGenerator.getInstance("DSA", providerName);
+        KeyPairGenerator dsaKeyPairGen = KeyPairGenerator.getInstance("DSA", getProviderName());
         dsaKeyPairGen.initialize(keysize);
         KeyPair keyPair = dsaKeyPairGen.generateKeyPair();
 
         X509EncodedKeySpec x509Spec = new X509EncodedKeySpec(keyPair.getPublic().getEncoded());
         PKCS8EncodedKeySpec pkcs8Spec = new PKCS8EncodedKeySpec(keyPair.getPrivate().getEncoded());
 
-        KeyFactory dsaKeyFactory = KeyFactory.getInstance("DSA", providerName);
+        KeyFactory dsaKeyFactory = KeyFactory.getInstance("DSA", getProviderName());
 
         PublicKey publicKey = dsaKeyFactory.generatePublic(x509Spec);
         PrivateKey privateKey = dsaKeyFactory.generatePrivate(pkcs8Spec);
         return new KeyPair(publicKey, privateKey);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     protected KeyPair generateKeyPairFromSpec() throws Exception {
         return null;
     }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -19,36 +19,16 @@ import java.security.Signature;
 import java.security.SignatureException;
 import java.security.spec.ECGenParameterSpec;
 import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import static org.junit.Assert.assertTrue;
 
 public class BaseTestECDSASignature extends BaseTestSignature {
 
-    // --------------------------------------------------------------------------
-    //
-    //
     static final byte[] origMsg = "this is the original message to be signed".getBytes();
 
-    // --------------------------------------------------------------------------
-    //
-    //
-    public BaseTestECDSASignature(String providerName) {
-        super(providerName);
-    }
-
-    // --------------------------------------------------------------------------
-    //
-    //
-    public void setUp() throws Exception {}
-
-    // --------------------------------------------------------------------------
-    //
-    //
-    public void tearDown() throws Exception {}
-
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA1withECDSA_192() throws Exception {
-        if (providerName.equals("OpenJCEPlusFIPS")) {
+        if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS no longer supports cuirve P-192. So skip test
             return;
         }
@@ -56,11 +36,9 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         doSignVerify("SHA1withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA1withECDSA_224() throws Exception {
-        if (providerName.equals("OpenJCEPlusFIPS")) {
+        if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS no longer supports SHA-1. So skip test
             return;
         }
@@ -68,11 +46,9 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         doSignVerify("SHA1withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA1withECDSA_256() throws Exception {
-        if (providerName.equals("OpenJCEPlusFIPS")) {
+        if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS no longer supports SHA-1. So skip test
             return;
         }
@@ -80,11 +56,9 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         doSignVerify("SHA1withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA1withECDSA_384() throws Exception {
-        if (providerName.equals("OpenJCEPlusFIPS")) {
+        if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS no longer supports SHA-1. So skip test
             return;
         }
@@ -92,11 +66,9 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         doSignVerify("SHA1withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA1withECDSA_521() throws Exception {
-        if (providerName.equals("OpenJCEPlusFIPS")) {
+        if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS no longer supports SHA-1. So skip test
             return;
         }
@@ -104,11 +76,9 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         doSignVerify("SHA1withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA224withECDSA_192() throws Exception {
-        if (providerName.equals("OpenJCEPlusFIPS")) {
+        if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS no longer supports cuirve P-192. So skip test
             return;
         }
@@ -116,43 +86,33 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         doSignVerify("SHA224withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA224withECDSA_224() throws Exception {
         KeyPair keyPair = generateKeyPair(224);
         doSignVerify("SHA224withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA224withECDSA_256() throws Exception {
         KeyPair keyPair = generateKeyPair(256);
         doSignVerify("SHA224withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA224withECDSA_384() throws Exception {
         KeyPair keyPair = generateKeyPair(384);
         doSignVerify("SHA224withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA224withECDSA_521() throws Exception {
         KeyPair keyPair = generateKeyPair(521);
         doSignVerify("SHA224withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA256withECDSA_192() throws Exception {
-        if (providerName.equals("OpenJCEPlusFIPS")) {
+        if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS no longer supports cuirve P-192. So skip test
             return;
         }
@@ -160,67 +120,53 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         doSignVerify("SHA256withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA256withECDSA_224() throws Exception {
         KeyPair keyPair = generateKeyPair(224);
         doSignVerify("SHA256withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA256withECDSA_256() throws Exception {
         KeyPair keyPair = generateKeyPair(256);
         doSignVerify("SHA256withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA256withECDSA_384() throws Exception {
         KeyPair keyPair = generateKeyPair(384);
         doSignVerify("SHA256withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA256withECDSA_521() throws Exception {
         KeyPair keyPair = generateKeyPair(521);
         doSignVerify("SHA256withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA384withECDSA_521() throws Exception {
         KeyPair keyPair = generateKeyPair(521);
         doSignVerify("SHA384withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA512withECDSA_521() throws Exception {
         KeyPair keyPair = generateKeyPair(521);
         doSignVerify("SHA512withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_224withECDSA_192() throws Exception {
         try {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 //FIPS no longer supports cuirve P-192. So skip test
                 return;
             }
             KeyPair keyPair = generateKeyPair(192);
             doSignVerify("SHA3-224withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -228,11 +174,9 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_256withECDSA_192() throws Exception {
-        if (providerName.equals("OpenJCEPlusFIPS")) {
+        if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS no longer supports cuirve P-192. So skip test
             return;
         }
@@ -240,7 +184,7 @@ public class BaseTestECDSASignature extends BaseTestSignature {
             KeyPair keyPair = generateKeyPair(192);
             doSignVerify("SHA3-256withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -248,19 +192,17 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_384withECDSA_192() throws Exception {
         try {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 //FIPS no longer supports cuirve P-192. So skip test
                 return;
             }
             KeyPair keyPair = generateKeyPair(192);
             doSignVerify("SHA3-384withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -268,11 +210,9 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_512withECDSA_192() throws Exception {
-        if (providerName.equals("OpenJCEPlusFIPS")) {
+        if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS no longer supports cuirve P-192. So skip test
             return;
         }
@@ -280,7 +220,7 @@ public class BaseTestECDSASignature extends BaseTestSignature {
             KeyPair keyPair = generateKeyPair(192);
             doSignVerify("SHA3-512withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -288,15 +228,13 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_224withECDSA_224() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(224);
             doSignVerify("SHA3-224withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -304,15 +242,13 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_256withECDSA_224() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(224);
             doSignVerify("SHA3-256withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -320,15 +256,13 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_384withECDSA_224() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(224);
             doSignVerify("SHA3-384withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -336,15 +270,13 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_512withECDSA_224() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(224);
             doSignVerify("SHA3-512withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -352,15 +284,13 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_224withECDSA_256() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(256);
             doSignVerify("SHA3-224withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -368,15 +298,13 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_256withECDSA_256() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(256);
             doSignVerify("SHA3-256withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -384,15 +312,13 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_384withECDSA_256() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(256);
             doSignVerify("SHA3-384withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -400,15 +326,13 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_512withECDSA_256() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(256);
             doSignVerify("SHA3-512withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -416,15 +340,13 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_224withECDSA_384() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(384);
             doSignVerify("SHA3-224withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -432,15 +354,13 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_256withECDSA_384() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(384);
             doSignVerify("SHA3-256withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -448,15 +368,13 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_384withECDSA_384() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(384);
             doSignVerify("SHA3-384withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -464,15 +382,13 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_512withECDSA_384() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(384);
             doSignVerify("SHA3-512withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -480,15 +396,13 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_224withECDSA_521() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(521);
             doSignVerify("SHA3-224withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -496,15 +410,13 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_256withECDSA_521() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(521);
             doSignVerify("SHA3-256withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -512,15 +424,13 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_384withECDSA_521() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(521);
             doSignVerify("SHA3-384withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -528,15 +438,13 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_512withECDSA_521() throws Exception {
         try {
             KeyPair keyPair = generateKeyPair(521);
             doSignVerify("SHA3-512withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -544,71 +452,59 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testDatawithECDSA_192() throws Exception {
-        if (providerName.equals("OpenJCEPlusFIPS")) {
+        if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS no longer supports cuirve P-192. So skip test
             return;
         }
         KeyPair keyPair = generateKeyPair(192);
-        MessageDigest md = MessageDigest.getInstance("SHA-1", providerName);
+        MessageDigest md = MessageDigest.getInstance("SHA-1", getProviderName());
         md.update(origMsg);
         byte[] digest = md.digest();
         doSignVerify("NONEwithECDSA", digest, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testDatawithECDSA_224() throws Exception {
         KeyPair keyPair = generateKeyPair(224);
-        MessageDigest md = MessageDigest.getInstance("SHA-224", providerName);
+        MessageDigest md = MessageDigest.getInstance("SHA-224", getProviderName());
         md.update(origMsg);
         byte[] digest = md.digest();
         doSignVerify("NONEwithECDSA", digest, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testDatawithECDSA_256() throws Exception {
         KeyPair keyPair = generateKeyPair(256);
-        MessageDigest md = MessageDigest.getInstance("SHA-256", providerName);
+        MessageDigest md = MessageDigest.getInstance("SHA-256", getProviderName());
         md.update(origMsg);
         byte[] digest = md.digest();
         doSignVerify("NONEwithECDSA", digest, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testDatawithECDSA_384() throws Exception {
         KeyPair keyPair = generateKeyPair(384);
-        MessageDigest md = MessageDigest.getInstance("SHA-384", providerName);
+        MessageDigest md = MessageDigest.getInstance("SHA-384", getProviderName());
         md.update(origMsg);
         byte[] digest = md.digest();
         doSignVerify("NONEwithECDSA", digest, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testDatawithECDSA_521() throws Exception {
         KeyPair keyPair = generateKeyPair(521);
-        MessageDigest md = MessageDigest.getInstance("SHA-512", providerName);
+        MessageDigest md = MessageDigest.getInstance("SHA-512", getProviderName());
         md.update(origMsg);
         byte[] digest = md.digest();
         doSignVerify("NONEwithECDSA", digest, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testDatawithECDSA_longdgst_err_224() throws Exception {
         KeyPair keyPair = generateKeyPair(224);
-        MessageDigest md = MessageDigest.getInstance("SHA-256", providerName);
+        MessageDigest md = MessageDigest.getInstance("SHA-256", getProviderName());
         md.update(origMsg);
         byte[] digest = md.digest();
         try {
@@ -621,12 +517,10 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testDatawithECDSA_longdgst_err_256() throws Exception {
         KeyPair keyPair = generateKeyPair(256);
-        MessageDigest md = MessageDigest.getInstance("SHA-512", providerName);
+        MessageDigest md = MessageDigest.getInstance("SHA-512", getProviderName());
         md.update(origMsg);
         byte[] digest = md.digest();
         try {
@@ -639,12 +533,10 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testDatawithECDSA_longdgst_err_384() throws Exception {
         KeyPair keyPair = generateKeyPair(384);
-        MessageDigest md = MessageDigest.getInstance("SHA-512", providerName);
+        MessageDigest md = MessageDigest.getInstance("SHA-512", getProviderName());
         md.update(origMsg);
         byte[] digest = md.digest();
         try {
@@ -657,12 +549,10 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testDatawithECDSA_longdgst_err_512() throws Exception {
         KeyPair keyPair = generateKeyPair(512);
-        MessageDigest md = MessageDigest.getInstance("SHA-512", providerName);
+        MessageDigest md = MessageDigest.getInstance("SHA-512", getProviderName());
         md.update(origMsg);
         byte[] digest = md.digest();
         byte[] digestLarge = new byte[digest.length * 2];
@@ -678,9 +568,10 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
+    @Test
     public void testDatawithECDSA_longdgst_521() throws Exception {
         KeyPair keyPair = generateKeyPair(521);
-        MessageDigest md = MessageDigest.getInstance("SHA-512", providerName);
+        MessageDigest md = MessageDigest.getInstance("SHA-512", getProviderName());
         md.update(origMsg);
         byte[] digest = md.digest();
         byte[] digestLarge = new byte[digest.length * 2];
@@ -694,11 +585,14 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         }
     }
 
-    /* Tests with supported curveNames */
+    /**
+     *  Tests with supported curveNames
+     */
+    @Test
     public void testSHA256withECDSA_256curves() throws Exception {
 
         KeyPair keyPair = null;
-        if (!providerName.equals("OpenJCEPlusFIPS")) {
+        if (!getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS does not support these curves. So skip test
             keyPair = generateKeyPair("secp256k1");
             doSignVerify("SHA256withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
@@ -722,6 +616,7 @@ public class BaseTestECDSASignature extends BaseTestSignature {
 
     }
 
+    @Test
     public void testSHA256withECDSA_384curves() throws Exception {
         KeyPair keyPair = generateKeyPair("secp384r1");
         doSignVerify("SHA384withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
@@ -734,6 +629,7 @@ public class BaseTestECDSASignature extends BaseTestSignature {
 
     }
 
+    @Test
     public void testSHA256withECDSA_521curves() throws Exception {
         KeyPair keyPair = generateKeyPair("secp521r1");
         doSignVerify("SHA512withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
@@ -746,8 +642,9 @@ public class BaseTestECDSASignature extends BaseTestSignature {
 
     }
 
+    @Test
     public void testSHA224withECDSA_160curves() throws Exception {
-        if (providerName.equals("OpenJCEPlusFIPS")) {
+        if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS no longer supports cuirve P-192. So skip test
             return;
         }
@@ -770,9 +667,10 @@ public class BaseTestECDSASignature extends BaseTestSignature {
 
     }
 
+    @Test
     public void testSHA224withECDSA_192curves() throws Exception {
 
-        if (providerName.equals("OpenJCEPlusFIPS")) {
+        if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS no longer supports cuirve P-192. So skip test
             return;
         }
@@ -792,10 +690,11 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         doSignVerify("SHA224withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
+    @Test
     public void testSHA224withECDSA_124curves() throws Exception {
 
         KeyPair keyPair = null;
-        if (!providerName.equals("OpenJCEPlusFIPS")) {
+        if (!getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS does not support this. so skip test
             keyPair = generateKeyPair("secp224k1");
             doSignVerify("SHA256withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
@@ -812,12 +711,13 @@ public class BaseTestECDSASignature extends BaseTestSignature {
 
     }
 
+    @Test
     public void testX962PrimeCurves() throws Exception {
 
 
         /* ANSI X9.62 prime curves */
 
-        if (providerName.equals("OpenJCEPlusFIPS")) {
+        if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS does not support this. so skip test
             return;
         }
@@ -849,17 +749,17 @@ public class BaseTestECDSASignature extends BaseTestSignature {
         doSignVerify("SHA256withECDSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    // OSB Oracle Security Fix 8277233 test
+    @Test
     public void testPostiveSigBytes() throws Exception {
-        doTestPositiveSigBytes("EC", "SHA256withECDSA", this.providerName);
+        doTestPositiveSigBytes("EC", "SHA256withECDSA", this.getProviderName());
 
-        if (!providerName.equals("OpenJCEPlusFIPS")) {
+        if (!getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS does not support this. so skip test
-            doTestPositiveSigBytes("DSA", "SHA256withDSA", this.providerName);
+            doTestPositiveSigBytes("DSA", "SHA256withDSA", this.getProviderName());
         }
     }
 
-    void doTestPositiveSigBytes(String keyAlg, String sigAlg, String providerName)
+    private void doTestPositiveSigBytes(String keyAlg, String sigAlg, String providerName)
             throws Exception {
         KeyPairGenerator kpg = KeyPairGenerator.getInstance(keyAlg, providerName);
         KeyPair kp = kpg.generateKeyPair();
@@ -889,13 +789,13 @@ public class BaseTestECDSASignature extends BaseTestSignature {
     //
     //
     private KeyPair generateKeyPair(int keysize) throws Exception {
-        KeyPairGenerator ecKeyPairGen = KeyPairGenerator.getInstance("EC", providerName);
+        KeyPairGenerator ecKeyPairGen = KeyPairGenerator.getInstance("EC", getProviderName());
         ecKeyPairGen.initialize(keysize);
         return ecKeyPairGen.generateKeyPair();
     }
 
     private KeyPair generateKeyPair(String curveName) throws Exception {
-        KeyPairGenerator ecKeyPairGen = KeyPairGenerator.getInstance("EC", providerName);
+        KeyPairGenerator ecKeyPairGen = KeyPairGenerator.getInstance("EC", getProviderName());
         ECGenParameterSpec ecgenParameterSpec = new ECGenParameterSpec(curveName);
         ecKeyPairGen.initialize(ecgenParameterSpec);
         return ecKeyPairGen.generateKeyPair();

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestJunit5.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestJunit5.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright IBM Corp. 2023, 2024
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution.
+ */
+
+package ibm.jceplus.junit.base;
+
+public class BaseTestJunit5 {
+
+    private String providerName;
+
+    /**
+     * Sets the provider name that is to be used to execute this test.
+     * 
+     * @param providerName the provider name associated with this test case for use.
+     */
+    public void setProviderName(String providerName) {
+        this.providerName = providerName;
+    }
+
+    /**
+     * Gets the provider name that is to be used to execute this test.
+     * 
+     * @return The provider name associated with this test case for use.
+     */
+    public String getProviderName() {
+        return this.providerName;
+    }
+}
+

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSSignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSSignature.java
@@ -50,7 +50,10 @@ import org.bouncycastle.crypto.util.SubjectPublicKeyInfoFactory;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import sun.security.x509.X500Name;
+import static org.junit.Assert.assertTrue;
 
 public class BaseTestRSAPSSSignature extends BaseTestSignature {
 
@@ -117,18 +120,17 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
     static boolean printJunitTrace = false;
 
 
-    public BaseTestRSAPSSSignature(String providerName) {
-        super(providerName);
+    @BeforeAll
+    public static void setup() {
         Security.addProvider(new BouncyCastleProvider());
         printJunitTrace = Boolean
                 .valueOf(System.getProperty("com.ibm.jceplus.junit.printJunitTrace"));
     }
 
-    public void setUp() throws Exception {}
-
+    @Test
     public void testRSASignatureWithPSS_SHA1() throws Exception {
         try {
-            dotestSignature(content, IBM_ALG, 512, null, providerName);
+            dotestSignature(content, IBM_ALG, 512, null, getProviderName());
 
         } catch (Exception e) {
             // TODO Auto-generated catch block
@@ -142,6 +144,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * Generate a key once and use it for multiple tests
      * @throws Exception
      */
+    @Test
     public void testRSASignatureWithPSSBigMsgMultiKeySize() throws Exception {
         try {
             for (int i = 512; i < 4096;) {
@@ -173,6 +176,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * Verify a certificate generated and signed by BC
      * @throws Exception
      */
+    @Test
     public void testCertBCtoIBM() throws Exception {
 
         // yesterday
@@ -214,7 +218,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
 
         InputStream is0 = new ByteArrayInputStream(derBytes0);
         X509Certificate certificate0 = (X509Certificate) CertificateFactory
-                .getInstance("X.509", providerName).generateCertificate(is0);
+                .getInstance("X.509", getProviderName()).generateCertificate(is0);
         if (printJunitTrace)
             System.out.println(toHex(certificate0.getSigAlgParams()));
 
@@ -230,6 +234,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * IBM vs BC
      * @throws Exception
      */
+    @Test
     public void testRSASignatureWithPSSMultiByteSize_timed() throws Exception {
         try {
             for (int i = 1; i <= 100; i++) {
@@ -239,7 +244,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
                 }
                 if (printJunitTrace)
                     System.out.println("msgSize=" + dynMsg.length);
-                dotestSignature(dynMsg, IBM_ALG, 512, null, providerName);
+                dotestSignature(dynMsg, IBM_ALG, 512, null, getProviderName());
 
             }
 
@@ -255,6 +260,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * IBM vs BC
      * @throws Exception
      */
+    @Test
     public void testRSASignatureWithPSSMultiByteSize_timed_BC() throws Exception {
         try {
             for (int i = 1; i <= 100; i++) {
@@ -279,6 +285,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * 
      * @throws Exception
      */
+    @Test
     public void testRSASignatureWithPSSMultiByteSize_BC2IBM() throws Exception {
         try {
             for (int i = 1; i <= 301; i++) {
@@ -305,7 +312,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * 
      * @throws Exception
      */
-
+    @Test
     public void testRSASignatureWithPSSMultiByteSize_IBM2BC2() throws Exception {
         try {
             for (int i = 1; i <= 301; i++) {
@@ -332,6 +339,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * Test after setting parameters
      * @throws Exception
      */
+    @Test
     public void testRSASignatureWithPSSParameterSpec() throws Exception {
         try {
             dotestSignaturePSSParameterSpec(content1, IBM_ALG, 512);
@@ -347,11 +355,12 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * SHA256
      * @throws Exception
      */
+    @Test
     public void testRSASignatureSHA256() throws Exception {
 
         try {
             PSSParameterSpec pssParameter = specSHA256Salt20;
-            dotestSignature(content, IBM_ALG, 2048, pssParameter, providerName);
+            dotestSignature(content, IBM_ALG, 2048, pssParameter, getProviderName());
 
         } catch (Exception e) {
             // TODO Auto-generated catch block
@@ -364,12 +373,13 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * SHA512
      * @throws Exception
      */
+    @Test
     public void testRSASignatureSHA512() throws Exception {
 
         PSSParameterSpec pssParameter = new PSSParameterSpec("SHA512", "MGF1",
                 MGF1ParameterSpec.SHA512, 20, 1);
         try {
-            dotestSignature(content, IBM_ALG, 2048, pssParameter, providerName);
+            dotestSignature(content, IBM_ALG, 2048, pssParameter, getProviderName());
 
         } catch (Exception e) {
             // TODO Auto-generated catch block
@@ -382,12 +392,13 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * SHA512/224
      * @throws Exception
      */
+    @Test
     public void testRSASignatureSHA512_224() throws Exception {
 
         PSSParameterSpec pssParameter = new PSSParameterSpec("SHA512/224", "MGF1",
                 MGF1ParameterSpec.SHA512_224, 20, 1);
         try {
-            dotestSignature(content, IBM_ALG, 2048, pssParameter, providerName);
+            dotestSignature(content, IBM_ALG, 2048, pssParameter, getProviderName());
 
         } catch (Exception e) {
             // TODO Auto-generated catch block
@@ -400,12 +411,13 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * SHA512/256
      * @throws Exception
      */
+    @Test
     public void testRSASignatureSHA512_256() throws Exception {
 
         PSSParameterSpec pssParameter = new PSSParameterSpec("SHA512/256", "MGF1",
                 MGF1ParameterSpec.SHA512_256, 20, 1);
         try {
-            dotestSignature(content, IBM_ALG, 2048, pssParameter, providerName);
+            dotestSignature(content, IBM_ALG, 2048, pssParameter, getProviderName());
 
         } catch (Exception e) {
             // TODO Auto-generated catch block
@@ -418,11 +430,12 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * SHA384
      * @throws Exception
      */
+    @Test
     public void testRSASignatureSHA384() throws Exception {
         try {
             PSSParameterSpec pssParameter = new PSSParameterSpec("SHA384", "MGF1",
                     MGF1ParameterSpec.SHA384, 20, 1);
-            dotestSignature(content, IBM_ALG, 2048, pssParameter, providerName);
+            dotestSignature(content, IBM_ALG, 2048, pssParameter, getProviderName());
 
         } catch (Exception e) {
             // TODO Auto-generated catch block
@@ -434,6 +447,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
     /**
      * SHA255 - test one byte
      */
+    @Test
     public void testRSASignatureSHA256OneByte() throws Exception {
         try {
             PSSParameterSpec pssParameterSpec = specSHA256Salt40;
@@ -450,6 +464,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * Bouncy Castle to IBM
      * @throws Exception
      */
+    @Test
     public void testRSASignatureSHA1_BC2IBM() throws Exception {
         try {
             dotestSignatureBC2IBM(oneByte, IBM_ALG, BC_ALG, 512, -1);
@@ -468,7 +483,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * IBM to BC
      * @throws Exception
      */
-
+    @Test
     public void testRSASignatureSHA1_IBM2BC() throws Exception {
         try {
             doSignatureIBM2BC(oneByte, IBM_ALG, BC_ALG, 512, -1);
@@ -484,6 +499,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * 0 salt length
      * @throws Exception
      */
+    @Test
     public void testRSASignatureSHA1_IBM2BC_0salt() throws Exception {
         try {
             doSignatureIBM2BC(oneByte, IBM_ALG, BC_ALG, 512, 0);
@@ -504,7 +520,6 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * @param jceprovider
      * @throws Exception
      */
-
     protected void dotestSignature(byte[] content, String algorithm, int keySize,
             PSSParameterSpec pssParameterSpec, String jceprovider) throws Exception {
 
@@ -537,7 +552,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
 
         // Check Signature
         // Signature verifySig = Signature.getInstance("SHA1withRSA/PSS",
-        // providerName);
+        // getProviderName());
         // verifySig.initVerify(cert);
         // verifySig.update(content);
         boolean signatureVerified = sig.verify(sigBytes);
@@ -563,7 +578,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
         // keyGen.initialize(keySize, new java.security.SecureRandom());
         // KeyPair keyPair = keyGen.genKeyPair();
 
-        Signature sig = Signature.getInstance(algorithm, providerName);
+        Signature sig = Signature.getInstance(algorithm, getProviderName());
         if (pssParameterSpec != null) {
             sig.setParameter(pssParameterSpec);
         }
@@ -577,7 +592,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
 
         // Check Signature
         // Signature verifySig = Signature.getInstance("SHA1withRSA/PSS",
-        // providerName);
+        // getProviderName());
         // verifySig.initVerify(cert);
         // verifySig.update(content);
         boolean signatureVerified = sig.verify(sigBytes);
@@ -627,7 +642,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
             int saltSize) throws NoSuchAlgorithmException, NoSuchProviderException,
             InvalidKeyException, SignatureException {
 
-        // Signature sig = Signature.getInstance(algorithm, providerName);
+        // Signature sig = Signature.getInstance(algorithm, getProviderName());
         Signature sig = Signature.getInstance(bcalgorithm, "BC");
         AlgorithmParameters algParams = sig.getParameters();
         try {
@@ -643,7 +658,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
         sig.update(plaintext);
         byte[] sigBytes = sig.sign();
 
-        Signature sig1 = Signature.getInstance(ibmalgorithm, providerName);
+        Signature sig1 = Signature.getInstance(ibmalgorithm, getProviderName());
         // Verify the signature
         sig1.initVerify(keyPair.getPublic());
         sig1.update(plaintext);
@@ -719,7 +734,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
                     MGF1ParameterSpec.SHA1, saltsize, 1);;
         }
 
-        // Signature sig = Signature.getInstance(algorithm, providerName);
+        // Signature sig = Signature.getInstance(algorithm, getProviderName());
         Signature sig = Signature.getInstance(bcalgorithm, "BC");
         if (pssParameterSpec != null) {
             sig.setParameter(pssParameterSpec);
@@ -738,7 +753,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
         sig.update(content);
         byte[] sigBytes = sig.sign();
 
-        Signature sig1 = Signature.getInstance(ibmalgorithm, providerName);
+        Signature sig1 = Signature.getInstance(ibmalgorithm, getProviderName());
         if (pssParameterSpec != null) {
             sig1.setParameter(pssParameterSpec);
         }
@@ -772,7 +787,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
         keyGen.initialize(keySize, new java.security.SecureRandom());
         KeyPair keyPair = keyGen.genKeyPair();
 
-        Signature sig = Signature.getInstance(algorithm, providerName);
+        Signature sig = Signature.getInstance(algorithm, getProviderName());
         // Set salt length
         PSSParameterSpec pss = new PSSParameterSpec("SHA-1", "MGF1",
                 MGF1ParameterSpec.SHA1, 20, 1);
@@ -810,7 +825,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
         keyGen.initialize(keySize, new java.security.SecureRandom());
         KeyPair keyPair = keyGen.genKeyPair();
 
-        Signature sig = Signature.getInstance(algorithm, providerName);
+        Signature sig = Signature.getInstance(algorithm, getProviderName());
         // Set salt length
         if (pssParameterSpec != null) {
             sig.setParameter(pssParameterSpec);
@@ -832,6 +847,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * Empty parameters
      * @throws Exception
      */
+    @Test
     public void testCertSelfSignVerifyEmptyParams() throws Exception {
 
         String alias = "TestRSAPSS";
@@ -848,6 +864,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * IBM to BC empty params
      * @throws Exception
      */
+    @Test
     public void testCertIBM2BCEmptyParams() throws Exception {
 
         String alias = "TestRSAPSS";
@@ -864,6 +881,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * All the 4 parameters are non default
      * @throws Exception
      */
+    @Test
     public void testCertIBM2BCNonDefaultParams() throws Exception {
 
         String alias = "TestRSAPSS";
@@ -880,7 +898,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * All parameters except salt are default
      * @throws Exception
      */
-
+    @Test
     public void testCertIBM2BCParamsSalt40() throws Exception {
 
         String alias = "TestRSAPSS";
@@ -897,6 +915,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * BC to IBM all default parameters
      * @throws Exception
      */
+    @Test
     public void testCertIBM2BCDefaultParams() throws Exception {
 
         String alias = "TestRSAPSS";
@@ -913,6 +932,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * Default parameters
      * @throws Exception
      */
+    @Test
     public void testCertSelfSignVerifyDefaultParams() throws Exception {
 
         String alias = "TestRSAPSS";
@@ -930,7 +950,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * Non default parameters
      * @throws Exception
      */
-
+    @Test
     public void testCertSelfSignVerifyNonDefaultParams() throws Exception {
 
         String alias = "TestRSAPSS";
@@ -947,6 +967,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
     /**
      * Non RSAPSS cert to make sure other certs are not broken by RSA-PSS
      */
+    @Test
     public void testCertNonPSS() throws Exception {
 
         String alias = "TestNonRSAPSS";
@@ -963,6 +984,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * only the Salt is non default
      * @throws Exception
      */
+    @Test
     public void testCertSelfSignDefaultParamsExceptSalt() throws Exception {
 
         String alias = "TestRSAPSS";
@@ -980,6 +1002,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * IBM to BC
      * @throws Exception
      */
+    @Test
     public void testCertSelfSignDefaultParamsExceptSaltBC() throws Exception {
 
         String alias = "TestRSAPSS";
@@ -1031,7 +1054,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
                 }
             }
         }
-        CertAndKeyGen keypair = new CertAndKeyGen(keyAlgName, sigAlgName, providerName);
+        CertAndKeyGen keypair = new CertAndKeyGen(keyAlgName, sigAlgName, getProviderName());
 
         // If DN is provided, parse it. Otherwise, prompt the user for it.
         X500Name x500Name = new X500Name(dname);
@@ -1204,7 +1227,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
                 }
             }
         }
-        CertAndKeyGen keypair = new CertAndKeyGen(keyAlgName, sigAlgName, providerName);
+        CertAndKeyGen keypair = new CertAndKeyGen(keyAlgName, sigAlgName, getProviderName());
 
         KeyPairGenerator.getInstance("RSA", "BC");
 
@@ -1439,6 +1462,7 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
         //                certDefaultParamsClient.getSigAlgParams());
     }
 
+    @Test
     public void testReadEmptyParam3rdPartyCertificates() throws IOException, CertificateException,
             InvalidKeyException, NoSuchAlgorithmException, NoSuchProviderException,
             SignatureException, InvalidParameterSpecException, InvalidAlgorithmParameterException {
@@ -1502,10 +1526,11 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
      * Test parameter spec
      * @throws IOException
      */
+    @Test
     public void testParameterSpec() throws IOException {
         Signature sig_ibm = null;
         try {
-            sig_ibm = Signature.getInstance(IBM_ALG, providerName);
+            sig_ibm = Signature.getInstance(IBM_ALG, getProviderName());
         } catch (NoSuchAlgorithmException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
@@ -1601,11 +1626,11 @@ public class BaseTestRSAPSSSignature extends BaseTestSignature {
         return buf.toString();
     }
 
-    @org.junit.Test
+    @Test
     public void testRSAPSSKeyFactory() throws Exception {
         try {
             String providerNameKF = "";
-            providerNameKF = providerName;
+            providerNameKF = getProviderName();
             if (printJunitTrace)
                 System.out.println("Test RSAPSS KeyFactory provider: " + providerNameKF);
             KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA", providerNameKF);

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -25,6 +25,8 @@ import java.security.spec.RSAPrivateKeySpec;
 import java.security.spec.RSAPublicKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestRSASignature extends BaseTestSignature {
 
@@ -32,7 +34,6 @@ public class BaseTestRSASignature extends BaseTestSignature {
     //
     //
     static final byte[] origMsg = "this is the original message to be signed".getBytes();
-    int keySize = 1024;
 
     static final BigInteger N = new BigInteger(
             "116231208661367609700141079576488663663527180869991078124978203037949869"
@@ -50,49 +51,17 @@ public class BaseTestRSASignature extends BaseTestSignature {
                     + "843638089774095747779777512895029847721754360216404183209801002443859648"
                     + "26168432372077852785");
 
-    //--------------------------------------------------------------------------
-    //
-    //
-
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public BaseTestRSASignature(String providerName) {
-        super(providerName);
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public BaseTestRSASignature(String providerName, int size) {
-        super(providerName);
-        this.keySize = size;
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public void setUp() throws Exception {}
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public void tearDown() throws Exception {}
-
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testRSAPlainKeySignature() throws Exception {
 
         KeyFactory kf;
 
-        if (providerName.equals("OpenJCEPlusFIPS")) {
+        if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS does not support plain keys
             return;
         }
 
-        kf = KeyFactory.getInstance("RSA", providerName);
+        kf = KeyFactory.getInstance("RSA", getProviderName());
 
         RSAPublicKeySpec pubSpec = new RSAPublicKeySpec(N, E);
         PublicKey publicKey = kf.generatePublic(pubSpec);
@@ -103,19 +72,17 @@ public class BaseTestRSASignature extends BaseTestSignature {
         doSignVerify("SHA1withRSA", origMsg, privateKey, publicKey);
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testRSAPlainKeySSLSignature() throws Exception {
 
         KeyFactory kf;
 
-        if (providerName.equals("OpenJCEPlusFIPS")) {
+        if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS does not support plain keys
             return;
         }
 
-        kf = KeyFactory.getInstance("RSA", providerName);
+        kf = KeyFactory.getInstance("RSA", getProviderName());
 
         RSAPublicKeySpec pubSpec = new RSAPublicKeySpec(N, E);
         PublicKey publicKey = kf.generatePublic(pubSpec);
@@ -126,59 +93,47 @@ public class BaseTestRSASignature extends BaseTestSignature {
         doSignVerify("RSAforSSL", origMsg, privateKey, publicKey);
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA1withRSA() throws Exception {
-        if (providerName.equals("OpenJCEPlusFIPS")) {
+        if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //SHA1 not supported in FIPS
             return;
         }
-        KeyPair keyPair = generateKeyPair(this.keySize);
+        KeyPair keyPair = generateKeyPair(getKeySize());
         doSignVerify("SHA1withRSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA224withRSA() throws Exception {
-        KeyPair keyPair = generateKeyPair(this.keySize);
+        KeyPair keyPair = generateKeyPair(getKeySize());
         doSignVerify("SHA224withRSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA256withRSA() throws Exception {
-        KeyPair keyPair = generateKeyPair(this.keySize);
+        KeyPair keyPair = generateKeyPair(getKeySize());
         doSignVerify("SHA256withRSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA384withRSA() throws Exception {
-        KeyPair keyPair = generateKeyPair(this.keySize);
+        KeyPair keyPair = generateKeyPair(getKeySize());
         doSignVerify("SHA384withRSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA512withRSA() throws Exception {
-        KeyPair keyPair = generateKeyPair(this.keySize);
+        KeyPair keyPair = generateKeyPair(getKeySize());
         doSignVerify("SHA512withRSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_224withRSA() throws Exception {
         try {
-            KeyPair keyPair = generateKeyPair(this.keySize);
+            KeyPair keyPair = generateKeyPair(getKeySize());
             doSignVerify("SHA3-224withRSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -186,15 +141,13 @@ public class BaseTestRSASignature extends BaseTestSignature {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_256withRSA() throws Exception {
         try {
-            KeyPair keyPair = generateKeyPair(this.keySize);
+            KeyPair keyPair = generateKeyPair(getKeySize());
             doSignVerify("SHA3-256withRSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -202,15 +155,13 @@ public class BaseTestRSASignature extends BaseTestSignature {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_384withRSA() throws Exception {
         try {
-            KeyPair keyPair = generateKeyPair(this.keySize);
+            KeyPair keyPair = generateKeyPair(getKeySize());
             doSignVerify("SHA3-384withRSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -218,15 +169,13 @@ public class BaseTestRSASignature extends BaseTestSignature {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHA3_512withRSA() throws Exception {
         try {
-            KeyPair keyPair = generateKeyPair(this.keySize);
+            KeyPair keyPair = generateKeyPair(getKeySize());
             doSignVerify("SHA3-512withRSA", origMsg, keyPair.getPrivate(), keyPair.getPublic());
         } catch (InvalidParameterException | InvalidKeyException | NoSuchAlgorithmException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -234,126 +183,97 @@ public class BaseTestRSASignature extends BaseTestSignature {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testRSAforSSL_hash1() throws Exception {
-        KeyPair keyPair = generateKeyPair(this.keySize);
+        KeyPair keyPair = generateKeyPair(getKeySize());
         byte[] sslHash = Arrays.copyOf(origMsg, 1);
         doSignVerify("RSAforSSL", sslHash, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testRSAforSSL_hash5() throws Exception {
-        KeyPair keyPair = generateKeyPair(this.keySize);
+        KeyPair keyPair = generateKeyPair(getKeySize());
         byte[] sslHash = Arrays.copyOf(origMsg, 5);
         doSignVerify("RSAforSSL", sslHash, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testRSAforSSL_hash20() throws Exception {
-        KeyPair keyPair = generateKeyPair(this.keySize);
+        KeyPair keyPair = generateKeyPair(getKeySize());
         byte[] sslHash = Arrays.copyOf(origMsg, 20);
         doSignVerify("RSAforSSL", sslHash, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testRSAforSSL_hash36() throws Exception {
-        KeyPair keyPair = generateKeyPair(this.keySize);
+        KeyPair keyPair = generateKeyPair(getKeySize());
         byte[] sslHash = Arrays.copyOf(origMsg, 36);
         doSignVerify("RSAforSSL", sslHash, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testRSAforSSL_hash40() throws Exception {
-        KeyPair keyPair = generateKeyPair(this.keySize);
+        KeyPair keyPair = generateKeyPair(getKeySize());
         byte[] sslHash = Arrays.copyOf(origMsg, 40);
         doSignVerify("RSAforSSL", sslHash, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testNONEwithRSA_hash1() throws Exception {
-        KeyPair keyPair = generateKeyPair(this.keySize);
+        KeyPair keyPair = generateKeyPair(getKeySize());
         byte[] sslHash = Arrays.copyOf(origMsg, 1);
         doSignVerify("NONEwithRSA", sslHash, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testNONEwithRSA_hash5() throws Exception {
-        KeyPair keyPair = generateKeyPair(this.keySize);
+        KeyPair keyPair = generateKeyPair(getKeySize());
         byte[] sslHash = Arrays.copyOf(origMsg, 5);
         doSignVerify("NONEwithRSA", sslHash, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testNONEwithRSA_hash20() throws Exception {
-        KeyPair keyPair = generateKeyPair(this.keySize);
+        KeyPair keyPair = generateKeyPair(getKeySize());
         byte[] sslHash = Arrays.copyOf(origMsg, 20);
         doSignVerify("NONEwithRSA", sslHash, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testNONEwithRSA_hash36() throws Exception {
-        KeyPair keyPair = generateKeyPair(this.keySize);
+        KeyPair keyPair = generateKeyPair(getKeySize());
         byte[] sslHash = Arrays.copyOf(origMsg, 36);
         doSignVerify("NONEwithRSA", sslHash, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testNONEwithRSA_hash40() throws Exception {
-        KeyPair keyPair = generateKeyPair(this.keySize);
+        KeyPair keyPair = generateKeyPair(getKeySize());
         byte[] sslHash = Arrays.copyOf(origMsg, 40);
         doSignVerify("NONEwithRSA", sslHash, keyPair.getPrivate(), keyPair.getPublic());
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     protected KeyPair generateKeyPair(int keysize) throws Exception {
-        KeyPairGenerator rsaKeyPairGen = KeyPairGenerator.getInstance("RSA", providerName);
+        KeyPairGenerator rsaKeyPairGen = KeyPairGenerator.getInstance("RSA", getProviderName());
         rsaKeyPairGen.initialize(keysize);
         return rsaKeyPairGen.generateKeyPair();
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     protected KeyPair generateKeyPairFromEncoded(int keysize) throws Exception {
-        KeyPairGenerator rsaKeyPairGen = KeyPairGenerator.getInstance("RSA", providerName);
+        KeyPairGenerator rsaKeyPairGen = KeyPairGenerator.getInstance("RSA", getProviderName());
         rsaKeyPairGen.initialize(keysize);
         KeyPair keyPair = rsaKeyPairGen.generateKeyPair();
 
         X509EncodedKeySpec x509Spec = new X509EncodedKeySpec(keyPair.getPublic().getEncoded());
         PKCS8EncodedKeySpec pkcs8Spec = new PKCS8EncodedKeySpec(keyPair.getPrivate().getEncoded());
 
-        KeyFactory rsaKeyFactory = KeyFactory.getInstance("RSA", providerName);
+        KeyFactory rsaKeyFactory = KeyFactory.getInstance("RSA", getProviderName());
 
         PublicKey publicKey = rsaKeyFactory.generatePublic(x509Spec);
         PrivateKey privateKey = rsaKeyFactory.generatePrivate(pkcs8Spec);
         return new KeyPair(publicKey, privateKey);
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     protected KeyPair generateKeyPairFromSpec() throws Exception {
         RSAPrivateCrtKeySpec crtSpec = new RSAPrivateCrtKeySpec(
                 new BigInteger("00BF6097526F553D345A702A86DA69A3C98379EFC52BD9246DBDD7F75B17CA115"
@@ -382,7 +302,7 @@ public class BaseTestRSASignature extends BaseTestSignature {
                                 + "48219A23BD70BF9FAEE7AA795D5A8537C90E88D3E4F8CA146907CB",
                         16));
 
-        KeyFactory rsaKeyFactory = KeyFactory.getInstance("RSA", providerName);
+        KeyFactory rsaKeyFactory = KeyFactory.getInstance("RSA", getProviderName());
 
         RSAPrivateCrtKey rsaPrivateKey = (RSAPrivateCrtKey) rsaKeyFactory.generatePrivate(crtSpec);
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSASignatureChunkUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSASignatureChunkUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -12,6 +12,10 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.Signature;
 import java.security.SignatureException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class BaseTestRSASignatureChunkUpdate extends BaseTestSignature {
     static final String KEY_ALGO = "RSA";
@@ -21,12 +25,9 @@ public class BaseTestRSASignatureChunkUpdate extends BaseTestSignature {
     protected KeyPair keyPair = null;
     protected int specifiedKeySize = 0;
 
-    public BaseTestRSASignatureChunkUpdate(String providerName) {
-        super(providerName);
-    }
-
+    @BeforeEach
     public void setUp() throws Exception {
-        keyPairGenerator = KeyPairGenerator.getInstance(KEY_ALGO, providerName);
+        keyPairGenerator = KeyPairGenerator.getInstance(KEY_ALGO, getProviderName());
         if (specifiedKeySize > 0) {
             keyPairGenerator.initialize(specifiedKeySize);
         } else {
@@ -35,8 +36,7 @@ public class BaseTestRSASignatureChunkUpdate extends BaseTestSignature {
         keyPair = keyPairGenerator.generateKeyPair();
     }
 
-    public void tearDown() throws Exception {}
-
+    @Test
     public void testSignatureChunks() throws Exception {
         testSignatureChunkUpdate(1024, "SHA1WithRSA", 100);
         testSignatureChunkUpdate(1024, "SHA256WithRSA", 100);
@@ -50,12 +50,12 @@ public class BaseTestRSASignatureChunkUpdate extends BaseTestSignature {
         byte[] inputBytes = getString(inputSize).getBytes();
         Signature signSignature;
 
-        if (providerName.contains("FIPS") && sigAlgo.contains("SHA1")) {
+        if (getProviderName().contains("FIPS") && sigAlgo.contains("SHA1")) {
             System.out.println("Sign with " + sigAlgo + ", provider: OpenJCEPlus");
             signSignature = Signature.getInstance(sigAlgo, "OpenJCEPlus");
         } else {
-            System.out.println("Sign with " + sigAlgo + ", provider: " + providerName);
-            signSignature = Signature.getInstance(sigAlgo, providerName);
+            System.out.println("Sign with " + sigAlgo + ", provider: " + getProviderName());
+            signSignature = Signature.getInstance(sigAlgo, getProviderName());
         }
 
         // Sign the message
@@ -75,8 +75,8 @@ public class BaseTestRSASignatureChunkUpdate extends BaseTestSignature {
         System.out.println("Signature Bytes Length: " + sigBytes.length);
 
         // Verify the signature
-        System.out.println("Verify with " + sigAlgo + ", provider: " + providerName);
-        Signature verifySignature = Signature.getInstance(sigAlgo, providerName);
+        System.out.println("Verify with " + sigAlgo + ", provider: " + getProviderName());
+        Signature verifySignature = Signature.getInstance(sigAlgo, getProviderName());
         verifySignature.initVerify(keyPair.getPublic());
         for (i = 0; i < (inputBytes.length / chunkSize); i++) {
             verifySignature.update(inputBytes, i * chunkSize, chunkSize);
@@ -105,10 +105,10 @@ public class BaseTestRSASignatureChunkUpdate extends BaseTestSignature {
         boolean result = false;
 
         try {
-            Signature signSignature = Signature.getInstance(sigAlgo, providerName);
+            Signature signSignature = Signature.getInstance(sigAlgo, getProviderName());
 
             // Sign the message
-            System.out.println("Sign with " + sigAlgo + ", provider: " + providerName);
+            System.out.println("Sign with " + sigAlgo + ", provider: " + getProviderName());
             signSignature.initSign(keyPair.getPrivate());
             int i = 0;
             for (i = 0; i < (inputBytes.length / chunkSize); i++) {
@@ -125,8 +125,8 @@ public class BaseTestRSASignatureChunkUpdate extends BaseTestSignature {
             System.out.println("Signature Bytes Length: " + sigBytes.length);
 
             // Verify the signature
-            System.out.println("Verify with " + sigAlgo + ", provider: " + providerName);
-            Signature verifySignature = Signature.getInstance(sigAlgo, providerName);
+            System.out.println("Verify with " + sigAlgo + ", provider: " + getProviderName());
+            Signature verifySignature = Signature.getInstance(sigAlgo, getProviderName());
             verifySignature.initVerify(keyPair.getPublic());
             for (i = 0; i < (inputBytes.length / chunkSize); i++) {
                 verifySignature.update(inputBytes, i * chunkSize, chunkSize);
@@ -142,8 +142,8 @@ public class BaseTestRSASignatureChunkUpdate extends BaseTestSignature {
             result = verifySignature.verify(sigBytes);
 
         } catch (SignatureException ex) {
-            if (providerName.contains("FIPS") && sigAlgo.contains("SHA1")) {
-                System.out.print("Could not sign data, " + "Provider: " + providerName
+            if (getProviderName().contains("FIPS") && sigAlgo.contains("SHA1")) {
+                System.out.print("Could not sign data, " + "Provider: " + getProviderName()
                         + ", Algorithm: " + sigAlgo + " <== Expected SignatureException caught\n");
                 System.out.println("Result(should be false): " + result);
                 assertFalse(result);

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -11,37 +11,54 @@ package ibm.jceplus.junit.base;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
+import static org.junit.Assert.assertTrue;
 
-public class BaseTestSignature extends BaseTest {
+public class BaseTestSignature extends BaseTestJunit5 {
 
-    //--------------------------------------------------------------------------
-    //
-    //
-    public BaseTestSignature(String providerName) {
-        super(providerName);
+    private int keysize = 0;
+
+    private String algo = null;
+
+    /**
+     * Sets the algorithm associated with this test.
+     * @param algorithm
+     */
+    public void setAlgorithm(String algorithm) {
+        this.algo = algorithm;
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
-    public void setUp() throws Exception {}
+    /**
+     * Gets the algorithm associated with this test.
+     * @return
+     */
+    public String getAlgorithm() {
+        return this.algo;
+    }
 
-    //--------------------------------------------------------------------------
-    //
-    //
-    public void tearDown() throws Exception {}
+    /**
+     * Sets the key size associated with this test.
+     * @param keySize
+     */
+    public void setKeySize(int keySize) {
+        this.keysize = keySize;
+    }
 
-    //--------------------------------------------------------------------------
-    //
-    //
+    /**
+     * Gets the key size associated with this test.
+     * @return
+     */
+    public int getKeySize() {
+        return this.keysize;
+    }
+
     protected void doSignVerify(String sigAlgo, byte[] message, PrivateKey privateKey,
             PublicKey publicKey) throws Exception {
-        Signature signing = Signature.getInstance(sigAlgo, providerName);
+        Signature signing = Signature.getInstance(sigAlgo, getProviderName());
         signing.initSign(privateKey);
         signing.update(message);
         byte[] signedBytes = signing.sign();
 
-        Signature verifying = Signature.getInstance(sigAlgo, providerName);
+        Signature verifying = Signature.getInstance(sigAlgo, getProviderName());
         verifying.initVerify(publicKey);
         verifying.update(message);
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestTruncatedDigest.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestTruncatedDigest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,14 +10,13 @@ package ibm.jceplus.junit.base;
 import java.security.AlgorithmParameters;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.security.Security;
 import java.security.Signature;
 import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.Test;
+import static org.junit.Assert.assertTrue;
 
 public class BaseTestTruncatedDigest extends BaseTestSignature {
-
 
     String IBM_ALG = "RSAPSS";
 
@@ -72,26 +71,18 @@ public class BaseTestTruncatedDigest extends BaseTestSignature {
     final int NONDEFAULT_PARAMS = 2;
     final int PARAMS_SALT40 = 3;
 
-
-    public BaseTestTruncatedDigest(String providerName) {
-        super(providerName);
-        Security.addProvider(new BouncyCastleProvider());
-    }
-
-    public void setUp() throws Exception {}
-
-
     /**
      * SHA512/224
      * @throws Exception
      */
+    @Test
     public void testRSASignatureSHA512_224() throws Exception {
 
 
         PSSParameterSpec pssParameter = new PSSParameterSpec("SHA-512", "MGF1",
                 MGF1ParameterSpec.SHA512, 64, 1);
         try {
-            dotestSignature(content, IBM_ALG, 2048, pssParameter, providerName);
+            dotestSignature(content, IBM_ALG, 2048, pssParameter, getProviderName());
         } catch (Exception e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
@@ -101,7 +92,7 @@ public class BaseTestTruncatedDigest extends BaseTestSignature {
         //         MGF1ParameterSpec.SHA512_224,28, 1);
         // try {
         //     dotestSignature(content, IBM_ALG, 2048, pssParameter2,
-        //             providerName);
+        //             getProviderName());
         // } catch (Exception e) {
         //     // TODO Auto-generated catch block
         //     e.printStackTrace();
@@ -112,7 +103,7 @@ public class BaseTestTruncatedDigest extends BaseTestSignature {
         // PSSParameterSpec pssParameter = new PSSParameterSpec("SHA-512", "MGF1",
         //         MGF1ParameterSpec.SHA512,64, 1);
         try {
-            dotestSignature(content, IBM_ALG, 2048, pssParameter3, providerName);
+            dotestSignature(content, IBM_ALG, 2048, pssParameter3, getProviderName());
 
         } catch (Exception e) {
             // TODO Auto-generated catch block
@@ -131,7 +122,7 @@ public class BaseTestTruncatedDigest extends BaseTestSignature {
     //             MGF1ParameterSpec.SHA512_256,20, 1);
     //     try {
     //         dotestSignature(content, IBM_ALG, 2048, pssParameter,
-    //                 providerName);
+    //                 getProviderName());
 
     //     } catch (Exception e) {
     //         // TODO Auto-generated catch block
@@ -151,7 +142,6 @@ public class BaseTestTruncatedDigest extends BaseTestSignature {
      * @param jceprovider
      * @throws Exception
      */
-
     protected void dotestSignature(byte[] content, String algorithm, int keySize,
             PSSParameterSpec pssParameterSpec, String jceprovider) throws Exception {
 
@@ -182,7 +172,7 @@ public class BaseTestTruncatedDigest extends BaseTestSignature {
 
         // Check Signature
         // Signature verifySig = Signature.getInstance("SHA1withRSA/PSS",
-        // providerName);
+        // getProviderName());
         // verifySig.initVerify(cert);
         // verifySig.update(content);
         boolean signatureVerified = sig.verify(sigBytes);

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -13,35 +13,18 @@ import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import org.junit.Before;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestMemStressDSASignature extends BaseTestSignature {
 
-    // --------------------------------------------------------------------------
-    //
-    //
     static final byte[] origMsg = "this is the original message to be signed".getBytes();
     int numTimes = 100;
     boolean printheapstats = false;
     String algo = "SHA256withDSA";
-    int keysize = 1024;
 
-    // --------------------------------------------------------------------------
-    //
-    //
-    public BaseTestMemStressDSASignature(String providerName) {
-        super(providerName);
-    }
-
-    public BaseTestMemStressDSASignature(String providerName, String algo, int keySize) {
-        super(providerName);
-        this.algo = algo;
-        this.keysize = keySize;
-
-    }
-
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Before
     public void setUp() throws Exception {
         String numTimesStr = System.getProperty("com.ibm.jceplus.memstress.numtimes");
         if (numTimesStr != null) {
@@ -49,22 +32,13 @@ public class BaseTestMemStressDSASignature extends BaseTestSignature {
         }
         printheapstats = Boolean
                 .valueOf(System.getProperty("com.ibm.jceplus.memstress.printheapstats"));
-        System.out.println("Testing DSASignature algorithm = " + this.algo + " keySize=" + keysize);
+        System.out.println("Testing DSASignature algorithm = " + this.algo + " keySize=" + getKeySize());
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
-    public void tearDown() throws Exception {}
-
-
-
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testSHAwithDSA() throws Exception {
         try {
-            KeyPair keyPair = generateKeyPair(this.keysize);
+            KeyPair keyPair = generateKeyPair(getKeySize());
             Runtime rt = Runtime.getRuntime();
             long prevTotalMemory = 0;
             long prevFreeMemory = rt.freeMemory();
@@ -91,7 +65,7 @@ public class BaseTestMemStressDSASignature extends BaseTestSignature {
                 }
             }
         } catch (InvalidParameterException | InvalidKeyException ipex) {
-            if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 assertTrue(true);
             } else {
                 assertTrue(false);
@@ -99,12 +73,8 @@ public class BaseTestMemStressDSASignature extends BaseTestSignature {
         }
     }
 
-
-    // --------------------------------------------------------------------------
-    //
-    //
     protected KeyPair generateKeyPair(int keysize) throws Exception {
-        KeyPairGenerator dsaKeyPairGen = KeyPairGenerator.getInstance("DSA", providerName);
+        KeyPairGenerator dsaKeyPairGen = KeyPairGenerator.getInstance("DSA", getProviderName());
         dsaKeyPairGen.initialize(keysize);
         return dsaKeyPairGen.generateKeyPair();
     }

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressECDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressECDSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,37 +10,20 @@ package ibm.jceplus.junit.base.memstress;
 import ibm.jceplus.junit.base.BaseTestSignature;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import org.junit.Before;
+import org.junit.jupiter.api.Test;
 
 public class BaseTestMemStressECDSASignature extends BaseTestSignature {
     int numTimes = 100;
     boolean printheapstats = false;
-    // --------------------------------------------------------------------------
-    //
-    //
+
     static final byte[] origMsg = "this is the original message to be signed".getBytes();
+
     String algo = "SHA256withECDSA";
+
     int curveSize = 256;
 
-
-    // --------------------------------------------------------------------------
-    //
-    //
-    public BaseTestMemStressECDSASignature(String providerName) {
-        super(providerName);
-    }
-
-    // --------------------------------------------------------------------------
-    //
-    //
-    public BaseTestMemStressECDSASignature(String providerName, String algo, int curveSize) {
-        super(providerName);
-        this.algo = algo;
-        this.curveSize = curveSize;
-    }
-
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Before
     public void setUp() throws Exception {
         String numTimesStr = System.getProperty("com.ibm.jceplus.memstress.numtimes");
         if (numTimesStr != null) {
@@ -51,14 +34,7 @@ public class BaseTestMemStressECDSASignature extends BaseTestSignature {
         System.out.println("Testing ECDSASignature");
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
-    public void tearDown() throws Exception {}
-
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testECDSA() throws Exception {
         KeyPair keyPair = generateKeyPair(this.curveSize);
         Runtime rt = Runtime.getRuntime();
@@ -89,12 +65,8 @@ public class BaseTestMemStressECDSASignature extends BaseTestSignature {
         }
     }
 
-
-    // --------------------------------------------------------------------------
-    //
-    //
     private KeyPair generateKeyPair(int keysize) throws Exception {
-        KeyPairGenerator ecKeyPairGen = KeyPairGenerator.getInstance("EC", providerName);
+        KeyPairGenerator ecKeyPairGen = KeyPairGenerator.getInstance("EC", getProviderName());
         ecKeyPairGen.initialize(keysize);
         return ecKeyPairGen.generateKeyPair();
     }

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressRSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressRSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -11,37 +11,17 @@ package ibm.jceplus.junit.base.memstress;
 import ibm.jceplus.junit.base.BaseTestSignature;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import org.junit.Before;
+import org.junit.jupiter.api.Test;
 
 public class BaseTestMemStressRSASignature extends BaseTestSignature {
 
-    //--------------------------------------------------------------------------
-    //
-    //
     static final byte[] origMsg = "this is the original message to be signed".getBytes();
     int numTimes = 100;
     boolean printheapstats = false;
     String algo = "SHA256withRSA";
-    int keysize = 1024;
 
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public BaseTestMemStressRSASignature(String providerName) {
-        super(providerName);
-    }
-
-    //
-    //
-    public BaseTestMemStressRSASignature(String providerName, String algo, int keysize) {
-        super(providerName);
-        this.algo = algo;
-        this.keysize = keysize;
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Before
     public void setUp() throws Exception {
         String numTimesStr = System.getProperty("com.ibm.jceplus.memstress.numtimes");
         if (numTimesStr != null) {
@@ -49,20 +29,12 @@ public class BaseTestMemStressRSASignature extends BaseTestSignature {
         }
         printheapstats = Boolean
                 .valueOf(System.getProperty("com.ibm.jceplus.memstress.printheapstats"));
-        System.out.println("Testing RSASignature algo=" + this.algo + " keysize=" + this.keysize);
+        System.out.println("Testing RSASignature algo=" + this.algo + " keysize=" + getKeySize());
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
-    public void tearDown() throws Exception {}
-
-
-    //--------------------------------------------------------------------------
-    //
-    //
+    @Test
     public void testRSASignature() throws Exception {
-        KeyPair keyPair = generateKeyPair(this.keysize);
+        KeyPair keyPair = generateKeyPair(getKeySize());
         Runtime rt = Runtime.getRuntime();
         long prevTotalMemory = 0;
         long prevFreeMemory = rt.freeMemory();
@@ -89,16 +61,10 @@ public class BaseTestMemStressRSASignature extends BaseTestSignature {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     protected KeyPair generateKeyPair(int keysize) throws Exception {
-        KeyPairGenerator rsaKeyPairGen = KeyPairGenerator.getInstance("RSA", providerName);
+        KeyPairGenerator rsaKeyPairGen = KeyPairGenerator.getInstance("RSA", getProviderName());
         rsaKeyPairGen.initialize(keysize);
         return rsaKeyPairGen.generateKeyPair();
     }
-
-
-
 }
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,14 +8,10 @@
 
 package ibm.jceplus.junit.openjceplus;
 
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestSuite;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({TestAES.class, TestAES_128.class, TestAES256Interop.class, TestAESCCM.class,
+@SelectClasses({TestAES.class, TestAES_128.class, TestAES256Interop.class, TestAESCCM.class,
         TestAESCCM2.class, TestAESCCMParameters.class, TestAESCCMInteropBC.class, TestAESGCM.class,
         TestAESGCMUpdate.class, TestAESGCMUpdateInteropBC.class, TestAESGCM_128.class,
         TestAESGCM_ExtIV.class, TestAESGCM_IntIV.class, TestAESGCMCipherInputStreamExceptions.class,
@@ -47,101 +43,8 @@ import org.junit.runners.Suite;
         TestSHA512_224.class, TestSHA512_256.class, TestSHA3_224.class, TestSHA3_256.class,
         TestSHA3_384.class, TestSHA3_512.class, TestRSAKeyInterop.class, TestRSAKeyInteropBC.class,
         TestXDH.class, TestXDHInterop.class, TestXDHInteropBC.class, TestXDHMultiParty.class,
-        TestXDHKeyPairGenerator.class, TestXDHKeyImport.class, TestIsAssignableFromOrder.class
+        TestXDHKeyPairGenerator.class, TestXDHKeyImport.class, TestIsAssignableFromOrder.class})
 
-})
-
+@Suite
 public class TestAll {
-
-    public static Test dynamic_suite() {
-        TestSuite suite = new TestSuite();
-        suite.addTest(new JUnit4TestAdapter(TestAES.class));
-        suite.addTest(new JUnit4TestAdapter(TestAES_128.class));
-        if (isCipherKeySizeSupported("AES", 192)) {
-            suite.addTest(new JUnit4TestAdapter(TestAES_192.class));
-        }
-        if (isCipherKeySizeSupported("AES", 256)) {
-            suite.addTest(new JUnit4TestAdapter(TestAES_256.class));
-        }
-
-        suite.addTest(new JUnit4TestAdapter(TestAESCCM.class));
-        suite.addTest(new JUnit4TestAdapter(TestAESCCM2.class));
-        suite.addTest(new JUnit4TestAdapter(TestAESCCMParameters.class));
-        suite.addTest(new JUnit4TestAdapter(TestAESCCMInteropBC.class));
-        suite.addTest(new JUnit4TestAdapter(TestAESGCM.class));
-        suite.addTest(new JUnit4TestAdapter(TestAESGCM_ExtIV.class));
-        suite.addTest(new JUnit4TestAdapter(TestAESGCM_IntIV.class));
-
-        suite.addTest(new JUnit4TestAdapter(TestAliases.class));
-
-        suite.addTest(new JUnit4TestAdapter(TestChaCha20.class));
-        suite.addTest(new JUnit4TestAdapter(TestChaCha20KAT.class));
-        suite.addTest(new JUnit4TestAdapter(TestChaCha20NoReuse.class));
-        suite.addTest(new JUnit4TestAdapter(TestChaCha20Poly1305.class));
-
-        suite.addTest(new JUnit4TestAdapter(TestDESede.class));
-
-        // suite.addTest(new JUnit4TestAdapter(TestDHKeyPairGenerator.class));
-        // suite.addTest(new JUnit4TestAdapter(TestDHMultiParty.class));
-
-        suite.addTest(new JUnit4TestAdapter(TestDSAKey.class));
-        suite.addTest(new JUnit4TestAdapter(TestDSASignature.class));
-
-
-        suite.addTest(new JUnit4TestAdapter(TestHmacMD5.class));
-        suite.addTest(new JUnit4TestAdapter(TestHmacMD5InteropSunJCE.class));
-        suite.addTest(new JUnit4TestAdapter(TestHmacSHA1.class));
-        suite.addTest(new JUnit4TestAdapter(TestHmacSHA1InteropSunJCE.class));
-        suite.addTest(new JUnit4TestAdapter(TestHmacSHA224.class));
-        suite.addTest(new JUnit4TestAdapter(TestHmacSHA224InteropSunJCE.class));
-        suite.addTest(new JUnit4TestAdapter(TestHmacSHA256.class));
-        suite.addTest(new JUnit4TestAdapter(TestHmacSHA256InteropSunJCE.class));
-        suite.addTest(new JUnit4TestAdapter(TestHmacSHA384.class));
-        suite.addTest(new JUnit4TestAdapter(TestHmacSHA384InteropSunJCE.class));
-        suite.addTest(new JUnit4TestAdapter(TestHmacSHA512.class));
-        suite.addTest(new JUnit4TestAdapter(TestHmacSHA512InteropSunJCE.class));
-
-        suite.addTest(new JUnit4TestAdapter(TestImplementationClassesExist.class));
-
-        suite.addTest(new JUnit4TestAdapter(TestMD5.class));
-
-        suite.addTest(new JUnit4TestAdapter(TestRSA.class));
-        suite.addTest(new JUnit4TestAdapter(TestRSAKey.class));
-        suite.addTest(new JUnit4TestAdapter(TestRSASignature.class));
-        suite.addTest(new JUnit4TestAdapter(TestRSASignatureInteropSunRsaSign.class));
-        suite.addTest(new JUnit4TestAdapter(TestRSATypeCheckDefault.class));
-        // suite.addTest(new JUnit4TestAdapter(TestRSAPSSSignature.class));
-
-        // // DO NOT ADD TO TEST SUITE, run separately
-        // suite.addTest(new JUnit4TestAdapter(TestRSATypeCheckDisabled.class));
-
-        // // DO NOT ADD TO TEST SUITE, run separately
-        // suite.addTest(new JUnit4TestAdapter(TestRSATypeCheckEnabled.class));
-
-        suite.addTest(new JUnit4TestAdapter(TestSHA1.class));
-        suite.addTest(new JUnit4TestAdapter(TestSHA224.class));
-        suite.addTest(new JUnit4TestAdapter(TestSHA256.class));
-        suite.addTest(new JUnit4TestAdapter(TestSHA384.class));
-        suite.addTest(new JUnit4TestAdapter(TestSHA512.class));
-        suite.addTest(new JUnit4TestAdapter(TestSHA512_224.class));
-        suite.addTest(new JUnit4TestAdapter(TestSHA512_256.class));
-        return suite;
-    }
-
-    public static Test suite() {
-        return new JUnit4TestAdapter(TestAll.class);
-    }
-
-    public static void main(String[] args) {
-        junit.textui.TestRunner.run(suite());
-    }
-
-    private static boolean isCipherKeySizeSupported(String algorithm, int keySize) {
-        try {
-            return javax.crypto.Cipher.getMaxAllowedKeyLength(algorithm) >= keySize;
-        } catch (Exception e) {
-        }
-        return false;
-    }
-
 }

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestDSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -7,39 +7,17 @@
  */
 
 package ibm.jceplus.junit.openjceplus;
+import ibm.jceplus.junit.base.BaseTestDSASignature;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestDSASignature extends BaseTestDSASignature {
 
-public class TestDSASignature extends ibm.jceplus.junit.base.BaseTestDSASignature {
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    static {
+    @BeforeAll
+    public void beforeAll() {
         Utils.loadProviderTestSuite();
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public TestDSASignature() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME);
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static void main(String[] args) throws Exception {
-        junit.textui.TestRunner.run(suite());
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static Test suite() {
-        TestSuite suite = new TestSuite(TestDSASignature.class);
-        return suite;
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
     }
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestECDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestECDSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,38 +8,17 @@
 
 package ibm.jceplus.junit.openjceplus;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import ibm.jceplus.junit.base.BaseTestECDSASignature;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
-public class TestECDSASignature extends ibm.jceplus.junit.base.BaseTestECDSASignature {
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestECDSASignature extends BaseTestECDSASignature {
 
-    //--------------------------------------------------------------------------
-    //
-    //
-    static {
+    @BeforeAll
+    public void beforeAll() {
         Utils.loadProviderTestSuite();
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public TestECDSASignature() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME);
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static void main(String[] args) throws Exception {
-        junit.textui.TestRunner.run(suite());
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static Test suite() {
-        TestSuite suite = new TestSuite(TestECDSASignature.class);
-        return suite;
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
     }
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAPSSSignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAPSSSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -7,39 +7,17 @@
  */
 
 package ibm.jceplus.junit.openjceplus;
+import ibm.jceplus.junit.base.BaseTestRSAPSSSignature;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestRSAPSSSignature extends BaseTestRSAPSSSignature {
 
-public class TestRSAPSSSignature extends ibm.jceplus.junit.base.BaseTestRSAPSSSignature {
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    static {
+    @BeforeAll
+    public void beforeAll() {
         Utils.loadProviderTestSuite();
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public TestRSAPSSSignature() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME);
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static void main(String[] args) throws Exception {
-        junit.textui.TestRunner.run(suite());
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static Test suite() {
-        TestSuite suite = new TestSuite(TestRSAPSSSignature.class);
-        return suite;
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
     }
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,38 +8,18 @@
 
 package ibm.jceplus.junit.openjceplus;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import ibm.jceplus.junit.base.BaseTestRSASignature;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
-public class TestRSASignature extends ibm.jceplus.junit.base.BaseTestRSASignature {
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestRSASignature extends BaseTestRSASignature {
 
-    //--------------------------------------------------------------------------
-    //
-    //
-    static {
+    @BeforeAll
+    public void beforeAll() {
         Utils.loadProviderTestSuite();
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public TestRSASignature() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME);
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static void main(String[] args) throws Exception {
-        junit.textui.TestRunner.run(suite());
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static Test suite() {
-        TestSuite suite = new TestSuite(TestRSASignature.class);
-        return suite;
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
+        setKeySize(1024);
     }
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSASignatureChunkUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSASignatureChunkUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -7,28 +7,17 @@
  */
 
 package ibm.jceplus.junit.openjceplus;
+import ibm.jceplus.junit.base.BaseTestRSASignatureChunkUpdate;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestRSASignatureChunkUpdate extends BaseTestRSASignatureChunkUpdate {
 
-public class TestRSASignatureChunkUpdate
-        extends ibm.jceplus.junit.base.BaseTestRSASignatureChunkUpdate {
-
-    static {
+    @BeforeAll
+    public void beforeAll() {
         Utils.loadProviderTestSuite();
-    }
-
-    public TestRSASignatureChunkUpdate() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME);
-    }
-
-    public static void main(String[] args) throws Exception {
-        junit.textui.TestRunner.run(suite());
-    }
-
-    public static Test suite() {
-        TestSuite suite = new TestSuite(
-                ibm.jceplus.junit.openjceplus.TestRSASignatureChunkUpdate.class);
-        return suite;
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
     }
 }

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestTruncatedDigest.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestTruncatedDigest.java
@@ -1,44 +1,22 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
  * in the file LICENSE in the source distribution.
  */
+
 package ibm.jceplus.junit.openjceplus;
+import ibm.jceplus.junit.base.BaseTestTruncatedDigest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
-
-public class TestTruncatedDigest extends ibm.jceplus.junit.base.BaseTestTruncatedDigest {
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    static {
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestTruncatedDigest extends BaseTestTruncatedDigest {
+    @BeforeAll
+    public void beforeAll() {
         Utils.loadProviderTestSuite();
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public TestTruncatedDigest() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME);
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static void main(String[] args) throws Exception {
-        junit.textui.TestRunner.run(suite());
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static Test suite() {
-        TestSuite suite = new TestSuite(TestTruncatedDigest.class);
-        return suite;
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
     }
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplus/integration/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/integration/TestAll.java
@@ -7,11 +7,11 @@
  */
 package ibm.jceplus.junit.openjceplus.integration;
 
-import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
+@SelectPackages({"ibm.jceplus.junit.openjceplus.integration"})
+
 @Suite
-@SelectClasses({TestTLS.class})
 public class TestAll {
-    
 }

--- a/src/test/java/ibm/jceplus/junit/openjceplus/integration/TestTLS.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/integration/TestTLS.java
@@ -8,20 +8,31 @@
 package ibm.jceplus.junit.openjceplus.integration;
 
 import ibm.jceplus.junit.base.integration.BaseTestTLS;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 public class TestTLS extends BaseTestTLS {
 
+    private static boolean insertProviderUponCleanup = false;
+
     @BeforeAll
     public static void init() throws Exception{
         if (java.security.Security.getProvider("OpenJCEPlusFIPS") != null) {
+            insertProviderUponCleanup = true;
             java.security.Security.removeProvider("OpenJCEPlusFIPS");
         }
         insertProvider("OpenJCEPlus", "com.ibm.crypto.plus.provider.OpenJCEPlus", 1);
     }
-    
+
+    @AfterAll
+    public static void cleanup() throws Exception {
+        if (insertProviderUponCleanup) {
+            insertProvider("OpenJCEPlusFIPS", "com.ibm.crypto.plus.provider.OpenJCEPlusFIPS", 2);
+        }
+    }
+
     @ParameterizedTest
     @CsvSource({"TLSv1.3,rsa_pkcs1_sha1,TLS_AES_128_GCM_SHA256",
         "TLSv1.3,rsa_pkcs1_sha256,TLS_AES_128_GCM_SHA256",

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressAll.java
@@ -8,43 +8,18 @@
 
 package ibm.jceplus.junit.openjceplus.memstress;
 
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestSuite;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({TestMemStressAES256.class, TestMemStressAESGCM.class,
-        TestMemStressChaChaPoly1305.class, TestMemStressDH.class, TestMemStressDHKeyPair.class,
-        TestMemStressDHKeyFactory.class, TestMemStressDSASignature.class,
-        TestMemStressDSAKeyPair.class, TestMemStressDSAKeyFactory.class,
-        TestMemStressECKeyPair.class, TestMemStressECKeyFactory.class,
-        TestMemStressECDSASignature.class, TestMemStressHKDF.class, TestMemStressHmacSHA256.class,
-        TestMemStressRSAPSS2.class, TestMemStressRSASignature.class, TestMemStressSHA256.class,
-        TestMemStressXDH_X25519.class, TestMemStressXDH_X448.class})
+@SelectClasses({TestMemStressAES256.class, TestMemStressAESGCM.class,
+                TestMemStressChaChaPoly1305.class, TestMemStressDH.class, TestMemStressDHKeyPair.class,
+                TestMemStressDHKeyFactory.class, TestMemStressDSASignature.class,
+                TestMemStressDSAKeyPair.class, TestMemStressDSAKeyFactory.class,
+                TestMemStressECKeyPair.class, TestMemStressECKeyFactory.class,
+                TestMemStressECDSASignature.class, TestMemStressHKDF.class, TestMemStressHmacSHA256.class,
+                TestMemStressRSAPSS2.class, TestMemStressRSASignature.class, TestMemStressSHA256.class,
+                TestMemStressXDH_X25519.class, TestMemStressXDH_X448.class})
 
+@Suite
 public class TestMemStressAll {
-
-    public static Test dynamic_suite() {
-        TestSuite suite = new TestSuite();
-        return suite;
-    }
-
-    public static Test suite() {
-        return new JUnit4TestAdapter(TestMemStressAll.class);
-    }
-
-    public static void main(String[] args) {
-        junit.textui.TestRunner.run(suite());
-    }
-
-    //    private static boolean isCipherKeySizeSupported(String algorithm, int keySize) {
-    //        try {
-    //            return javax.crypto.Cipher.getMaxAllowedKeyLength(algorithm) >= keySize;
-    //        } catch (Exception e) {
-    //        }
-    //        return false;
-    //    }
-
 }

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressDSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,39 +10,19 @@ package ibm.jceplus.junit.openjceplus.memstress;
 
 import ibm.jceplus.junit.base.memstress.BaseTestMemStressDSASignature;
 import ibm.jceplus.junit.openjceplus.Utils;
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TestMemStressDSASignature extends BaseTestMemStressDSASignature {
 
-    //--------------------------------------------------------------------------
-    //
-    //
-    static {
+    @BeforeAll
+    public void beforeAll() {
         Utils.loadProviderTestSuite();
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public TestMemStressDSASignature() {
-
-        super(Utils.TEST_SUITE_PROVIDER_NAME, "SHA256withDSA", 1024);
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static void main(String[] args) throws Exception {
-        junit.textui.TestRunner.run(suite());
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static Test suite() {
-        TestSuite suite = new TestSuite(TestMemStressDSASignature.class);
-        return suite;
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
+        setAlgorithm("SHA256withDSA");
+        setKeySize(1024);
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressECDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressECDSASignature.java
@@ -1,48 +1,26 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
  * in the file LICENSE in the source distribution.
  */
-
 package ibm.jceplus.junit.openjceplus.memstress;
 
 import ibm.jceplus.junit.base.memstress.BaseTestMemStressECDSASignature;
 import ibm.jceplus.junit.openjceplus.Utils;
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TestMemStressECDSASignature extends BaseTestMemStressECDSASignature {
 
-    //--------------------------------------------------------------------------
-    //
-    //
-    static {
+    @BeforeAll
+    public void beforeAll() {
         Utils.loadProviderTestSuite();
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public TestMemStressECDSASignature() {
-
-        super(Utils.TEST_SUITE_PROVIDER_NAME, "SHA256withECDSA", 256);
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static void main(String[] args) throws Exception {
-        junit.textui.TestRunner.run(suite());
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static Test suite() {
-        TestSuite suite = new TestSuite(TestMemStressECDSASignature.class);
-        return suite;
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
+        setAlgorithm("SHA256withECDSA");
+        setKeySize(256);
     }
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressRSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressRSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,39 +10,18 @@ package ibm.jceplus.junit.openjceplus.memstress;
 
 import ibm.jceplus.junit.base.memstress.BaseTestMemStressRSASignature;
 import ibm.jceplus.junit.openjceplus.Utils;
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TestMemStressRSASignature extends BaseTestMemStressRSASignature {
 
-    //--------------------------------------------------------------------------
-    //
-    //
-    static {
+    @BeforeAll
+    public void beforeAll() {
         Utils.loadProviderTestSuite();
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public TestMemStressRSASignature() {
-
-        super(Utils.TEST_SUITE_PROVIDER_NAME, "SHA256withRSA", 1024);
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static void main(String[] args) throws Exception {
-        junit.textui.TestRunner.run(suite());
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static Test suite() {
-        TestSuite suite = new TestSuite(TestMemStressRSASignature.class);
-        return suite;
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
+        setAlgorithm("SHA256withRSA");
+        setKeySize(1024);
     }
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestECDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestECDSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,40 +10,16 @@ package ibm.jceplus.junit.openjceplus.multithread;
 
 import ibm.jceplus.junit.base.BaseTestECDSASignature;
 import ibm.jceplus.junit.openjceplus.Utils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TestECDSASignature extends BaseTestECDSASignature {
 
-    // --------------------------------------------------------------------------
-    //
-    //
-    static {
+    @BeforeAll
+    public void beforeAll() {
         Utils.loadProviderTestSuite();
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
     }
-
-    // --------------------------------------------------------------------------
-    //
-    //
-    public TestECDSASignature() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME);
-    }
-
-    // --------------------------------------------------------------------------
-    //
-    //
-    public static void main(String[] args) throws Exception {
-        String[] nargs = {
-                ibm.jceplus.junit.openjceplus.multithread.TestECDSASignature.class.getName()};
-        junit.textui.TestRunner.main(nargs);
-    }
-
-    // --------------------------------------------------------------------------
-    //
-    //
-    public void testECDSASignature() throws Exception {
-        System.out.println("executing testECDSASignature");
-        BaseTestECDSASignature bt = new BaseTestECDSASignature(providerName);
-        bt.run();
-    }
-
-
 }

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestRSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestRSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,38 +10,17 @@ package ibm.jceplus.junit.openjceplus.multithread;
 
 import ibm.jceplus.junit.base.BaseTestRSASignature;
 import ibm.jceplus.junit.openjceplus.Utils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TestRSASignature extends BaseTestRSASignature {
 
-    //--------------------------------------------------------------------------
-    //
-    //
-    static {
+    @BeforeAll
+    public void beforeAll() {
         Utils.loadProviderTestSuite();
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
+        setKeySize(1024);
     }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public TestRSASignature() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME);
-    }
-
-    public void testRSASignature() throws Exception {
-        System.out.println("executing testRSASignature");
-        BaseTestRSASignature bt = new BaseTestRSASignature(providerName);
-        bt.run();
-
-    }
-
-    public static void main(String[] args) {
-        String[] nargs = {
-                ibm.jceplus.junit.openjceplus.multithread.TestRSASignature.class.getName()};
-        junit.textui.TestRunner.main(nargs);
-    }
-    //--------------------------------------------------------------------------
-    //
-    //
-
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAll.java
@@ -8,13 +8,10 @@
 
 package ibm.jceplus.junit.openjceplusfips;
 
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({TestAES.class, TestAES_128.class, TestAES256Interop.class, TestAESCCM.class,
+@SelectClasses({TestAES.class, TestAES_128.class, TestAES256Interop.class, TestAESCCM.class,
         TestAESCCM2.class, TestAESCCMParameters.class, TestAESCCMInteropBC.class, TestAESGCM.class,
         TestAESGCMUpdate.class, TestAESGCM_128.class, TestAESGCM_ExtIV.class,
         TestAESGCM_IntIV.class, TestAESGCMCipherInputStreamExceptions.class,
@@ -41,15 +38,6 @@ import org.junit.runners.Suite;
         TestRSAKeyInterop.class, TestRSAKeyInteropBC.class, TestRSAPSS2.class,
         TestFIPSVerifyOnlyTest.class, TestRSASignatureWithSpecificSize.class})
 
+@Suite
 public class TestAll {
-
-    public static Test suite() {
-        return new JUnit4TestAdapter(TestAll.class);
-    }
-
-    public static void main(String[] args) {
-        junit.textui.TestRunner.run(suite());
-    }
-
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -7,39 +7,17 @@
  */
 
 package ibm.jceplus.junit.openjceplusfips;
+import ibm.jceplus.junit.base.BaseTestDSASignature;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestDSASignature extends BaseTestDSASignature {
 
-public class TestDSASignature extends ibm.jceplus.junit.base.BaseTestDSASignature {
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    static {
+    @BeforeAll
+    public void beforeAll() {
         Utils.loadProviderTestSuite();
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public TestDSASignature() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME);
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static void main(String[] args) throws Exception {
-        junit.textui.TestRunner.run(suite());
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static Test suite() {
-        TestSuite suite = new TestSuite(TestDSASignature.class);
-        return suite;
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
     }
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECDSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,38 +8,17 @@
 
 package ibm.jceplus.junit.openjceplusfips;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import ibm.jceplus.junit.base.BaseTestECDSASignature;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
-public class TestECDSASignature extends ibm.jceplus.junit.base.BaseTestECDSASignature {
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestECDSASignature extends BaseTestECDSASignature {
 
-    //--------------------------------------------------------------------------
-    //
-    //
-    static {
+    @BeforeAll
+    public void beforeAll() {
         Utils.loadProviderTestSuite();
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public TestECDSASignature() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME);
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static void main(String[] args) throws Exception {
-        junit.textui.TestRunner.run(suite());
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static Test suite() {
-        TestSuite suite = new TestSuite(TestECDSASignature.class);
-        return suite;
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
     }
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,38 +8,17 @@
 
 package ibm.jceplus.junit.openjceplusfips;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import ibm.jceplus.junit.base.BaseTestRSASignature;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
-public class TestRSASignature extends ibm.jceplus.junit.base.BaseTestRSASignature {
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    static {
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestRSASignature extends BaseTestRSASignature {
+    @BeforeAll
+    public void beforeAll() {
         Utils.loadProviderTestSuite();
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public TestRSASignature() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME, 2048);
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static void main(String[] args) throws Exception {
-        junit.textui.TestRunner.run(suite());
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static Test suite() {
-        TestSuite suite = new TestSuite(TestRSASignature.class);
-        return suite;
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
+        setKeySize(2048);
     }
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSASignatureChunkUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSASignatureChunkUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -7,26 +7,17 @@
  */
 package ibm.jceplus.junit.openjceplusfips;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import ibm.jceplus.junit.base.BaseTestRSASignatureChunkUpdate;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
-public class TestRSASignatureChunkUpdate
-        extends ibm.jceplus.junit.base.BaseTestRSASignatureChunkUpdate {
-    static {
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestRSASignatureChunkUpdate extends BaseTestRSASignatureChunkUpdate {
+
+    @BeforeAll
+    public void beforeAll() {
         Utils.loadProviderTestSuite();
-    }
-
-    public TestRSASignatureChunkUpdate() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME);
-    }
-
-    public static void main(String[] args) throws Exception {
-        junit.textui.TestRunner.run(suite());
-    }
-
-    public static Test suite() {
-        TestSuite suite = new TestSuite(
-                ibm.jceplus.junit.openjceplusfips.TestRSASignatureChunkUpdate.class);
-        return suite;
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
     }
 }

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSASignatureWithSpecificSize.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSASignatureWithSpecificSize.java
@@ -7,36 +7,36 @@
  */
 package ibm.jceplus.junit.openjceplusfips;
 
+import ibm.jceplus.junit.base.BaseTestJunit5;
 import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-public class TestRSASignatureWithSpecificSize extends ibm.jceplus.junit.base.BaseTest {
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestRSASignatureWithSpecificSize extends BaseTestJunit5 { 
 
-    //--------------------------------------------------------------------------
-    //
-    //
     static final byte[] origMsg = "this is the original message to be signed I changed to a very long message to make sure enough bytes are there for copying."
             .getBytes();
 
-    static {
+    @BeforeAll
+    public void beforeAll() {
         Utils.loadProviderTestSuite();
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
-    public TestRSASignatureWithSpecificSize() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME);
-    }
-
-    // RSA signature sign allows at least 2048 bits of RSA key to be used for sign a signature.
-    public byte[] doSign(String sigAlgo, byte[] message, PrivateKey privateKey) throws Exception {
+    /**
+     * RSA signature sign allows at least 2048 bits of RSA key to be used for sign a signature.
+     */
+    private byte[] doSign(String sigAlgo, byte[] message, PrivateKey privateKey) throws Exception {
         Signature sign = Signature.getInstance(sigAlgo, Utils.TEST_SUITE_PROVIDER_NAME);
         try {
             sign.initSign(privateKey);
@@ -60,7 +60,7 @@ public class TestRSASignatureWithSpecificSize extends ibm.jceplus.junit.base.Bas
     }
 
     // RSA signature verify allows at least 2048 bits of RSA key to be used for sign a signature.
-    public void doVerify(String sigAlgo, byte[] message, PublicKey publicKey, 
+    private void doVerify(String sigAlgo, byte[] message, PublicKey publicKey, 
             byte[] signedBytes) throws Exception {
         Signature verify = Signature.getInstance(sigAlgo, Utils.TEST_SUITE_PROVIDER_NAME);
         try {
@@ -87,13 +87,20 @@ public class TestRSASignatureWithSpecificSize extends ibm.jceplus.junit.base.Bas
         }
     }
 
-    // Use a non FIPS provider to get a 1024 bits of RSA key.
-    public KeyPair generateKeyPair(int keysize) throws Exception {
+    /**
+     * Use a non FIPS provider to get a 1024 bits of RSA key.
+     * 
+     * @param keysize
+     * @return
+     * @throws Exception
+     */
+    private KeyPair generateKeyPair(int keysize) throws Exception {
         KeyPairGenerator rsaKeyPairGen = KeyPairGenerator.getInstance("RSA", Utils.PROVIDER_SunRsaSign);
         rsaKeyPairGen.initialize(keysize);
         return rsaKeyPairGen.generateKeyPair();
     }
 
+    @Test
     public void testSHA256withRSA_1024() throws Exception {
         KeyPair keyPair = generateKeyPair(1024);
         System.out.println("Keysize is 1024");
@@ -101,6 +108,7 @@ public class TestRSASignatureWithSpecificSize extends ibm.jceplus.junit.base.Bas
         doVerify("SHA256withRSA", origMsg, keyPair.getPublic(), signedBytes);
     }
 
+    @Test
     public void testSHA256withRSA_2048() throws Exception {
         KeyPair keyPair = generateKeyPair(2048);
         System.out.println("Keysize is 2048");
@@ -108,6 +116,7 @@ public class TestRSASignatureWithSpecificSize extends ibm.jceplus.junit.base.Bas
         doVerify("SHA256withRSA", origMsg, keyPair.getPublic(), signedBytes);
     }
 
+    @Test
     public void testSHA256withRSA_3072() throws Exception {
         KeyPair keyPair = generateKeyPair(3072);
         System.out.println("Keysize is 3072");
@@ -115,6 +124,7 @@ public class TestRSASignatureWithSpecificSize extends ibm.jceplus.junit.base.Bas
         doVerify("SHA256withRSA", origMsg, keyPair.getPublic(), signedBytes);
     }
 
+    @Test
     public void testSHA256withRSA_4096() throws Exception {
         KeyPair keyPair = generateKeyPair(4096);
         System.out.println("Keysize is 4096");
@@ -122,7 +132,12 @@ public class TestRSASignatureWithSpecificSize extends ibm.jceplus.junit.base.Bas
         doVerify("SHA256withRSA", origMsg, keyPair.getPublic(), signedBytes);
     }
 
-    // check large size
+    /**
+     * Check large size
+     * 
+     * @throws Exception
+     */
+    @Test
     public void testSHA256withRSA_5120() throws Exception {
         KeyPair keyPair = generateKeyPair(5120);
         System.out.println("Keysize is 5120");
@@ -130,7 +145,12 @@ public class TestRSASignatureWithSpecificSize extends ibm.jceplus.junit.base.Bas
         doVerify("SHA256withRSA", origMsg, keyPair.getPublic(), signedBytes);
     }
 
-    // check small size
+    /**
+     * Check small size
+     * 
+     * @throws Exception
+     */
+    @Test
     public void testSHA256withRSA_512() throws Exception {
         KeyPair keyPair = generateKeyPair(512);
         System.out.println("Keysize is 512");
@@ -138,7 +158,12 @@ public class TestRSASignatureWithSpecificSize extends ibm.jceplus.junit.base.Bas
         doVerify("SHA256withRSA", origMsg, keyPair.getPublic(), signedBytes);
     }
 
-    // check size not in the list
+    /**
+     * Check size not in the list
+     * 
+     * @throws Exception
+     */
+    @Test
     public void testSHA256withRSA_1032() throws Exception {
         KeyPair keyPair = generateKeyPair(1032);
         System.out.println("Keysize is 1032");
@@ -146,26 +171,16 @@ public class TestRSASignatureWithSpecificSize extends ibm.jceplus.junit.base.Bas
         doVerify("SHA256withRSA", origMsg, keyPair.getPublic(), signedBytes);
     }
 
-    // check size not in the list
+    /**
+     * Check size not in the list
+     * 
+     * @throws Exception
+     */
+    @Test
     public void testSHA256withRSA_2056() throws Exception {
         KeyPair keyPair = generateKeyPair(2056);
         System.out.println("keysize is 2056");
         byte[] signedBytes = doSign("SHA256withRSA", origMsg, keyPair.getPrivate());
         doVerify("SHA256withRSA", origMsg, keyPair.getPublic(), signedBytes);
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static void main(String[] args) throws Exception {
-        junit.textui.TestRunner.run(suite());
-    }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static Test suite() {
-        TestSuite suite = new TestSuite(TestRSASignatureWithSpecificSize.class);
-        return suite;
     }
 }

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/integration/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/integration/TestAll.java
@@ -7,10 +7,11 @@
  */
 package ibm.jceplus.junit.openjceplusfips.integration;
 
-import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
+@SelectPackages({"ibm.jceplus.junit.openjceplusfips.integration"})
+
 @Suite
-@SelectClasses({TestTLS.class})
 public class TestAll {
 }

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/integration/TestTLS.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/integration/TestTLS.java
@@ -8,18 +8,29 @@
 package ibm.jceplus.junit.openjceplusfips.integration;
 
 import ibm.jceplus.junit.base.integration.BaseTestTLS;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-public class TestTLS extends BaseTestTLS{
+public class TestTLS extends BaseTestTLS {
+
+    private static boolean insertProviderUponCleanup = false;
 
     @BeforeAll
     public static void init() throws Exception {
         if (java.security.Security.getProvider("OpenJCEPlus") != null) {
+            insertProviderUponCleanup = true;
             java.security.Security.removeProvider("OpenJCEPlus");
         }
         insertProvider("OpenJCEPlusFIPS", "com.ibm.crypto.plus.provider.OpenJCEPlusFIPS", 1);
+    }
+
+    @AfterAll
+    public static void cleanup() throws Exception {
+        if (insertProviderUponCleanup) {
+            insertProvider("OpenJCEPlus", "com.ibm.crypto.plus.provider.OpenJCEPlus", 2);
+        }
     }
     
     @ParameterizedTest

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestECDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestECDSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,40 +10,16 @@ package ibm.jceplus.junit.openjceplusfips.multithread;
 
 import ibm.jceplus.junit.base.BaseTestECDSASignature;
 import ibm.jceplus.junit.openjceplusfips.Utils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TestECDSASignature extends BaseTestECDSASignature {
 
-    // --------------------------------------------------------------------------
-    //
-    //
-    static {
+    @BeforeAll
+    public void beforeAll() {
         Utils.loadProviderTestSuite();
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
     }
-
-    // --------------------------------------------------------------------------
-    //
-    //
-    public TestECDSASignature() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME);
-    }
-
-    // --------------------------------------------------------------------------
-    //
-    //
-    public static void main(String[] args) throws Exception {
-        String[] nargs = {
-                ibm.jceplus.junit.openjceplusfips.multithread.TestECDSASignature.class.getName()};
-        junit.textui.TestRunner.main(nargs);
-    }
-
-    // --------------------------------------------------------------------------
-    //
-    //
-    public void testECDSASignature() throws Exception {
-        System.out.println("executing testECDSASignature");
-        BaseTestECDSASignature bt = new BaseTestECDSASignature(providerName);
-        bt.run();
-    }
-
-
 }

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,38 +10,17 @@ package ibm.jceplus.junit.openjceplusfips.multithread;
 
 import ibm.jceplus.junit.base.BaseTestRSASignature;
 import ibm.jceplus.junit.openjceplusfips.Utils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TestRSASignature extends BaseTestRSASignature {
 
-    //--------------------------------------------------------------------------
-    //
-    //
-    static {
+    @BeforeAll
+    public void beforeAll() {
         Utils.loadProviderTestSuite();
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
+        setKeySize(2048);
     }
-
-    //--------------------------------------------------------------------------
-    //
-    //
-    public TestRSASignature() {
-        super(Utils.TEST_SUITE_PROVIDER_NAME, 2048);
-    }
-
-    public void testRSASignature() throws Exception {
-        System.out.println("executing testRSASignature");
-        BaseTestRSASignature bt = new BaseTestRSASignature(providerName);
-        bt.run();
-
-    }
-
-    public static void main(String[] args) {
-        String[] nargs = {
-                ibm.jceplus.junit.openjceplusfips.multithread.TestRSASignature.class.getName()};
-        junit.textui.TestRunner.main(nargs);
-    }
-    //--------------------------------------------------------------------------
-    //
-    //
-
 }
-


### PR DESCRIPTION
This update migrates a portion of the tests associated with signatures to Junit5 format. Updates include:
- A new BaseTestJunit5 class is provided that tests can extend in this update and in the future.
- Main methods in individual tests were present inconsistently through the test code and have been removed given that individual tests can be executed directly via mvn surefire or other Junit5 runners.
- Constructors for various tests have also been removed since they are not in use.
- The `TestTLS` was found to impact other tests depending on the order tests are run. If the `OpenJCEPlus` provider is present when running `OpenJCEPlusFIPS` related tests then it is removed, then restored after the test is run. A similar pattern is followed when executing a similar test with `OpenJCEPlus`.
- A few methods were found to be private and should not be declared as public.
- Most tests are currently written to expect a single instance of a given test for each @Test method specified. By default this is not the behavior in Junit5. This update tags various tests with @TestInstance of Lifecycle.PER_CLASS. This tells JUnit to create only one instance of the test class and then reuse it between tests tagged with @Test.
- `static` blocks are often replaced with `@BeforeAll` syntax executed when a test is constructed.
- The higher level test suite classes were modified to also use junit5 syntax ( `@SelectClasses` and `@Suite`).
- Empty comment blocks have been removed as they have no value.
- Mulithreaded test case drivers have been modified to use new Junit5 launchers to launch test classes contained in
`org.junit.platform.launcher package`.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>

