### PR TITLE
Set provider version to 23 and remove 22 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>OpenJCEPlus</artifactId>
-    <version>22</version>
+    <version>23</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -103,15 +103,6 @@
                 <build.native.file>${basedir}/buildNativeMac.sh</build.native.file>
                 <build.platform.value>Mac</build.platform.value>
                 <build.target.jgskitlib.dir>${project.basedir}/target/buildmac/aarch64/</build.target.jgskitlib.dir>
-            </properties>
-          </profile>
-          <profile>
-            <id>Profile for JDK 22 Build</id>
-            <activation>
-              <jdk>22</jdk>
-            </activation>
-            <properties>
-                <jdk.build.target>22</jdk.build.target>
             </properties>
           </profile>
           <profile>
@@ -268,8 +259,8 @@
                         <message>"Property ock.library.path is not set, perhaps this required property is missing from the command line?"</message>
                       </requireProperty>
                       <requireJavaVersion>
-                        <version>x = 22</version>
-                        <message>"Java 22 required to build OpenJCEPlus."</message>
+                        <version>x = 23</version>
+                        <message>"Java 23 required to build OpenJCEPlus."</message>
                       </requireJavaVersion>
                       <requireEnvironmentVariable>
                         <variableName>JAVA_HOME</variableName>

--- a/src/main/native/jgskit_resource.rc
+++ b/src/main/native/jgskit_resource.rc
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -27,13 +27,13 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "IBM\0"
             VALUE "FileDescription", "Native JGSKIT runtime library\0"
-            VALUE "FileVersion", "21\0"
+            VALUE "FileVersion", "23\0"
 	        VALUE "Build Increment", "0\0"
             VALUE "InternalName", "jgskit.dll\0"
-            VALUE "LegalCopyright", "(C) Copyright IBM Corp. 2023. Licensed under the Apache License 2.0.\0"
+            VALUE "LegalCopyright", "(C) Copyright IBM Corp. 2023, 2024. Licensed under the Apache License 2.0.\0"
             VALUE "OriginalFilename", "jgskit.dll\0"
-            VALUE "ProductName", "OpenJCEPlus Crypto Provider for Windows, 21.0\0"
-            VALUE "ProductVersion", "21.0\0"
+            VALUE "ProductName", "OpenJCEPlus Crypto Provider for Windows, 23.0\0"
+            VALUE "ProductVersion", "23.0\0"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
The version of the OpenJCEPlus provider needs to be set to `23` for the `java23` and `main` branches.

The Java 22 profile is no longer allowable for building the `java23` and `main` branches given that Java 23 is now generally available.

Copyrights and versions were updated in the jgskit_resource.rc file.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>
