### PR TITLE
Update multithreaded tests

### DIFF
--- a/src/test/java/ibm/jceplus/junit/TestMultithread.java
+++ b/src/test/java/ibm/jceplus/junit/TestMultithread.java
@@ -16,9 +16,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import junit.framework.Test;
 import junit.framework.TestCase;
-import junit.framework.TestSuite;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
@@ -29,37 +27,51 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
 
 public class TestMultithread extends TestCase {
     private final int numThreads = 10;
-    private final int timeoutSec = 1500;
+    private final int timeoutSec = 3000;
     private final String[] testList = {
-            "ibm.jceplus.junit.openjceplus.multithread.TestAliases",
-            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCMUpdate",
-            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCMCopySafe",
-            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCMCipherInputStreamExceptions",
-            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCMCICOWithGCM",
-            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCMSameBuffer",
-            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCMWithByteBuffer",
-            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCMLong",
-            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCM_128",
-            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCM_192",
-            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCM_256",
-            "ibm.jceplus.junit.openjceplus.multithread.TestDH",
-            "ibm.jceplus.junit.openjceplus.multithread.TestECDH",
-            "ibm.jceplus.junit.openjceplus.multithread.TestECDHInteropSunEC",
-            "ibm.jceplus.junit.openjceplus.multithread.TestDSAKey",
             "ibm.jceplus.junit.openjceplus.multithread.TestAES_128",
             "ibm.jceplus.junit.openjceplus.multithread.TestAES_192",
             "ibm.jceplus.junit.openjceplus.multithread.TestAES_256",
+            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCM_128",
+            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCM_192",
+            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCM_256",
+            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCMCICOWithGCM",
+            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCMCICOWithGCMAndAAD",
+            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCMCipherInputStreamExceptions",
+            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCMCopySafe",
+            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCMLong",
+            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCMNonExpanding",
+            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCMSameBuffer",
+            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCMUpdate",
+            "ibm.jceplus.junit.openjceplus.multithread.TestAESGCMWithByteBuffer",
+            "ibm.jceplus.junit.openjceplus.multithread.TestAliases",
             "ibm.jceplus.junit.openjceplus.multithread.TestDESede",
-            "ibm.jceplus.junit.openjceplus.multithread.TestECDSASignature",
+            "ibm.jceplus.junit.openjceplus.multithread.TestDH",
+            "ibm.jceplus.junit.openjceplus.multithread.TestDSAKey",
             "ibm.jceplus.junit.openjceplus.multithread.TestDSASignatureInteropSUN",
+            "ibm.jceplus.junit.openjceplus.multithread.TestECDH",
+            "ibm.jceplus.junit.openjceplus.multithread.TestECDHInteropSunEC",
+            "ibm.jceplus.junit.openjceplus.multithread.TestECDSASignature",
+            "ibm.jceplus.junit.openjceplus.multithread.TestEdDSASignature",
+            "ibm.jceplus.junit.openjceplus.multithread.TestHKDF",
             "ibm.jceplus.junit.openjceplus.multithread.TestHmacMD5",
             "ibm.jceplus.junit.openjceplus.multithread.TestHmacMD5InteropSunJCE",
             "ibm.jceplus.junit.openjceplus.multithread.TestHmacSHA256",
+            "ibm.jceplus.junit.openjceplus.multithread.TestHmacSHA256InteropSunJCE",
             "ibm.jceplus.junit.openjceplus.multithread.TestHmacSHA3_224",
             "ibm.jceplus.junit.openjceplus.multithread.TestHmacSHA3_256",
             "ibm.jceplus.junit.openjceplus.multithread.TestHmacSHA3_384",
             "ibm.jceplus.junit.openjceplus.multithread.TestHmacSHA3_512",
-            "ibm.jceplus.junit.openjceplus.multithread.TestHmacSHA256InteropSunJCE",
+            "ibm.jceplus.junit.openjceplus.multithread.TestMiniRSAPSS2",
+            "ibm.jceplus.junit.openjceplus.multithread.TestRSASignature",
+            "ibm.jceplus.junit.openjceplus.multithread.TestRSA_2048",
+            "ibm.jceplus.junit.openjceplus.multithread.TestRSAKey",
+            "ibm.jceplus.junit.openjceplus.multithread.TestRSAPSS",
+            "ibm.jceplus.junit.openjceplus.multithread.TestRSAPSS2",
+            //"ibm.jceplus.junit.openjceplus.multithread.TestRSAPSSInterop2",
+            "ibm.jceplus.junit.openjceplus.multithread.TestRSAPSSInterop3",
+            "ibm.jceplus.junit.openjceplus.multithread.TestRSASignatureInteropSunRsaSign",
+            "ibm.jceplus.junit.openjceplus.multithread.TestSHA256Clone_SharedMD",
             "ibm.jceplus.junit.openjceplus.multithread.TestSHA3_224",
             "ibm.jceplus.junit.openjceplus.multithread.TestSHA3_256",
             "ibm.jceplus.junit.openjceplus.multithread.TestSHA3_384",
@@ -67,18 +79,10 @@ public class TestMultithread extends TestCase {
             "ibm.jceplus.junit.openjceplus.multithread.TestSHA512",
             "ibm.jceplus.junit.openjceplus.multithread.TestSHA512_224",
             "ibm.jceplus.junit.openjceplus.multithread.TestSHA512_256",
-            "ibm.jceplus.junit.openjceplus.multithread.TestSHA256Clone_SharedMD",
-            "ibm.jceplus.junit.openjceplus.multithread.TestRSASignature",
-            /*"ibm.jceplus.junit.openjceplus.multithread.TestRSA_2048",*/
-            "ibm.jceplus.junit.openjceplus.multithread.TestRSAKey",
-            "ibm.jceplus.junit.openjceplus.multithread.TestRSASignatureInteropSunRsaSign",
-            "ibm.jceplus.junit.openjceplus.multithread.TestHKDF",
-            "ibm.jceplus.junit.openjceplus.multithread.TestEdDSASignature",
             "ibm.jceplus.junit.openjceplus.multithread.TestXDH",
             "ibm.jceplus.junit.openjceplus.multithread.TestXDHKeyImport",
             "ibm.jceplus.junit.openjceplus.multithread.TestXDHKeyPairGenerator",
-            "ibm.jceplus.junit.openjceplus.multithread.TestXDHMultiParty"/*,
-            "ibm.jceplus.junit.openjceplus.multithread.TestMiniRSAPSS2"*/};
+            "ibm.jceplus.junit.openjceplus.multithread.TestXDHMultiParty"};
 
     public TestMultithread() {}
 
@@ -128,7 +132,7 @@ public class TestMultithread extends TestCase {
         for (TestExecutionSummary.Failure failure : failures) {
             failure.getException().printStackTrace();
         }
-        //failed = !failures.isEmpty();
+        failed = !failures.isEmpty();
 
         return failed;
     }
@@ -173,14 +177,5 @@ public class TestMultithread extends TestCase {
                 fail("Failed tests:\n\t" + allFailedTests);
             }
         }
-    }
-
-    public static Test suite() {
-        TestSuite suite = new TestSuite(TestMultithread.class);
-        return suite;
-    }
-
-    public static void main(String[] args) {
-        junit.textui.TestRunner.run(suite());
     }
 }

--- a/src/test/java/ibm/jceplus/junit/TestMultithreadFIPS.java
+++ b/src/test/java/ibm/jceplus/junit/TestMultithreadFIPS.java
@@ -15,9 +15,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import junit.framework.Test;
 import junit.framework.TestCase;
-import junit.framework.TestSuite;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
@@ -28,47 +26,57 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
 
 public class TestMultithreadFIPS extends TestCase {
     private final int numThreads = 10;
-    private final int timeoutSec = 1500;
-    private final String[] testList = {"ibm.jceplus.junit.openjceplusfips.multithread.TestAliases",
-            /*"ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMUpdate",*/
-            "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMCopySafe",
-            "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMCipherInputStreamExceptions",
+    private final int timeoutSec = 3000;
+    private final String[] testList = {
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestAES_128",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestAES_192",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestAES_256",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCM_128",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCM_192",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCM_256",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMCICOWithGCM",
-            "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMSameBuffer",
-            "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMWithByteBuffer",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMCICOWithGCMAndAAD",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMCipherInputStreamExceptions",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMCopySafe",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMLong",
-            /*"ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCM_128",*/
-            /*"ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCM_192",*/
-            /*"ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCM_256",*/
-            "ibm.jceplus.junit.openjceplus.multithread.TestDH",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMNonExpanding",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMSameBuffer",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMUpdate",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMWithByteBuffer",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestAliases",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestDESede",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestDH",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestDSAKey",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestDSASignatureInteropSUN",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestECDH",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestECDHInteropSunEC",
-            /*"ibm.jceplus.junit.openjceplusfips.multithread.TestDSAKey",*/
-            /*"ibm.jceplus.junit.openjceplusfips.multithread.TestAES_128",*/
-            /*"ibm.jceplus.junit.openjceplusfips.multithread.TestAES_192",*/
-            /*"ibm.jceplus.junit.openjceplusfips.multithread.TestAES_256",*/
-            "ibm.jceplus.junit.openjceplusfips.multithread.TestDESede",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestECDSASignature",
-            "ibm.jceplus.junit.openjceplusfips.multithread.TestDSASignatureInteropSUN",
-            /*"ibm.jceplus.junit.openjceplusfips.multithread.TestHmacMD5", */
-            /*"ibm.jceplus.junit.openjceplusfips.multithread.TestHmacMD5InteropSunJCE",*/
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestHKDF",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestHmacSHA256",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestHmacSHA256InteropSunJCE",
-            "ibm.jceplus.junit.openjceplusfips.multithread.TestSHA512",
-            "ibm.jceplus.junit.openjceplusfips.multithread.TestSHA256Clone_SharedMD",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestHmacSHA3_224",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestHmacSHA3_256",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestHmacSHA3_384",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestHmacSHA3_512",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestMiniRSAPSS2",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestRSASignature",
-            /*"ibm.jceplus.junit.openjceplusfips.multithread.TestRSA_2048",*/
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestRSA_2048",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestRSAKey",
-            "ibm.jceplus.junit.openjceplusfips.multithread.TestRSASignatureInteropSunRsaSign",
-            /*"ibm.jceplus.junit.openjceplusfips.multithread.TestHKDF",*/
-            /*"ibm.jceplus.junit.openjceplusfips.multithread.TestMiniRSAPSS2",*/
-            "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMCICOWithGCMAndAAD",
-            "ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMNonExpanding"//,
-            /*"ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMWithKeyAndIvCheck",*/
-            /*"ibm.jceplus.junit.openjceplusfips.multithread.TestRSAPSS",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestRSAPSS",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestRSAPSS2",
-            "ibm.jceplus.junit.openjceplusfips.multithread.TestRSAPSSInterop2",
-            "ibm.jceplus.junit.openjceplusfips.multithread.TestRSAPSSInterop3"*/};
+            //"ibm.jceplus.junit.openjceplusfips.multithread.TestRSAPSSInterop2",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestRSAPSSInterop3",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestRSASignatureInteropSunRsaSign",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestSHA256Clone_SharedMD",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestSHA3_224",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestSHA3_256",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestSHA3_384",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestSHA3_512",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestSHA512",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestSHA512_224",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestSHA512_256",
+            //"ibm.jceplus.junit.openjceplusfips.multithread.TestAESGCMWithKeyAndIvCheck", // test not in other test suites?
+    };
     public final Object ob = new Object();
 
     public TestMultithreadFIPS() {}
@@ -164,14 +172,5 @@ public class TestMultithreadFIPS extends TestCase {
                 fail("Failed tests:\n\t" + allFailedTests);
             }
         }
-    }
-
-    public static Test suite() {
-        TestSuite suite = new TestSuite(TestMultithreadFIPS.class);
-        return suite;
-    }
-
-    public static void main(String[] args) {
-        junit.textui.TestRunner.run(suite());
     }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAES.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAES.java
@@ -28,11 +28,10 @@ import javax.crypto.spec.RC2ParameterSpec;
 import javax.crypto.spec.RC5ParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
 
 public class BaseTestAES extends BaseTestCipher {
-    //--------------------------------------------------------------------------
-    //
-    //
 
     // 14 bytes: PASSED
     static final byte[] plainText14 = "12345678123456".getBytes();
@@ -52,7 +51,7 @@ public class BaseTestAES extends BaseTestCipher {
             .getBytes();
 
     // 512, 65536, 524288 bytes, payload increment of 32 bytes (up to 16384 bytes) : PASSED
-    Random r = new Random(5);
+    static Random r = new Random(5);
     static int iteration = 0;
     static final byte[] plainText512 = new byte[512];
     static final byte[] plainText65536 = new byte[65536];
@@ -67,13 +66,16 @@ public class BaseTestAES extends BaseTestCipher {
     static boolean warmup = false;
     protected SecretKey key;
     protected AlgorithmParameters params = null;
+
+    /*
+     * Only be used within tests that have no intentions of making use of cp.
+     * Do not make use of this field with tests that are making use of cp for
+     * multithreaded testing of this cipher.
+     */
     protected Cipher cp = null;
     protected boolean success = true;
     protected int specifiedKeySize = 0;
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public BaseTestAES(String providerName) {
         super(providerName);
         try {
@@ -85,9 +87,6 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public BaseTestAES(String providerName, int keySize) throws Exception {
         super(providerName);
         this.specifiedKeySize = keySize;
@@ -103,35 +102,26 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
-    public void setUp() throws Exception {
-        byte[] encodedKey = new byte[(specifiedKeySize > 0 ? specifiedKeySize : 128) / 8];
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
         r.nextBytes(plainText512);
         r.nextBytes(plainText65536);
         r.nextBytes(plainText524288);
         r.nextBytes(plainText1048576);
         r.nextBytes(plainText16KB);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        byte[] encodedKey = new byte[(specifiedKeySize > 0 ? specifiedKeySize : 128) / 8];
         r.nextBytes(encodedKey);
         key = new SecretKeySpec(encodedKey, 0, encodedKey.length, "AES");
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
-    public void tearDown() throws Exception {}
-
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES() throws Exception {
         encryptDecrypt("AES");
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_CBC_ISO10126Padding() throws Exception {
         try {
             cp = Cipher.getInstance("AES/CBC/ISO10126Padding", providerName);
@@ -141,23 +131,14 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_CBC_NoPadding() throws Exception {
         encryptDecrypt("AES/CBC/NoPadding", true, false);
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_CBC_PKCS5Padding() throws Exception {
         encryptDecrypt("AES/CBC/PKCS5Padding");
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_CFB_ISO10126Padding() throws Exception {
         try {
             cp = Cipher.getInstance("AES/CFB/ISO10126Padding", providerName);
@@ -167,37 +148,22 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_CFB8_NoPadding() throws Exception {
         encryptDecrypt("AES/CFB8/NoPadding");
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_CFB_NoPadding() throws Exception {
         encryptDecrypt("AES/CFB/NoPadding");
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_CFB8_PKCS5Padding() throws Exception {
         encryptDecrypt("AES/CFB8/PKCS5Padding");
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_CFB_PKCS5Padding() throws Exception {
         encryptDecrypt("AES/CFB/PKCS5Padding");
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_CFB128_ISO10126Padding() throws Exception {
         try {
             cp = Cipher.getInstance("AES/CFB128/ISO10126Padding", providerName);
@@ -207,23 +173,14 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_CFB128_NoPadding() throws Exception {
         encryptDecrypt("AES/CFB128/NoPadding");
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_CFB128_PKCS5Padding() throws Exception {
         encryptDecrypt("AES/CFB128/PKCS5Padding");
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_CTR_ISO10126Padding() throws Exception {
         try {
             cp = Cipher.getInstance("AES/CTR/ISO10126Padding", providerName);
@@ -233,23 +190,14 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_CTR_NoPadding() throws Exception {
         encryptDecrypt("AES/CTR/NoPadding");
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_CTR_PKCS5Padding() throws Exception {
         encryptDecrypt("AES/CTR/PKCS5Padding");
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_CTS_ISO10126Padding() throws Exception {
         try {
             cp = Cipher.getInstance("AES/CTS/ISO10126Padding", providerName);
@@ -258,9 +206,6 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_CTS_NoPadding() throws Exception {
         try {
             cp = Cipher.getInstance("AES/CTS/NoPadding", providerName);
@@ -269,9 +214,6 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_CTS_PKCS5Padding() throws Exception {
         try {
             cp = Cipher.getInstance("AES/CTS/PKCS5Padding", providerName);
@@ -281,9 +223,6 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_ECB_ISO10126Padding() throws Exception {
         try {
             cp = Cipher.getInstance("AES/ECB/ISO10126Padding", providerName);
@@ -293,23 +232,14 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_ECB_NoPadding() throws Exception {
         encryptDecrypt("AES/ECB/NoPadding", true, false);
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_ECB_PKCS5Padding() throws Exception {
         encryptDecrypt("AES/ECB/PKCS5Padding");
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_OFB_ISO10126Padding() throws Exception {
         try {
             cp = Cipher.getInstance("AES/OFB/ISO10126Padding", providerName);
@@ -319,23 +249,14 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_OFB_NoPadding() throws Exception {
         encryptDecrypt("AES/OFB/NoPadding");
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_OFB_PKCS5Padding() throws Exception {
         encryptDecrypt("AES/OFB/PKCS5Padding");
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_PCBC_ISO10126Padding() throws Exception {
         try {
             cp = Cipher.getInstance("AES/PCBC/ISO10126Padding", providerName);
@@ -345,9 +266,6 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_PCBC_NoPadding() throws Exception {
         try {
             cp = Cipher.getInstance("AES/PCBC/NoPadding", providerName);
@@ -357,9 +275,6 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAES_PCBC_PKCS5Padding() throws Exception {
         try {
             cp = Cipher.getInstance("AES/PCBC/PKCS5Padding", providerName);
@@ -369,13 +284,10 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAESShortBuffer() throws Exception {
         try {
             // Test AES Cipher
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
 
             // Encrypt the plain text
             cp.init(Cipher.ENCRYPT_MODE, key);
@@ -387,12 +299,9 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAESIllegalBlockSizeEncrypt() throws Exception {
         try {
-            cp = Cipher.getInstance("AES/CBC/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/CBC/NoPadding", providerName);
 
             int blockSize = cp.getBlockSize();
             byte[] message = new byte[blockSize - 1];
@@ -408,17 +317,14 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAESIllegalBlockSizeDecrypt() throws Exception {
         try {
-            cp = Cipher.getInstance("AES/CBC/PKCS5Padding", providerName);
+            Cipher cp = Cipher.getInstance("AES/CBC/PKCS5Padding", providerName);
 
             // Encrypt the plain text
             cp.init(Cipher.ENCRYPT_MODE, key);
             byte[] cipherText = cp.doFinal(plainText);
-            params = cp.getParameters();
+            AlgorithmParameters params = cp.getParameters();
 
             // Verify the text
             cp.init(Cipher.DECRYPT_MODE, key, params);
@@ -431,18 +337,15 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAESBadPaddingDecrypt() throws NoSuchAlgorithmException, NoSuchProviderException,
             NoSuchPaddingException, InvalidKeyException, InvalidAlgorithmParameterException {
         try {
-            cp = Cipher.getInstance("AES/CBC/PKCS5Padding", providerName);
+            Cipher cp = Cipher.getInstance("AES/CBC/PKCS5Padding", providerName);
 
             // Encrypt the plain text
             cp.init(Cipher.ENCRYPT_MODE, key);
             byte[] cipherText = cp.doFinal(plainText);
-            params = cp.getParameters();
+            AlgorithmParameters params = cp.getParameters();
             // Create Bad Padding
             cipherText[cipherText.length - 1]++;
             // Verify the text
@@ -462,9 +365,6 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAESNoSuchAlgorithm() throws Exception {
         try {
             cp = Cipher.getInstance("AES/BBC/PKCS5Padding", providerName);
@@ -474,11 +374,8 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testAESNull() throws Exception {
-        cp = Cipher.getInstance("AES", providerName);
+        Cipher cp = Cipher.getInstance("AES", providerName);
         SecretKey nullKey = null;
 
         try {
@@ -495,11 +392,8 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testIllegalParamSpec() throws Exception {
-        cp = Cipher.getInstance("AES/CBC/PKCS5Padding", providerName);
+        Cipher cp = Cipher.getInstance("AES/CBC/PKCS5Padding", providerName);
 
         try {
             byte[] iv = null;
@@ -551,19 +445,16 @@ public class BaseTestAES extends BaseTestCipher {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testArguments() throws Exception {
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(null);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[0]);
         } catch (Exception e) {
@@ -571,21 +462,21 @@ public class BaseTestAES extends BaseTestCipher {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(null, 0);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(null, 1);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[0], 0);
             fail("Did not get expected ShortBufferException on doFinal(new byte[0], 0)");
@@ -593,7 +484,7 @@ public class BaseTestAES extends BaseTestCipher {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[0], 1);
             fail("Should have gotten exception on doFinal(new byte[0], 1)");
@@ -601,7 +492,7 @@ public class BaseTestAES extends BaseTestCipher {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[cp.getOutputSize(0)], 1);
             fail("Expected ShortBufferException");
@@ -609,28 +500,28 @@ public class BaseTestAES extends BaseTestCipher {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(null, 0, 0);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(null, 1, 0);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(null, 0, 1);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[0], 0, 0);
         } catch (Exception e) {
@@ -638,7 +529,7 @@ public class BaseTestAES extends BaseTestCipher {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[0], 1, 0);
             fail("Did not get expected exception on doFinal(new byte[0], 1, 0)");
@@ -646,7 +537,7 @@ public class BaseTestAES extends BaseTestCipher {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[0], 0, 1);
             fail("Did not get expected exception on doFinal(new byte[0], 0, 1)");
@@ -654,14 +545,14 @@ public class BaseTestAES extends BaseTestCipher {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(null, 0, 0, null);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[0], 0, 0, new byte[0]);
             fail("Did not get expected ShortBufferException on doFinal(new byte[0], 0, 9, new byte[0])");
@@ -669,14 +560,14 @@ public class BaseTestAES extends BaseTestCipher {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[0], 0, 0, null, 0);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[0], 0, 0, new byte[0], 0);
             fail("Did not get expected ShortBufferException on doFinal(new byte[0], 0, 0, new byte[0], 0)");
@@ -684,14 +575,14 @@ public class BaseTestAES extends BaseTestCipher {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(null);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(new byte[0]);
         } catch (Exception e) {
@@ -699,28 +590,28 @@ public class BaseTestAES extends BaseTestCipher {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(null, 0, 0);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(null, 1, 0);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(null, 0, 1);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(new byte[0], 0, 0);
         } catch (Exception e) {
@@ -728,76 +619,73 @@ public class BaseTestAES extends BaseTestCipher {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(new byte[0], 1, 0);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(new byte[0], 0, 1);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(null, 0, 0, null);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(null, 0, 0, new byte[0]);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(new byte[0], 0, 0, null);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(new byte[0], 0, 0, new byte[0]);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(new byte[0], 0, 0, null, 0);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(new byte[0], 0, 0, null, 1);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES", providerName);
+            Cipher cp = Cipher.getInstance("AES", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(new byte[0], 0, 0, new byte[0], 0);
         } catch (Exception e) {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     protected boolean encryptDecrypt(Cipher cp) throws Exception {
         cp.init(Cipher.ENCRYPT_MODE, key);
         byte[] cipherText = cp.doFinal(plainText);
-        params = cp.getParameters();
+        AlgorithmParameters params = cp.getParameters();
 
         // Verify the text
         cp.init(Cipher.DECRYPT_MODE, key, params);
@@ -806,24 +694,15 @@ public class BaseTestAES extends BaseTestCipher {
         return Arrays.equals(plainText, newPlainText);
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     protected void encryptDecrypt(String algorithm) throws Exception {
         encryptDecrypt(algorithm, false, false);
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     protected void encryptDecrypt(String algorithm, boolean requireLengthMultipleBlockSize,
             boolean testFinalizeOnly) throws Exception {
         encryptDecrypt(algorithm, requireLengthMultipleBlockSize, null, testFinalizeOnly);
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     protected void encryptDecrypt(String algorithm, boolean requireLengthMultipleBlockSize,
             AlgorithmParameters algParams, boolean testFinalizeOnly) throws Exception {
         encryptDecrypt(algorithm, requireLengthMultipleBlockSize, algParams, plainText14,
@@ -851,9 +730,6 @@ public class BaseTestAES extends BaseTestCipher {
                 testFinalizeOnly);
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     protected void encryptDecrypt(String algorithm, boolean requireLengthMultipleBlockSize,
             AlgorithmParameters algParams, byte[] message, boolean testFinalizeOnly)
             throws Exception {
@@ -884,7 +760,7 @@ public class BaseTestAES extends BaseTestCipher {
             AlgorithmParameters algParams, byte[] message) throws Exception
 
     {
-        cp = Cipher.getInstance(algorithm, providerName);
+        Cipher cp = Cipher.getInstance(algorithm, providerName);
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);
         } else {
@@ -893,7 +769,7 @@ public class BaseTestAES extends BaseTestCipher {
         int blockSize = cp.getBlockSize();
         try {
             byte[] cipherText = cp.doFinal(message);
-            params = cp.getParameters();
+            AlgorithmParameters params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
                 assertTrue(
@@ -927,7 +803,7 @@ public class BaseTestAES extends BaseTestCipher {
     //
     protected void encryptDecryptUpdate(String algorithm, boolean requireLengthMultipleBlockSize,
             AlgorithmParameters algParams, byte[] message) throws Exception {
-        cp = Cipher.getInstance(algorithm, providerName);
+        Cipher cp = Cipher.getInstance(algorithm, providerName);
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);
         } else {
@@ -937,7 +813,7 @@ public class BaseTestAES extends BaseTestCipher {
         try {
             byte[] cipherText1 = cp.update(message);
             byte[] cipherText2 = cp.doFinal();
-            params = cp.getParameters();
+            AlgorithmParameters params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
                 assertTrue(
@@ -975,7 +851,7 @@ public class BaseTestAES extends BaseTestCipher {
     protected void encryptDecryptPartialUpdate(String algorithm,
             boolean requireLengthMultipleBlockSize, AlgorithmParameters algParams, byte[] message)
             throws Exception {
-        cp = Cipher.getInstance(algorithm, providerName);
+        Cipher cp = Cipher.getInstance(algorithm, providerName);
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);
         } else {
@@ -986,7 +862,7 @@ public class BaseTestAES extends BaseTestCipher {
         try {
             byte[] cipherText1 = cp.update(message, 0, partialLen);
             byte[] cipherText2 = cp.doFinal(message, partialLen, message.length - partialLen);
-            params = cp.getParameters();
+            AlgorithmParameters params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
                 assertTrue(
@@ -1027,7 +903,7 @@ public class BaseTestAES extends BaseTestCipher {
             throws Exception
 
     {
-        cp = Cipher.getInstance(algorithm, providerName);
+        Cipher cp = Cipher.getInstance(algorithm, providerName);
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);
         } else {
@@ -1036,7 +912,7 @@ public class BaseTestAES extends BaseTestCipher {
         int blockSize = cp.getBlockSize();
         try {
             byte[] cipherText = cp.doFinal(message);
-            params = cp.getParameters();
+            AlgorithmParameters params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
                 assertTrue(
@@ -1076,7 +952,7 @@ public class BaseTestAES extends BaseTestCipher {
             throws Exception
 
     {
-        cp = Cipher.getInstance(algorithm, providerName);
+        Cipher cp = Cipher.getInstance(algorithm, providerName);
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);
         } else {
@@ -1086,10 +962,11 @@ public class BaseTestAES extends BaseTestCipher {
         try {
             byte[] cipherText0 = cp.doFinal(message);
 
-            byte[] resultBuffer = Arrays.copyOf(message, cp.getOutputSize(message.length));
-            int resultLen = cp.doFinal(resultBuffer, 0, message.length, resultBuffer);
+            byte[] messageCopy = Arrays.copyOf(message, cp.getOutputSize(message.length));
+            byte[] resultBuffer = new byte[messageCopy.length];
+            int resultLen = cp.doFinal(messageCopy, 0, message.length, resultBuffer);
             byte[] cipherText = Arrays.copyOf(resultBuffer, resultLen);
-            params = cp.getParameters();
+            AlgorithmParameters params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
                 assertTrue(
@@ -1125,7 +1002,7 @@ public class BaseTestAES extends BaseTestCipher {
             throws Exception
 
     {
-        cp = Cipher.getInstance(algorithm, providerName);
+        Cipher cp = Cipher.getInstance(algorithm, providerName);
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);
         } else {
@@ -1142,7 +1019,7 @@ public class BaseTestAES extends BaseTestCipher {
             byte[] cipherText = new byte[cipherText1Len + cipherText2.length];
             System.arraycopy(resultBuffer, 0, cipherText, 0, cipherText1Len);
             System.arraycopy(cipherText2, 0, cipherText, cipherText1Len, cipherText2.length);
-            params = cp.getParameters();
+            AlgorithmParameters params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
                 assertTrue(
@@ -1173,7 +1050,6 @@ public class BaseTestAES extends BaseTestCipher {
                     (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
         }
     }
-
 
     //--------------------------------------------------------------------------
     // warmup functions for enable fastjni

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM.java
@@ -31,9 +31,6 @@ import javax.crypto.spec.RC5ParameterSpec;
 import org.junit.Assume;
 
 public class BaseTestAESGCM extends BaseTest {
-    // --------------------------------------------------------------------------
-    //
-    //
 
     // 14 bytes: PASSED
     static final byte[] plainText14 = "12345678123456".getBytes();
@@ -88,13 +85,9 @@ public class BaseTestAESGCM extends BaseTest {
     static final byte[] plainText4096 = plainText4096String.getBytes();
     static final byte[] plainText = plainText4096; // default value
 
-    // --------------------------------------------------------------------------
-    //
-    //
     protected KeyGenerator aesKeyGen;
     protected SecretKey key;
     protected AlgorithmParameters params = null;
-    protected Cipher cp = null;
     protected boolean success = true;
     protected Method methodCipherUpdateAAD = null;
     protected Constructor<?> ctorGCMParameterSpec = null;
@@ -103,17 +96,10 @@ public class BaseTestAESGCM extends BaseTest {
     byte[] ivBytes = "123456".getBytes();
     byte[] aadBytes = new byte[16];
 
-
-    // --------------------------------------------------------------------------
-    //
-    //
     public BaseTestAESGCM(String providerName) {
         super(providerName);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public BaseTestAESGCM(String providerName, int keySize) throws Exception {
         super(providerName);
         this.specifiedKeySize = keySize;
@@ -121,9 +107,6 @@ public class BaseTestAESGCM extends BaseTest {
         Assume.assumeTrue(javax.crypto.Cipher.getMaxAllowedKeyLength("AES") >= keySize);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void setUp() throws Exception {
         aesKeyGen = KeyGenerator.getInstance("AES", providerName);
         if (specifiedKeySize > 0) {
@@ -171,17 +154,9 @@ public class BaseTestAESGCM extends BaseTest {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
-    public void tearDown() throws Exception {}
-
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testAES_GCM_encrypt_offset() throws Exception {
         // Test AES GCM - Encrypt Offset by 1
-        cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+        Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
 
         byte[] iv = new byte[16];
         byte[] aad = new byte[16];
@@ -215,12 +190,9 @@ public class BaseTestAESGCM extends BaseTest {
                 byteEqual(plainText, 0, decrypted, 0, plainText.length));
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testAES_GCM_decrypt_offset() throws Exception {
         // Test AES GCM - Decrypt Offset by 1
-        cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+        Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
 
         byte[] iv = new byte[16];
         byte[] aad = new byte[16];
@@ -253,12 +225,9 @@ public class BaseTestAESGCM extends BaseTest {
                 byteEqual(plainText, 0, decrypted, offset, plainText.length));
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testAES_GCM_encrypt_large_buffer() throws Exception {
         // Test AES GCM - Encrypting buffer large
-        cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+        Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
 
         byte[] iv = new byte[16];
         byte[] aad = new byte[16];
@@ -286,12 +255,9 @@ public class BaseTestAESGCM extends BaseTest {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testAES_GCM_decrypt_large_buffer() throws Exception {
         // Test AES GCM - Decrypting buffer large
-        cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+        Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
 
         byte[] iv = new byte[16];
         byte[] aad = new byte[16];
@@ -328,12 +294,9 @@ public class BaseTestAESGCM extends BaseTest {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testAES_GCM() throws Exception {
         // Test AES GCM Cipher
-        cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+        Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
 
         // Encrypt the plain text
         cp.init(Cipher.ENCRYPT_MODE, key);
@@ -348,12 +311,9 @@ public class BaseTestAESGCM extends BaseTest {
                 byteEqual(plainText, 0, newPlainText1, 0, plainText.length));
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testAES_GCM_2() throws Exception {
         // Test AES GCM Cipher using duplicate calls
-        cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+        Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
 
         // Encrypt the plain text
         cp.init(Cipher.ENCRYPT_MODE, key);
@@ -377,13 +337,10 @@ public class BaseTestAESGCM extends BaseTest {
                 byteEqual(plainText, 0, newPlainText1, 0, plainText.length));
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testAES_GCM_encrypt_empty_text() throws Exception {
         try {
             // Test AES GCM - Encrypt Cipher.doFinal() without text
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
 
             // Encrypt the plain text
             cp.init(Cipher.ENCRYPT_MODE, key);
@@ -397,13 +354,10 @@ public class BaseTestAESGCM extends BaseTest {
         assertTrue("Passed - Cipher.doFinal() encrypt empty text", true);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testAES_GCM_decrypt_without_parameters() throws Exception {
         try {
             // Test AES GCM - Decrypt Cipher.doFinal() without parameters
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
 
             cp.init(Cipher.DECRYPT_MODE, key);
             cp.doFinal();
@@ -418,13 +372,10 @@ public class BaseTestAESGCM extends BaseTest {
                 false);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testAES_GCM_decrypt_empty_text() throws Exception {
         try {
             // Test AES GCM - Decrypt Cipher.doFinal() without text
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
 
             byte[] iv = new byte[16];
             // GCMParameterSpec gps = new GCMParameterSpec(16 * 8, iv);
@@ -442,14 +393,11 @@ public class BaseTestAESGCM extends BaseTest {
         assertTrue("Failed - Cipher.doFinal() decrypt should have thrown exception", false);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testAES_GCM_5() {
         try {
             // Test AES GCM Cipher Cipher.doFinal(plainTxt) on decrypt -
             // incorrect text
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
 
             // Encrypt the plain text
             cp.init(Cipher.ENCRYPT_MODE, key);
@@ -471,14 +419,11 @@ public class BaseTestAESGCM extends BaseTest {
         assertTrue("Failed - Expected AEADBadTagException", false);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testAES_GCM_Exception() throws Exception {
         // ProviderException
         try {
             // Test AES GCM Cipher
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
 
             // Encrypt the plain text
             //cp.init(Cipher.ENCRYPT_MODE, key);
@@ -501,13 +446,10 @@ public class BaseTestAESGCM extends BaseTest {
         assertTrue("Failed - Expected IllegalStateException", true);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testAESShortBuffer() throws Exception {
         try {
             // Test AES Cipher
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
 
             // Encrypt the plain text
             cp.init(Cipher.ENCRYPT_MODE, key);
@@ -519,12 +461,9 @@ public class BaseTestAESGCM extends BaseTest {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testAESIllegalBlockSize() throws Exception {
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
 
             // Encrypt the plain text
             cp.init(Cipher.ENCRYPT_MODE, key);
@@ -548,11 +487,8 @@ public class BaseTestAESGCM extends BaseTest {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testAESNull() throws Exception {
-        cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+        Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
         SecretKey nullKey = null;
 
         try {
@@ -569,11 +505,8 @@ public class BaseTestAESGCM extends BaseTest {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testIllegalParamSpec() throws Exception {
-        cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+        Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
 
         try {
             byte[] iv = null;
@@ -625,19 +558,16 @@ public class BaseTestAESGCM extends BaseTest {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testArguments() throws Exception {
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(null);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[0]);
         } catch (Exception e) {
@@ -645,21 +575,21 @@ public class BaseTestAESGCM extends BaseTest {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(null, 0);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(null, 1);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[0], 0);
             fail("Did not get expected ShortBufferException on doFinal(new byte[0], 0)");
@@ -667,7 +597,7 @@ public class BaseTestAESGCM extends BaseTest {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[0], 1);
             fail("Should have gotten exception on doFinal(new byte[0], 1)");
@@ -675,7 +605,7 @@ public class BaseTestAESGCM extends BaseTest {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[cp.getOutputSize(0)], 1);
             fail("Expected ShortBufferException");
@@ -683,28 +613,28 @@ public class BaseTestAESGCM extends BaseTest {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(null, 0, 0);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(null, 1, 0);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(null, 0, 1);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[0], 0, 0);
         } catch (Exception e) {
@@ -712,7 +642,7 @@ public class BaseTestAESGCM extends BaseTest {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[0], 1, 0);
             fail("Did not get expected exception on doFinal(new byte[0], 1, 0)");
@@ -720,7 +650,7 @@ public class BaseTestAESGCM extends BaseTest {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[0], 0, 1);
             fail("Did not get expected exception on doFinal(new byte[0], 0, 1)");
@@ -728,14 +658,14 @@ public class BaseTestAESGCM extends BaseTest {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(null, 0, 0, null);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[0], 0, 0, new byte[0]);
             fail("Did not get expected ShortBufferException on doFinal(new byte[0], 0, 9, new byte[0])");
@@ -743,14 +673,14 @@ public class BaseTestAESGCM extends BaseTest {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[0], 0, 0, null, 0);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.doFinal(new byte[0], 0, 0, new byte[0], 0);
             fail("Did not get expected ShortBufferException on doFinal(new byte[0], 0, 0, new byte[0], 0)");
@@ -758,14 +688,14 @@ public class BaseTestAESGCM extends BaseTest {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(null);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(new byte[0]);
         } catch (Exception e) {
@@ -773,28 +703,28 @@ public class BaseTestAESGCM extends BaseTest {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(null, 0, 0);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(null, 1, 0);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(null, 0, 1);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(new byte[0], 0, 0);
         } catch (Exception e) {
@@ -802,63 +732,63 @@ public class BaseTestAESGCM extends BaseTest {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(new byte[0], 1, 0);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(new byte[0], 0, 1);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(null, 0, 0, null);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(null, 0, 0, new byte[0]);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(new byte[0], 0, 0, null);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(new byte[0], 0, 0, new byte[0]);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(new byte[0], 0, 0, null, 0);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(new byte[0], 0, 0, null, 1);
         } catch (Exception e) {
         }
 
         try {
-            cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
+            Cipher cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             cp.init(Cipher.ENCRYPT_MODE, key);
             cp.update(new byte[0], 0, 0, new byte[0], 0);
         } catch (Exception e) {
@@ -882,9 +812,6 @@ public class BaseTestAESGCM extends BaseTest {
         return false;
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     protected boolean encryptDecrypt(Cipher cp) throws Exception {
         cp.init(Cipher.ENCRYPT_MODE, key);
         byte[] cipherText = cp.doFinal(plainText);
@@ -897,24 +824,15 @@ public class BaseTestAESGCM extends BaseTest {
         return byteEqual(plainText, 0, newPlainText, 0, plainText.length);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     protected void encryptDecrypt(String algorithm) throws Exception {
         encryptDecrypt(algorithm, false);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     protected void encryptDecrypt(String algorithm, boolean requireLengthMultipleBlockSize)
             throws Exception {
         encryptDecrypt(algorithm, requireLengthMultipleBlockSize, null);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     protected void encryptDecrypt(String algorithm, boolean requireLengthMultipleBlockSize,
             AlgorithmParameters algParams) throws Exception {
         encryptDecrypt(algorithm, requireLengthMultipleBlockSize, algParams, plainText14);
@@ -924,9 +842,6 @@ public class BaseTestAESGCM extends BaseTest {
         encryptDecrypt(algorithm, requireLengthMultipleBlockSize, algParams, plainText128);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     protected void encryptDecrypt(String algorithm, boolean requireLengthMultipleBlockSize,
             AlgorithmParameters algParams, byte[] message) throws Exception {
         encryptDecryptDoFinal(algorithm, requireLengthMultipleBlockSize, algParams, message);
@@ -941,7 +856,7 @@ public class BaseTestAESGCM extends BaseTest {
             AlgorithmParameters algParams, byte[] message) throws Exception
 
     {
-        cp = Cipher.getInstance(algorithm, providerName);
+        Cipher cp = Cipher.getInstance(algorithm, providerName);
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);
         } else {
@@ -985,7 +900,7 @@ public class BaseTestAESGCM extends BaseTest {
     //
     protected void encryptDecryptUpdate(String algorithm, boolean requireLengthMultipleBlockSize,
             AlgorithmParameters algParams, byte[] message) throws Exception {
-        cp = Cipher.getInstance(algorithm, providerName);
+        Cipher cp = Cipher.getInstance(algorithm, providerName);
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);
         } else {
@@ -1033,7 +948,7 @@ public class BaseTestAESGCM extends BaseTest {
     protected void encryptDecryptPartialUpdate(String algorithm,
             boolean requireLengthMultipleBlockSize, AlgorithmParameters algParams, byte[] message)
             throws Exception {
-        cp = Cipher.getInstance(algorithm, providerName);
+        Cipher cp = Cipher.getInstance(algorithm, providerName);
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);
         } else {
@@ -1077,13 +992,9 @@ public class BaseTestAESGCM extends BaseTest {
         }
     }
 
-
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testShortBuffer() throws Exception {
+        Cipher cp = null;
         try {
-
             cp = Cipher.getInstance("AES/GCM/NoPadding", providerName);
             GCMParameterSpec parameterSpec = new GCMParameterSpec(128, ivBytes); //128 bit auth tag length
             cp.init(Cipher.ENCRYPT_MODE, key, parameterSpec);
@@ -1098,9 +1009,6 @@ public class BaseTestAESGCM extends BaseTest {
         }
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public void testEncryptAfterShortBufferRetry() throws Exception {
         Cipher cpl = Cipher.getInstance("AES/GCM/NoPadding", providerName);
         GCMParameterSpec parameterSpec = new GCMParameterSpec(128, ivBytes); //128 bit auth tag length

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDESede.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDESede.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -24,9 +24,6 @@ import javax.crypto.spec.RC2ParameterSpec;
 import javax.crypto.spec.RC5ParameterSpec;
 
 public class BaseTestDESede extends BaseTestCipher {
-    // --------------------------------------------------------------------------
-    //
-    //
 
     // 14 bytes: PASSED
     static final byte[] plainText14 = "12345678123456".getBytes();
@@ -47,36 +44,29 @@ public class BaseTestDESede extends BaseTestCipher {
 
     static final byte[] plainText = plainText128; // default value
 
-    // --------------------------------------------------------------------------
-    //
-    //
     protected boolean supportsEncrypt;
     protected String encryptProviderName;
     protected KeyGenerator keyGen;
     protected SecretKey key;
     protected AlgorithmParameters params = null;
+
+    /*
+     * Only be used within tests that have no intentions of making use of cp.
+     * Do not make use of this field with tests that are making use of cp for
+     * multithreaded testing of this cipher.
+     */
     protected Cipher cp = null;
 
-
-    // --------------------------------------------------------------------------
-    //
-    //
     public BaseTestDESede(String providerName) {
         this(providerName, true);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public BaseTestDESede(String providerName, boolean supportsEncrypt) {
         super(providerName);
         this.supportsEncrypt = supportsEncrypt;
         this.encryptProviderName = supportsEncrypt ? providerName : "IBMJCE";
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void setUp() throws Exception {
         try {
             keyGen = KeyGenerator.getInstance("DESede", providerName);
@@ -91,14 +81,6 @@ public class BaseTestDESede extends BaseTestCipher {
         key = keyGen.generateKey();
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
-    public void tearDown() throws Exception {}
-
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede() throws Exception {
         try {
             encryptDecrypt("DESede");
@@ -112,9 +94,6 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_CBC_ISO10126Padding() throws Exception {
         try {
             cp = Cipher.getInstance("DESede/CBC/ISO10126Padding", providerName);
@@ -131,9 +110,6 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_CBC_NoPadding() throws Exception {
         try {
             encryptDecrypt("DESede/CBC/NoPadding", true);
@@ -147,9 +123,6 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_CBC_PKCS5Padding() throws Exception {
         try {
             encryptDecrypt("DESede/CBC/PKCS5Padding");
@@ -163,9 +136,6 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_CFB_ISO10126Padding() throws Exception {
         String algorithm = "DESede/CFB/ISO10126Padding";
 
@@ -181,23 +151,14 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_CFB_NoPadding() throws Exception {
         encryptDecrypt("DESede/CFB/NoPadding");
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_CFB_PKCS5Padding() throws Exception {
         encryptDecrypt("DESede/CFB/PKCS5Padding");
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_CFB64_ISO10126Padding() throws Exception {
         String algorithm = "DESede/CFB64/ISO10126Padding";
 
@@ -213,23 +174,14 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_CFB64_NoPadding() throws Exception {
         encryptDecrypt("DESede/CFB64/NoPadding");
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_CFB64_PKCS5Padding() throws Exception {
         encryptDecrypt("DESede/CFB64/PKCS5Padding");
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_CTR_ISO10126Padding() throws Exception {
         try {
             cp = Cipher.getInstance("DESede/CTR/ISO10126Padding", providerName);
@@ -238,9 +190,6 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_CTR_NoPadding() throws Exception {
         try {
             cp = Cipher.getInstance("DESede/CTR/NoPadding", providerName);
@@ -249,9 +198,6 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_CTR_PKCS5Padding() throws Exception {
         try {
             cp = Cipher.getInstance("DESede/CTR/PKCS5Padding", providerName);
@@ -260,9 +206,6 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_CTS_ISO10126Padding() throws Exception {
         try {
             cp = Cipher.getInstance("DESede/CTS/ISO10126Padding", providerName);
@@ -271,9 +214,6 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_CTS_NoPadding() throws Exception {
         try {
             cp = Cipher.getInstance("DESede/CTS/NoPadding", providerName);
@@ -282,9 +222,6 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_CTS_PKCS5Padding() throws Exception {
         try {
             cp = Cipher.getInstance("DESede/CTS/PKCS5Padding", providerName);
@@ -294,9 +231,6 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_ECB_ISO10126Padding() throws Exception {
         try {
             cp = Cipher.getInstance("DESede/ECB/ISO10126Padding", providerName);
@@ -313,9 +247,6 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_ECB_NoPadding() throws Exception {
         try {
             encryptDecrypt("DESede/ECB/NoPadding", true);
@@ -329,9 +260,6 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_ECB_PKCS5Padding() throws Exception {
         try {
             encryptDecrypt("DESede/ECB/PKCS5Padding");
@@ -345,9 +273,6 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_OFB_ISO10126Padding() throws Exception {
         String algorithm = "DESede/OFB/ISO10126Padding";
 
@@ -362,23 +287,14 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_OFB_NoPadding() throws Exception {
         encryptDecrypt("DESede/OFB/NoPadding");
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_OFB_PKCS5Padding() throws Exception {
         encryptDecrypt("DESede/OFB/PKCS5Padding");
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_PCBC_ISO10126Padding() throws Exception {
         try {
             cp = Cipher.getInstance("DESede/PCBC/ISO10126Padding", providerName);
@@ -388,9 +304,6 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_PCBC_NoPadding() throws Exception {
         try {
             cp = Cipher.getInstance("DESede/PCBC/NoPadding", providerName);
@@ -400,9 +313,6 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESede_PCBC_PKCS5Padding() throws Exception {
         try {
             cp = Cipher.getInstance("DESede/PCBC/PKCS5Padding", providerName);
@@ -412,12 +322,10 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESedeShortBuffer() throws Exception {
         try {
             // Test DESede Cipher
+            Cipher cp = null;
             try {
                 cp = Cipher.getInstance("DESede", encryptProviderName);
             } catch (NoSuchAlgorithmException nsae) {
@@ -445,15 +353,13 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESedeIllegalBlockSizeEncrypt() throws Exception {
         if (supportsEncrypt == false) {
             return;
         }
 
         try {
+            Cipher cp = null;
             try {
                 cp = Cipher.getInstance("DESede/CBC/NoPadding", providerName);
             } catch (NoSuchAlgorithmException nsae) {
@@ -479,11 +385,9 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESedeIllegalBlockSizeDecrypt() throws Exception {
         try {
+            Cipher cp = null;
             try {
                 cp = Cipher.getInstance("DESede/CBC/PKCS5Padding", encryptProviderName);
             } catch (NoSuchAlgorithmException nsae) {
@@ -511,9 +415,6 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESedeNoSuchAlgorithm() throws Exception {
         try {
             cp = Cipher.getInstance("DESede/BBC/PKCS5Padding", providerName);
@@ -523,10 +424,8 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDESedeNull() throws Exception {
+        Cipher cp = null;
         try {
             cp = Cipher.getInstance("DESede", providerName);
         } catch (NoSuchAlgorithmException nsae) {
@@ -554,10 +453,8 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testIllegalParamSpec() throws Exception {
+        Cipher cp = null;
         try {
             cp = Cipher.getInstance("DESede/CBC/PKCS5Padding", providerName);
         } catch (NoSuchAlgorithmException nsae) {
@@ -619,11 +516,8 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testArgumentsDecrypt() throws Exception {
-
+        Cipher cp = null;
         try {
             cp = Cipher.getInstance("DESede", encryptProviderName);
         } catch (NoSuchAlgorithmException nsae) {
@@ -880,14 +774,11 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testArgumentsEncrypt() throws Exception {
         if (supportsEncrypt == false) {
             return;
         }
-
+        Cipher cp = null;
         try {
             try {
                 cp = Cipher.getInstance("DESede", providerName);
@@ -1133,9 +1024,6 @@ public class BaseTestDESede extends BaseTestCipher {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     protected boolean encryptDecrypt(Cipher cp) throws Exception {
         cp.init(Cipher.ENCRYPT_MODE, key);
         byte[] cipherText = cp.doFinal(plainText);
@@ -1148,24 +1036,15 @@ public class BaseTestDESede extends BaseTestCipher {
         return Arrays.equals(plainText, newPlainText);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     protected void encryptDecrypt(String algorithm) throws Exception {
         encryptDecrypt(algorithm, false);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     protected void encryptDecrypt(String algorithm, boolean requireLengthMultipleBlockSize)
             throws Exception {
         encryptDecrypt(algorithm, requireLengthMultipleBlockSize, null);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     protected void encryptDecrypt(String algorithm, boolean requireLengthMultipleBlockSize,
             AlgorithmParameters algParams) throws Exception {
         encryptDecrypt(algorithm, requireLengthMultipleBlockSize, algParams, plainText14);
@@ -1175,9 +1054,6 @@ public class BaseTestDESede extends BaseTestCipher {
         encryptDecrypt(algorithm, requireLengthMultipleBlockSize, algParams, plainText128);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     protected void encryptDecrypt(String algorithm, boolean requireLengthMultipleBlockSize,
             AlgorithmParameters algParams, byte[] message) throws Exception {
         encryptDecryptDoFinal(algorithm, requireLengthMultipleBlockSize, algParams, message);
@@ -1189,9 +1065,6 @@ public class BaseTestDESede extends BaseTestCipher {
         encryptDecryptUpdateCopySafe(algorithm, requireLengthMultipleBlockSize, algParams, message);
     }
 
-    // --------------------------------------------------------------------------
-    // Run encrypt/decrypt test using just doFinal calls
-    //
     protected void encryptDecryptDoFinal(String algorithm, boolean requireLengthMultipleBlockSize,
             AlgorithmParameters algParams, byte[] message) throws Exception
 
@@ -1200,7 +1073,7 @@ public class BaseTestDESede extends BaseTestCipher {
             return;
         }
 
-        cp = Cipher.getInstance(algorithm, encryptProviderName);
+        Cipher cp = Cipher.getInstance(algorithm, encryptProviderName);
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);
         } else {
@@ -1250,7 +1123,7 @@ public class BaseTestDESede extends BaseTestCipher {
         if (isTransformationValidButUnsupported(algorithm)) {
             return;
         }
-        cp = Cipher.getInstance(algorithm, encryptProviderName);
+        Cipher cp = Cipher.getInstance(algorithm, encryptProviderName);
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);
         } else {
@@ -1304,7 +1177,7 @@ public class BaseTestDESede extends BaseTestCipher {
         if (isTransformationValidButUnsupported(algorithm)) {
             return;
         }
-        cp = Cipher.getInstance(algorithm, encryptProviderName);
+        Cipher cp = Cipher.getInstance(algorithm, encryptProviderName);
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);
         } else {
@@ -1363,7 +1236,7 @@ public class BaseTestDESede extends BaseTestCipher {
             return;
         }
 
-        cp = Cipher.getInstance(algorithm, encryptProviderName);
+        Cipher cp = Cipher.getInstance(algorithm, encryptProviderName);
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);
         } else {
@@ -1421,7 +1294,7 @@ public class BaseTestDESede extends BaseTestCipher {
             return;
         }
 
-        cp = Cipher.getInstance(algorithm, encryptProviderName);
+        Cipher cp = Cipher.getInstance(algorithm, encryptProviderName);
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);
         } else {
@@ -1478,7 +1351,7 @@ public class BaseTestDESede extends BaseTestCipher {
             return;
         }
 
-        cp = Cipher.getInstance(algorithm, encryptProviderName);
+        Cipher cp = Cipher.getInstance(algorithm, encryptProviderName);
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);
         } else {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDH.java
@@ -22,9 +22,6 @@ import javax.crypto.spec.DHParameterSpec;
 
 public class BaseTestDH extends BaseTest {
 
-    // --------------------------------------------------------------------------
-    //
-    //
     static final byte[] origMsg = "this is the original message to be signed".getBytes();
 
     static DHParameterSpec algParameterSpec_1024, algParameterSpec_2048, algParameterSpec_3072,
@@ -100,28 +97,16 @@ public class BaseTestDH extends BaseTest {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public BaseTestDH(String providerName) {
         super(providerName);
         myProviderName = providerName;
         generateParameters(providerName);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void setUp() throws Exception {}
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void tearDown() throws Exception {}
 
-    // --------------------------------------------------------------------------
-    //
-    //
     /**
      * Basic DH example
      *
@@ -379,18 +364,18 @@ public class BaseTestDH extends BaseTest {
                 break;
 
             case "4096":
-                keyPairA = keyPairA_1024;
-                keyPairB = keyPairB_1024;
+                keyPairA = keyPairA_4096;
+                keyPairB = keyPairB_4096;
                 break;
 
             case "6144":
-                keyPairA = keyPairA_1024;
-                keyPairB = keyPairB_1024;
+                keyPairA = keyPairA_6144;
+                keyPairB = keyPairB_6144;
                 break;
 
             case "8192":
-                keyPairA = keyPairA_1024;
-                keyPairB = keyPairB_1024;
+                keyPairA = keyPairA_8192;
+                keyPairB = keyPairB_8192;
                 break;
         }
 
@@ -475,19 +460,11 @@ public class BaseTestDH extends BaseTest {
     }
 
     static private DHParameterSpec generateDHParameters_static(int size) throws Exception {
-        // java.security.Provider java_provider;
-        // java_provider = java.security.Security.getProvider("OpenJCEPlus");
-        // if( java_provider == null ) {
-        //     java_provider = (java.security.Provider)Class.forName("com.ibm.crypto.plus.provider.OpenJCEPlus").newInstance();
-        //     java.security.Security.insertProviderAt(java_provider, 1);
-        // }
         AlgorithmParameterGenerator algParamGen = AlgorithmParameterGenerator.getInstance("DH",
                 myProviderName);
         algParamGen.init(size);
         AlgorithmParameters algParams = algParamGen.generateParameters();
         DHParameterSpec dhps = algParams.getParameterSpec(DHParameterSpec.class);
         return dhps;
-
     }
-
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDSAKey.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDSAKey.java
@@ -22,38 +22,74 @@ import java.security.spec.DSAPublicKeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
+import java.util.Base64;
 
 public class BaseTestDSAKey extends BaseTest {
+    private static String publicKey1024 = "MIIBuDCCASwGByqGSM44BAEwggEfAoGBAP1/U4EddRIpUt9KnC7"
+                                        + "s5Of2EbdSPO9EAMMeP4C2USZpRV1AIlH7WT2NWPq/xfW6MPbLm1"
+                                        + "Vs14E7gB00b/JmYLdrmVClpJ+f6AR7ECLCT7up1/63xhv4O1fnx"
+                                        + "qimFQ8E+4P208UewwI1VBNaFpEy9nXzrith1yrv8iIDGZ3RSAHH"
+                                        + "AhUAl2BQjxUjC8yykrmCouuEC/BYHPUCgYEA9+GghdabPd7LvKt"
+                                        + "cNrhXuXmUr7v6OuqC+VdMCz0HgmdRWVeOutRZT+ZxBxCBgLRJFn"
+                                        + "Ej6EwoFhO3zwkyjMim4TwWeotUfI0o4KOuHiuzpnWRbqN/C/ohN"
+                                        + "WLx+2J6ASQ7zKTxvqhRkImog9/hWuWfBpKLZl6Ae1UlZAFMO/7P"
+                                        + "SSoDgYUAAoGBAKES3BYGBLgJAjVrX8E+XqGS0PISkw4XDFNRmxj"
+                                        + "zYITQCn1vW6LqKIa774qZ/YMhNS+IjjmzopkUFPQRyRZr715XHg"
+                                        + "ckj3wviNkjHBVb7cYLl7VSyUHujlC5O8zRtH1uaZhIXjLZ5s7Yt"
+                                        + "AToIR78LByFRV5HdTroN16uGJPFi+pv";
+    private static String publicKey2048 = "MIIDRzCCAjoGByqGSM44BAEwggItAoIBAQDBFbxm6EEiDWq/5Zm"
+                                        + "In2/hl8Sd0piJnQBC2XV3BWeg30EVvGboQSINar/lmYifb+GXxJ"
+                                        + "3SmImdAELZdXcFZ6DeQRW8ZuhBIg1qv+WZiJ9v4ZfEndKYiZ0AQ"
+                                        + "tl1dwVnoN1BFbxm6EEiDWq/5ZmIn2/hl8Sd0piJnQBC2XV3BWeg"
+                                        + "3EEVvGboQSINar/lmYifb+GXxJ3SmImdAELZdXcFZ6DbQRW8Zuh"
+                                        + "BIg1qv+WZiJ9v4ZfEndKYiZ0AQtl1dwVnoNpBFbxm6EEiDWq/5Z"
+                                        + "mIn2/hl8Sd0piJnQBC2XV3BWeg2KM+hJWvYg2zJ+dct5yoBS7Sx"
+                                        + "KpOWOIZpwJmOWae8BE9AiEA6VUEEKoMDhxuHBm2jDho2QwLPA8N"
+                                        + "OjKFSO2cmwFijTMCggEBAIWeQQfQ4KzgmzWm6oUv4M8bJN5Anu+"
+                                        + "3K7UkhxDd6RMHj2qRUotPAY1QukNIkiH/aBFW/58qYunRja4X5r"
+                                        + "nek3JsTyiFjjTt/BUwifk1h/v9hsoEKSlCLXiR2JVqlMm6MYMhD"
+                                        + "mzaG0cNNCJY6ash5wTnvQqaTyCdFBS+Ng2kv6zNolPkUjWwlsBi"
+                                        + "UcRcTfIYCwMq2jMz8OybxWxIUrMFUq9BX6CZf1uUY33FPMVO9gV"
+                                        + "q4efm555G10qdQ1KEUd90iMfV4+pZ6tTSs/bSOKL+7uTHuiGb8Y"
+                                        + "vHlvkctrp6e5eC3JjN/CoQ7TGUa0xPMC3t9rFTJzcj17hrqMpis"
+                                        + "lBtDj4DggEFAAKCAQASQ0GXKor25Jebe1UXVLU8/az2HRCfD8zk"
+                                        + "v30PBJYtcG3cCBBiJpM/AgRtVVYKMVJIIaUFDkU1JpcprTzJKfa"
+                                        + "OlsaxuGKtKh8ps0EQBkr56/ORS/nGCvGv88ZwzfODB8/3Gazsiu"
+                                        + "fQ4Ey+dhLVJrZr0qWV4ug24nMRaMr2aGjzQoFN+YGqL30DZOP2b"
+                                        + "xZ/kwV0ymZ6U9HE2WQIoUc3uNpZAL9/yVenYI6J/ABNJ/+amBEn"
+                                        + "2kXoKd584KEN0OW3pHvXjvq+i6ecZrBdjHHUqB/yNBwHTxVO+S8"
+                                        + "alyMhRAEQFuce07a+9JlBG/Lbt2UBuRWIeFaCTfYlwpyQVM08844V";
+    private static String privateKey1024 = "MIIBSwIBADCCASwGByqGSM44BAEwggEfAoGBAP1/U4EddRIpUt"
+                                        + "9KnC7s5Of2EbdSPO9EAMMeP4C2USZpRV1AIlH7WT2NWPq/xfW6M"
+                                        + "PbLm1Vs14E7gB00b/JmYLdrmVClpJ+f6AR7ECLCT7up1/63xhv4"
+                                        + "O1fnxqimFQ8E+4P208UewwI1VBNaFpEy9nXzrith1yrv8iIDGZ3"
+                                        + "RSAHHAhUAl2BQjxUjC8yykrmCouuEC/BYHPUCgYEA9+GghdabPd"
+                                        + "7LvKtcNrhXuXmUr7v6OuqC+VdMCz0HgmdRWVeOutRZT+ZxBxCBg"
+                                        + "LRJFnEj6EwoFhO3zwkyjMim4TwWeotUfI0o4KOuHiuzpnWRbqN/"
+                                        + "C/ohNWLx+2J6ASQ7zKTxvqhRkImog9/hWuWfBpKLZl6Ae1UlZAF"
+                                        + "MO/7PSSoEFgIUCc41R8JfeJttaKod0kM2TQBnVNA=";
+    private static String privateKey2048 = "MIICZQIBADCCAjoGByqGSM44BAEwggItAoIBAQDBFbxm6EEiDW"
+                                        + "q/5ZmIn2/hl8Sd0piJnQBC2XV3BWeg30EVvGboQSINar/lmYifb"
+                                        + "+GXxJ3SmImdAELZdXcFZ6DeQRW8ZuhBIg1qv+WZiJ9v4ZfEndKY"
+                                        + "iZ0AQtl1dwVnoN1BFbxm6EEiDWq/5ZmIn2/hl8Sd0piJnQBC2XV"
+                                        + "3BWeg3EEVvGboQSINar/lmYifb+GXxJ3SmImdAELZdXcFZ6DbQR"
+                                        + "W8ZuhBIg1qv+WZiJ9v4ZfEndKYiZ0AQtl1dwVnoNpBFbxm6EEiD"
+                                        + "Wq/5ZmIn2/hl8Sd0piJnQBC2XV3BWeg2KM+hJWvYg2zJ+dct5yo"
+                                        + "BS7SxKpOWOIZpwJmOWae8BE9AiEA6VUEEKoMDhxuHBm2jDho2Qw"
+                                        + "LPA8NOjKFSO2cmwFijTMCggEBAIWeQQfQ4KzgmzWm6oUv4M8bJN"
+                                        + "5Anu+3K7UkhxDd6RMHj2qRUotPAY1QukNIkiH/aBFW/58qYunRj"
+                                        + "a4X5rnek3JsTyiFjjTt/BUwifk1h/v9hsoEKSlCLXiR2JVqlMm6"
+                                        + "MYMhDmzaG0cNNCJY6ash5wTnvQqaTyCdFBS+Ng2kv6zNolPkUjW"
+                                        + "wlsBiUcRcTfIYCwMq2jMz8OybxWxIUrMFUq9BX6CZf1uUY33FPM"
+                                        + "VO9gVq4efm555G10qdQ1KEUd90iMfV4+pZ6tTSs/bSOKL+7uTHu"
+                                        + "iGb8YvHlvkctrp6e5eC3JjN/CoQ7TGUa0xPMC3t9rFTJzcj17hr"
+                                        + "qMpislBtDj4EIgIgJGAGjgXTmTeq0L8Oo2jCuSCLmEeFfMM9xjt"
+                                        +"tGLOCEc8=";
 
-    // --------------------------------------------------------------------------
-    //
-    //
-    protected KeyPairGenerator dsaKeyPairGen;
-    protected KeyFactory dsaKeyFactory;
-
-    // --------------------------------------------------------------------------
-    //
-    //
     public BaseTestDSAKey(String providerName) {
         super(providerName);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
-    public void setUp() throws Exception {
-        dsaKeyPairGen = KeyPairGenerator.getInstance("DSA", providerName);
-        dsaKeyFactory = KeyFactory.getInstance("DSA", providerName);
-    }
-
-    // --------------------------------------------------------------------------
-    //
-    //
-    public void tearDown() throws Exception {}
-
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDSAKeyGen_1024() throws Exception {
         try {
             KeyPair dsaKeyPair = generateKeyPair(1024);
@@ -68,18 +104,12 @@ public class BaseTestDSAKey extends BaseTest {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDSAKeyGen_2048() throws Exception {
         KeyPair dsaKeyPair = generateKeyPair(2048);
         dsaKeyPair.getPublic();
         dsaKeyPair.getPrivate();
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDSAKeyGenFromParams_1024() throws Exception {
         try {
             AlgorithmParameters algParams = generateParameters(1024);
@@ -98,9 +128,6 @@ public class BaseTestDSAKey extends BaseTest {
 
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDSAKeyFactoryCreateFromEncoded_1024() throws Exception {
         try {
 
@@ -114,16 +141,10 @@ public class BaseTestDSAKey extends BaseTest {
         }
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDSAKeyFactoryCreateFromEncoded_2048() throws Exception {
         keyFactoryCreateFromEncoded(2048);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDSAKeyFactoryCreateFromKeySpec_1024() throws Exception {
         try {
             keyFactoryCreateFromKeySpec(1024);
@@ -137,16 +158,10 @@ public class BaseTestDSAKey extends BaseTest {
 
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public void testDSAKeyFactoryCreateFromKeySpec_2048() throws Exception {
         keyFactoryCreateFromKeySpec(2048);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     protected AlgorithmParameters generateParameters(int size) throws Exception {
         AlgorithmParameterGenerator algParmGen = AlgorithmParameterGenerator.getInstance("DSA",
                 providerName);
@@ -155,10 +170,8 @@ public class BaseTestDSAKey extends BaseTest {
         return algParams;
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     protected KeyPair generateKeyPair(int size) throws Exception {
+        KeyPairGenerator dsaKeyPairGen = KeyPairGenerator.getInstance("DSA", providerName);
         dsaKeyPairGen.initialize(size);
         KeyPair keyPair = dsaKeyPairGen.generateKeyPair();
 
@@ -181,10 +194,8 @@ public class BaseTestDSAKey extends BaseTest {
         return keyPair;
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     protected KeyPair generateKeyPair(DSAParameterSpec dsaParameterSpec) throws Exception {
+        KeyPairGenerator dsaKeyPairGen = KeyPairGenerator.getInstance("DSA", providerName);
         dsaKeyPairGen.initialize(dsaParameterSpec);
         KeyPair keyPair = dsaKeyPairGen.generateKeyPair();
 
@@ -207,36 +218,48 @@ public class BaseTestDSAKey extends BaseTest {
         return keyPair;
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
-    protected void keyFactoryCreateFromEncoded(int size) throws Exception {
+    protected KeyPair keyFactoryCreateFromEncoded(int size) throws Exception {
+        byte[] publicKeyArray = null;
+        byte[] privateKeyArray = null;
+        if (providerName.equals("OpenJCEPlusFIPS")) {
+            if (size == 1024) {
+                publicKeyArray = Base64.getDecoder().decode(publicKey1024);
+                privateKeyArray = Base64.getDecoder().decode(privateKey1024);
+            } else if (size == 2048) {
+                publicKeyArray = Base64.getDecoder().decode(publicKey2048);
+                privateKeyArray = Base64.getDecoder().decode(privateKey2048);
+            } else {
+                fail("Unsupported size for keyFactoryCreateFromEncoded method");
+            }
+        } else {
+            KeyPair dsaKeyPair = generateKeyPair(size);
+            publicKeyArray = dsaKeyPair.getPublic().getEncoded();
+            privateKeyArray = dsaKeyPair.getPrivate().getEncoded();
+        }
 
-        KeyPair dsaKeyPair = generateKeyPair(size);
+        X509EncodedKeySpec x509Spec = new X509EncodedKeySpec(publicKeyArray);
+        PKCS8EncodedKeySpec pkcs8Spec = new PKCS8EncodedKeySpec(privateKeyArray);
 
-        X509EncodedKeySpec x509Spec = new X509EncodedKeySpec(dsaKeyPair.getPublic().getEncoded());
-        PKCS8EncodedKeySpec pkcs8Spec = new PKCS8EncodedKeySpec(
-                dsaKeyPair.getPrivate().getEncoded());
-
+        KeyFactory dsaKeyFactory = KeyFactory.getInstance("DSA", providerName);
         DSAPublicKey dsaPub = (DSAPublicKey) dsaKeyFactory.generatePublic(x509Spec);
         DSAPrivateKey dsaPriv = (DSAPrivateKey) dsaKeyFactory.generatePrivate(pkcs8Spec);
 
-        if (!Arrays.equals(dsaPub.getEncoded(), dsaKeyPair.getPublic().getEncoded())) {
+        if (!Arrays.equals(dsaPub.getEncoded(), publicKeyArray)) {
             fail("DSA public key does not match generated public key");
         }
 
-        if (!Arrays.equals(dsaPriv.getEncoded(), dsaKeyPair.getPrivate().getEncoded())) {
+        if (!Arrays.equals(dsaPriv.getEncoded(), privateKeyArray)) {
             fail("DSA private key does not match generated public key");
         }
+
+        return new KeyPair(dsaPub, dsaPriv);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     protected void keyFactoryCreateFromKeySpec(int size) throws Exception {
 
-        KeyPair dsaKeyPair = generateKeyPair(size);
+        KeyPair dsaKeyPair = keyFactoryCreateFromEncoded(size);
 
+        KeyFactory dsaKeyFactory = KeyFactory.getInstance("DSA", providerName);
         DSAPublicKeySpec dsaPubSpec = dsaKeyFactory
                 .getKeySpec(dsaKeyPair.getPublic(), DSAPublicKeySpec.class);
         DSAPublicKey dsaPub = (DSAPublicKey) dsaKeyFactory.generatePublic(dsaPubSpec);

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestEdDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestEdDSASignature.java
@@ -27,6 +27,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.NamedParameterSpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import static org.junit.Assert.assertTrue;
 
@@ -299,7 +300,7 @@ public class BaseTestEdDSASignature extends BaseTestSignature {
 
         Signature sig = Signature.getInstance(name, getProviderName());
         sig.initSign(kp.getPrivate());
-        byte[] testMessage = origMsg;
+        byte[] testMessage = Arrays.copyOf(origMsg, origMsg.length);
         sig.update(testMessage);
         byte[] msgSig = sig.sign();
 

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAll.java
@@ -19,7 +19,7 @@ import org.junit.platform.suite.api.Suite;
         TestAESGCMSameBuffer.class, TestAESGCMWithByteBuffer.class,
         TestAESGCMCICOWithGCMAndAAD.class, TestAESGCMLong.class, TestAESGCMBufferIV.class,
         TestAliases.class, TestDHKeyPairGenerator.class, TestDH.class, TestDHMultiParty.class,
-        TestDHInteropSunJCE.class, TestDHKeyFactory.class, TestECDH.class,
+        TestDHInteropSunJCE.class, TestDHKeyFactory.class, TestDSAKey.class, TestECDH.class,
         TestECDHInteropSunEC.class, TestECDHMultiParty.class, TestECDSASignature.class,
         TestECDSASignatureInteropSunEC.class, TestECKeyImport.class,
         TestECKeyImportInteropSunEC.class, TestECKeyPairGenerator.class, TestHKDF.class,

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDSAKey.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDSAKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,38 +8,28 @@
 
 package ibm.jceplus.junit.openjceplusfips;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Disabled;
 
 public class TestDSAKey extends ibm.jceplus.junit.base.BaseTestDSAKey {
 
-    //--------------------------------------------------------------------------
-    //
-    //
     static {
         Utils.loadProviderTestSuite();
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
     public TestDSAKey() {
         super(Utils.TEST_SUITE_PROVIDER_NAME);
     }
 
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static void main(String[] args) throws Exception {
-        junit.textui.TestRunner.run(suite());
-    }
+    @Disabled("DSA key generation is not available in FIPS mode.")
+    @Override
+    public void testDSAKeyGen_1024() throws Exception {}
 
-    //--------------------------------------------------------------------------
-    //
-    //
-    public static Test suite() {
-        TestSuite suite = new TestSuite(TestDSAKey.class);
-        return suite;
-    }
+    @Disabled("DSA key generation is not available in FIPS mode.")
+    @Override
+    public void testDSAKeyGen_2048() throws Exception {}
+
+    @Disabled("DSA algorithm parameters are not available in FIPS mode.")
+    @Override
+    public void testDSAKeyGenFromParams_1024() throws Exception {}
 }
 

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestDSAKey.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestDSAKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,43 +10,27 @@ package ibm.jceplus.junit.openjceplusfips.multithread;
 
 import ibm.jceplus.junit.base.BaseTestDSAKey;
 import ibm.jceplus.junit.openjceplusfips.Utils;
+import org.junit.jupiter.api.Disabled;
 
 public class TestDSAKey extends BaseTestDSAKey {
 
-    // --------------------------------------------------------------------------
-    //
-    //
     static {
         Utils.loadProviderTestSuite();
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
     public TestDSAKey() {
         super(Utils.TEST_SUITE_PROVIDER_NAME);
     }
 
-    // --------------------------------------------------------------------------
-    //
-    //
+    @Disabled("DSA key generation is not available in FIPS mode.")
+    @Override
+    public void testDSAKeyGen_1024() throws Exception {}
 
+    @Disabled("DSA key generation is not available in FIPS mode.")
+    @Override
+    public void testDSAKeyGen_2048() throws Exception {}
 
-    public void testDSAKey() throws Exception {
-
-        System.out.println("executing testDSAKey");
-        BaseTestDSAKey bt = new BaseTestDSAKey(providerName);
-        bt.run();
-
-    }
-
-    // --------------------------------------------------------------------------
-    //
-    //
-    public static void main(String[] args) throws Exception {
-        String[] nargs = {ibm.jceplus.junit.openjceplusfips.multithread.TestDSAKey.class.getName()};
-        junit.textui.TestRunner.main(nargs);
-    }
-
-
+    @Disabled("DSA algorithm parameters are not available in FIPS mode.")
+    @Override
+    public void testDSAKeyGenFromParams_1024() throws Exception {}
 }

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA3_224.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA3_224.java
@@ -8,24 +8,22 @@
 
 package ibm.jceplus.junit.openjceplusfips.multithread;
 
-import ibm.jceplus.junit.base.BaseTestDH;
-import ibm.jceplus.junit.openjceplusfips.Utils;
+import ibm.jceplus.junit.base.BaseTestHmacSHA3_224;
+import ibm.jceplus.junit.openjceplus.Utils;
 
-public class TestDH extends BaseTestDH {
+public class TestHmacSHA3_224 extends ibm.jceplus.junit.base.BaseTestHmacSHA3_224 {
 
     static {
         Utils.loadProviderTestSuite();
     }
 
-    public TestDH() {
+    public TestHmacSHA3_224() {
         super(Utils.TEST_SUITE_PROVIDER_NAME);
-        isMulti = true;
     }
 
-    public void testDH() throws Exception {
-        System.out.println("executing testDH");
-        BaseTestDH bt = new BaseTestDH(providerName);
+    public void testHmacSHA3_224() throws Exception {
+        System.out.println("executing testHmacSHA3_224");
+        BaseTestHmacSHA3_224 bt = new BaseTestHmacSHA3_224(providerName);
         bt.run();
     }
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA3_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA3_256.java
@@ -8,24 +8,22 @@
 
 package ibm.jceplus.junit.openjceplusfips.multithread;
 
-import ibm.jceplus.junit.base.BaseTestDH;
-import ibm.jceplus.junit.openjceplusfips.Utils;
+import ibm.jceplus.junit.base.BaseTestHmacSHA3_256;
+import ibm.jceplus.junit.openjceplus.Utils;
 
-public class TestDH extends BaseTestDH {
+public class TestHmacSHA3_256 extends ibm.jceplus.junit.base.BaseTestHmacSHA3_256 {
 
     static {
         Utils.loadProviderTestSuite();
     }
 
-    public TestDH() {
+    public TestHmacSHA3_256() {
         super(Utils.TEST_SUITE_PROVIDER_NAME);
-        isMulti = true;
     }
 
-    public void testDH() throws Exception {
-        System.out.println("executing testDH");
-        BaseTestDH bt = new BaseTestDH(providerName);
+    public void testHmacSHA3_256() throws Exception {
+        System.out.println("executing testHmacSHA3_256");
+        BaseTestHmacSHA3_256 bt = new BaseTestHmacSHA3_256(providerName);
         bt.run();
     }
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA3_384.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA3_384.java
@@ -8,24 +8,22 @@
 
 package ibm.jceplus.junit.openjceplusfips.multithread;
 
-import ibm.jceplus.junit.base.BaseTestDH;
-import ibm.jceplus.junit.openjceplusfips.Utils;
+import ibm.jceplus.junit.base.BaseTestHmacSHA3_384;
+import ibm.jceplus.junit.openjceplus.Utils;
 
-public class TestDH extends BaseTestDH {
+public class TestHmacSHA3_384 extends ibm.jceplus.junit.base.BaseTestHmacSHA3_384 {
 
     static {
         Utils.loadProviderTestSuite();
     }
 
-    public TestDH() {
+    public TestHmacSHA3_384() {
         super(Utils.TEST_SUITE_PROVIDER_NAME);
-        isMulti = true;
     }
 
-    public void testDH() throws Exception {
-        System.out.println("executing testDH");
-        BaseTestDH bt = new BaseTestDH(providerName);
+    public void testHmacSHA3_384() throws Exception {
+        System.out.println("executing testHmacSHA3_384");
+        BaseTestHmacSHA3_384 bt = new BaseTestHmacSHA3_384(providerName);
         bt.run();
     }
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA3_512.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA3_512.java
@@ -8,24 +8,22 @@
 
 package ibm.jceplus.junit.openjceplusfips.multithread;
 
-import ibm.jceplus.junit.base.BaseTestDH;
-import ibm.jceplus.junit.openjceplusfips.Utils;
+import ibm.jceplus.junit.base.BaseTestHmacSHA3_512;
+import ibm.jceplus.junit.openjceplus.Utils;
 
-public class TestDH extends BaseTestDH {
+public class TestHmacSHA3_512 extends ibm.jceplus.junit.base.BaseTestHmacSHA3_512 {
 
     static {
         Utils.loadProviderTestSuite();
     }
 
-    public TestDH() {
+    public TestHmacSHA3_512() {
         super(Utils.TEST_SUITE_PROVIDER_NAME);
-        isMulti = true;
     }
 
-    public void testDH() throws Exception {
-        System.out.println("executing testDH");
-        BaseTestDH bt = new BaseTestDH(providerName);
+    public void testHmacSHA3_512() throws Exception {
+        System.out.println("executing testHmacSHA3_512");
+        BaseTestHmacSHA3_512 bt = new BaseTestHmacSHA3_512(providerName);
         bt.run();
     }
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA3_224.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA3_224.java
@@ -8,24 +8,22 @@
 
 package ibm.jceplus.junit.openjceplusfips.multithread;
 
-import ibm.jceplus.junit.base.BaseTestDH;
-import ibm.jceplus.junit.openjceplusfips.Utils;
+import ibm.jceplus.junit.base.BaseTestSHA3_224KAT;
+import ibm.jceplus.junit.openjceplus.Utils;
 
-public class TestDH extends BaseTestDH {
+public class TestSHA3_224 extends ibm.jceplus.junit.base.BaseTestSHA3_224KAT {
 
     static {
         Utils.loadProviderTestSuite();
     }
 
-    public TestDH() {
+    public TestSHA3_224() {
         super(Utils.TEST_SUITE_PROVIDER_NAME);
-        isMulti = true;
     }
 
-    public void testDH() throws Exception {
-        System.out.println("executing testDH");
-        BaseTestDH bt = new BaseTestDH(providerName);
+    public void testSHA3_224() throws Exception {
+        System.out.println("executing testSHA3_224");
+        BaseTestSHA3_224KAT bt = new BaseTestSHA3_224KAT(providerName);
         bt.run();
     }
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA3_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA3_256.java
@@ -8,24 +8,22 @@
 
 package ibm.jceplus.junit.openjceplusfips.multithread;
 
-import ibm.jceplus.junit.base.BaseTestDH;
-import ibm.jceplus.junit.openjceplusfips.Utils;
+import ibm.jceplus.junit.base.BaseTestSHA3_256KAT;
+import ibm.jceplus.junit.openjceplus.Utils;
 
-public class TestDH extends BaseTestDH {
+public class TestSHA3_256 extends BaseTestSHA3_256KAT {
 
     static {
         Utils.loadProviderTestSuite();
     }
 
-    public TestDH() {
+    public TestSHA3_256() {
         super(Utils.TEST_SUITE_PROVIDER_NAME);
-        isMulti = true;
     }
 
-    public void testDH() throws Exception {
-        System.out.println("executing testDH");
-        BaseTestDH bt = new BaseTestDH(providerName);
+    public void testSHA3_256() throws Exception {
+        System.out.println("executing testSHA3_256");
+        BaseTestSHA3_256KAT bt = new BaseTestSHA3_256KAT(providerName);
         bt.run();
     }
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA3_384.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA3_384.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright IBM Corp. 2023,2024
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution.
+ */
+
+package ibm.jceplus.junit.openjceplusfips.multithread;
+
+import ibm.jceplus.junit.base.BaseTestSHA3_384KAT;
+import ibm.jceplus.junit.openjceplus.Utils;
+
+public class TestSHA3_384 extends ibm.jceplus.junit.base.BaseTestSHA3_384KAT {
+
+    static {
+        Utils.loadProviderTestSuite();
+    }
+
+    public TestSHA3_384() {
+        super(Utils.TEST_SUITE_PROVIDER_NAME);
+    }
+
+    public void testSHA3_384() throws Exception {
+        System.out.println("executing testSHA3_384");
+        BaseTestSHA3_384KAT bt = new BaseTestSHA3_384KAT(providerName);
+        bt.run();
+    }
+}

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA3_512.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA3_512.java
@@ -8,24 +8,22 @@
 
 package ibm.jceplus.junit.openjceplusfips.multithread;
 
-import ibm.jceplus.junit.base.BaseTestDH;
-import ibm.jceplus.junit.openjceplusfips.Utils;
+import ibm.jceplus.junit.base.BaseTestSHA3_512KAT;
+import ibm.jceplus.junit.openjceplus.Utils;
 
-public class TestDH extends BaseTestDH {
+public class TestSHA3_512 extends ibm.jceplus.junit.base.BaseTestSHA3_512KAT {
 
     static {
         Utils.loadProviderTestSuite();
     }
 
-    public TestDH() {
+    public TestSHA3_512() {
         super(Utils.TEST_SUITE_PROVIDER_NAME);
-        isMulti = true;
     }
 
-    public void testDH() throws Exception {
-        System.out.println("executing testDH");
-        BaseTestDH bt = new BaseTestDH(providerName);
+    public void testSHA3_512() throws Exception {
+        System.out.println("executing testSHA3_512");
+        BaseTestSHA3_512KAT bt = new BaseTestSHA3_512KAT(providerName);
         bt.run();
     }
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA512_224.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA512_224.java
@@ -1,12 +1,11 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
  * in the file LICENSE in the source distribution.
  */
-package ibm.jceplus.junit.openjceplus.multithread;
-
+package ibm.jceplus.junit.openjceplusfips.multithread;
 
 import ibm.jceplus.junit.base.BaseTestSHA512_224;
 import ibm.jceplus.junit.openjceplus.Utils;
@@ -24,9 +23,6 @@ public class TestSHA512_224 extends BaseTestSHA512_224 {
     public void testSHA512_224() throws Exception {
         System.out.println("executing testSHA512_224");
         BaseTestSHA512_224 bt = new BaseTestSHA512_224(providerName);
-
         bt.run();
-
     }
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA512_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA512_256.java
@@ -5,27 +5,24 @@
  * this file except in compliance with the License.  You can obtain a copy
  * in the file LICENSE in the source distribution.
  */
-
 package ibm.jceplus.junit.openjceplusfips.multithread;
 
-import ibm.jceplus.junit.base.BaseTestDH;
-import ibm.jceplus.junit.openjceplusfips.Utils;
+import ibm.jceplus.junit.base.BaseTestSHA512_256;
+import ibm.jceplus.junit.openjceplus.Utils;
 
-public class TestDH extends BaseTestDH {
+public class TestSHA512_256 extends BaseTestSHA512_256 {
 
     static {
         Utils.loadProviderTestSuite();
     }
 
-    public TestDH() {
+    public TestSHA512_256() {
         super(Utils.TEST_SUITE_PROVIDER_NAME);
-        isMulti = true;
     }
 
-    public void testDH() throws Exception {
-        System.out.println("executing testDH");
-        BaseTestDH bt = new BaseTestDH(providerName);
+    public void testSHA512_256() throws Exception {
+        System.out.println("executing testSHA512_256");
+        BaseTestSHA512_256 bt = new BaseTestSHA512_256(providerName);
         bt.run();
     }
 }
-


### PR DESCRIPTION
Several updates are made to both FIPS and non-FIPS multithreaded tests.
- Base tests are updated to avoid race conditions between class fields
- Tests are added and the lists between FIPS and non-FIPS are updated to be similar.
- Certain test cases not available in FIPS mode are disabled

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>