### PR TITLE
Update github action build to use Semeru 23

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Setup Semeru JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '22.0.1+8'
+          java-version: '23.0.0+37'
           distribution: 'semeru'
           architecture: 'x64'
       # Uncomment to capture all files in the runner for debugging purposes.          


### PR DESCRIPTION
Semeru Java 23 is now generally available. The `main` and `java23` branches be updated accordingly.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>
