### PR TITLE
Use openjdk Debug class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
                   <configuration>
                     <useModulePath>false</useModulePath>
                     <!-- Could add -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0.0.0.0:8787 for debug -->
+                    <!-- Could add -Djava.security.auth.debug=all for debug -->
                     <argLine>
                       @{argLine}
                       --patch-module openjceplus="target${file.separator}classes${path.separator}target${file.separator}test-classes"
@@ -165,7 +166,6 @@
                     <trimStackTrace>false</trimStackTrace>
                     <systemPropertyVariables>
                       <jgskit.library.path>${build.target.jgskitlib.dir}</jgskit.library.path>
-                      <!--java.security.auth.debug>all</java.security.auth.debug-->
                     </systemPropertyVariables>
                     <includes>
                       <include>
@@ -208,6 +208,7 @@
                   <configuration>
                     <useModulePath>false</useModulePath>
                     <trimStackTrace>false</trimStackTrace>
+                    <!-- Could add -Djava.security.auth.debug=all for debug -->
                     <argLine>
                       --add-exports openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED
                       --add-exports java.base/sun.security.util=ALL-UNNAMED
@@ -347,12 +348,10 @@
                         Exports statements below this line are necessary for
                         compiling only the test source with target `test-compile`.
                         When compiling only the tests, using an SDK that contains
-                        a bundled version of OpenJCEPlus, the packages com.ibm.misc and
+                        a bundled version of OpenJCEPlus, the package
                         com.ibm.crypto.plus.provider.ock must be explictly exported
                         for unit testing purposes for the tests to compile.
                         -->
-                        <arg>--add-exports </arg>
-                        <arg>openjceplus/com.ibm.misc=ALL-UNNAMED</arg>
                         <arg>--add-exports </arg>
                         <arg>openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED</arg>
                     </compilerArgs>

--- a/src/main/java/com/ibm/crypto/plus/provider/AESCCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESCCMCipher.java
@@ -10,7 +10,6 @@ package com.ibm.crypto.plus.provider;
 
 import com.ibm.crypto.plus.provider.ock.CCMCipher;
 import com.ibm.crypto.plus.provider.ock.OCKContext;
-import com.ibm.misc.Debug;
 import ibm.security.internal.spec.CCMParameterSpec;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -31,6 +30,7 @@ import javax.crypto.CipherSpi;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.ShortBufferException;
+import sun.security.util.Debug;
 
 public final class AESCCMCipher extends CipherSpi implements AESConstants, CCMConstants {
 
@@ -53,8 +53,7 @@ public final class AESCCMCipher extends CipherSpi implements AESConstants, CCMCo
     private byte[] authData = null;
     private boolean updateCalled = false;
     // User enabled debugging
-    private static Debug debug = Debug.getInstance("jceplus");
-
+    private static Debug debug = Debug.getInstance(OpenJCEPlusProvider.DEBUG_VALUE);
 
     /*
      * index of the content size left in the buffer

--- a/src/main/java/com/ibm/crypto/plus/provider/OAEPParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OAEPParameters.java
@@ -8,7 +8,6 @@
 
 package com.ibm.crypto.plus.provider;
 
-import com.ibm.misc.Debug;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.AlgorithmParametersSpi;
@@ -18,6 +17,7 @@ import java.security.spec.InvalidParameterSpecException;
 import java.security.spec.MGF1ParameterSpec;
 import javax.crypto.spec.OAEPParameterSpec;
 import javax.crypto.spec.PSource;
+import sun.security.util.Debug;
 import sun.security.util.DerInputStream;
 import sun.security.util.DerOutputStream;
 import sun.security.util.DerValue;

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
@@ -10,7 +10,6 @@ package com.ibm.crypto.plus.provider;
 
 import com.ibm.crypto.plus.provider.ock.OCKContext;
 import com.ibm.crypto.plus.provider.ock.OCKException;
-import com.ibm.misc.Debug;
 import java.lang.reflect.Constructor;
 import java.security.AccessController;
 import java.security.InvalidParameterException;
@@ -24,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import javax.crypto.SecretKey;
+import sun.security.util.Debug;
 
 @SuppressWarnings({"removal", "deprecation"})
 public final class OpenJCEPlus extends OpenJCEPlusProvider {
@@ -64,7 +64,7 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
     private static volatile OpenJCEPlus instance;
 
     // User enabled debugging
-    private static Debug debug = Debug.getInstance("jceplus");
+    private static Debug debug = Debug.getInstance(DEBUG_VALUE);
 
     private static boolean ockInitialized = false;
     private static OCKContext ockContext;
@@ -74,8 +74,8 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
     public OpenJCEPlus() {
         super("OpenJCEPlus", info);
 
-        if (debug2) {
-            System.out.println("New OpenJCEPlus instance");
+        if (debug != null) {
+            debug.println("New OpenJCEPlus instance");
         }
 
         final OpenJCEPlusProvider jce = this;
@@ -100,23 +100,15 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
         if (instance == null) {
             instance = this;
         }
-
-        if (debug2 || (debug != null)) {
-            System.out
-                    .println("OpenJCEPlus Build-Level: " + getDebugDate(this.getClass().getName()));
-            System.out
-                    .println("OpenJCEPlus library build date: " + OCKContext.getLibraryBuildDate());
+    
+        if (debug != null) {
+            debug.println("OpenJCEPlus Build-Level: " + getDebugDate(this.getClass().getName()));
+            debug.println("OpenJCEPlus library build date: " + OCKContext.getLibraryBuildDate());
             try {
-                System.out.println(
-                        "OpenJCEPlus dependent library version: " + ockContext.getOCKVersion());
-                if (debug2) {
-                    System.out.println("OpenJCEPlus dependent library path: "
-                            + ockContext.getOCKInstallPath());
-                }
+                debug.println("OpenJCEPlus dependent library version: " + ockContext.getOCKVersion());
+                debug.println("OpenJCEPlus dependent library path: " + ockContext.getOCKInstallPath());
             } catch (Throwable t) {
-                if (debug2) {
-                    t.printStackTrace(System.out);
-                }
+                t.printStackTrace(System.out);
             }
         }
     }
@@ -808,9 +800,9 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
                 String[] aliases, Map<String, String> attributes) {
             super(provider, type, algorithm, className, toList(aliases), attributes);
 
-            if (debug2) {
-                System.out.println("Constructing OpenJCEPlusService: " + provider + ", " + type
-                        + ", " + algorithm + ", " + className);
+            if (debug != null) {
+                debug.println("Constructing OpenJCEPlusService: " + provider + ", " + type
+                            + ", " + algorithm + ", " + className);
             }
         }
 
@@ -1000,7 +992,7 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
                 }
             }
 
-            if (debug2 || (debug != null)) {
+            if (debug != null) {
                 exceptionToThrow.printStackTrace(System.out);
             }
 
@@ -1030,7 +1022,7 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
     }
 
     void setOCKExceptionCause(Exception exception, Throwable ockException) {
-        if (debug2) {
+        if (debug != null) {
             exception.initCause(ockException);
         }
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -10,7 +10,6 @@ package com.ibm.crypto.plus.provider;
 
 import com.ibm.crypto.plus.provider.ock.OCKContext;
 import com.ibm.crypto.plus.provider.ock.OCKException;
-import com.ibm.misc.Debug;
 import java.lang.reflect.Constructor;
 import java.security.AccessController;
 import java.security.InvalidParameterException;
@@ -24,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import javax.crypto.SecretKey;
+import sun.security.util.Debug;
 
 @SuppressWarnings({"removal", "deprecation"})
 public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
@@ -62,7 +62,7 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
     private static volatile OpenJCEPlusFIPS instance;
 
     // User enabled debugging
-    private static Debug debug = Debug.getInstance("jceplus");
+    private static Debug debug = Debug.getInstance(DEBUG_VALUE);
 
     private static boolean ockInitialized = false;
     private static OCKContext ockContext;
@@ -70,10 +70,9 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public OpenJCEPlusFIPS() {
         super("OpenJCEPlusFIPS", info);
-        if (debug2) {
-            System.out.println("New OpenJCEPlusFIPS instance");
+        if (debug != null) {
+            debug.println("New OpenJCEPlusFIPS instance");
         }
-
         final OpenJCEPlusProvider jce = this;
 
         AccessController.doPrivileged(new java.security.PrivilegedAction() {
@@ -97,22 +96,14 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
             instance = this;
         }
 
-        if (debug2 || (debug != null)) {
-            System.out.println(
-                    "OpenJCEPlusFIPS Build-Level: " + getDebugDate(this.getClass().getName()));
-            System.out.println(
-                    "OpenJCEPlusFIPS library build date: " + OCKContext.getLibraryBuildDate());
+        if (debug != null) {
+            debug.println("OpenJCEPlusFIPS Build-Level: " + getDebugDate(this.getClass().getName()));
+            debug.println("OpenJCEPlusFIPS library build date: " + OCKContext.getLibraryBuildDate());
             try {
-                System.out.println(
-                        "OpenJCEPlusFIPS dependent library version: " + ockContext.getOCKVersion());
-                if (debug2) {
-                    System.out.println("OpenJCEPlusFIPS dependent library path: "
-                            + ockContext.getOCKInstallPath());
-                }
+                debug.println("OpenJCEPlusFIPS dependent library version: " + ockContext.getOCKVersion());
+                debug.println("OpenJCEPlusFIPS dependent library path: " + ockContext.getOCKInstallPath());
             } catch (Throwable t) {
-                if (debug2) {
-                    t.printStackTrace(System.out);
-                }
+                t.printStackTrace(System.out);
             }
         }
     }
@@ -607,8 +598,8 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
                 String[] aliases, Map<String, String> attributes) {
             super(provider, type, algorithm, className, toList(aliases), attributes);
 
-            if (debug2) {
-                System.out.println("Constructing OpenJCEPlusService: " + provider + ", " + type
+            if (debug != null) {
+                debug.println("Constructing OpenJCEPlusService: " + provider + ", " + type
                         + ", " + algorithm + ", " + className);
             }
         }
@@ -794,7 +785,7 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
                 }
             }
 
-            if (debug2 || (debug != null)) {
+            if (debug != null) {
                 exceptionToThrow.printStackTrace(System.out);
             }
 
@@ -824,7 +815,7 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
     }
 
     void setOCKExceptionCause(Exception exception, Throwable ockException) {
-        if (debug2) {
+        if (debug != null) {
             exception.initCause(ockException);
         }
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
@@ -24,8 +24,7 @@ public abstract class OpenJCEPlusProvider extends java.security.Provider {
 
     private static final String JAVA_VER = System.getProperty("java.specification.version");
 
-    // Are we debugging? -- for developers
-    static final boolean debug2 = false;
+    static final String DEBUG_VALUE = "jceplus";
 
     //    private static boolean verifiedSelfIntegrity = false;
     private static boolean verifiedSelfIntegrity = true;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
@@ -8,7 +8,6 @@
 
 package com.ibm.crypto.plus.provider.ock;
 
-import com.ibm.misc.Debug;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -16,11 +15,10 @@ import java.nio.ByteBuffer;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.ProviderException;
+import sun.security.util.Debug;
 
 @SuppressWarnings({"removal", "deprecation"})
 final class NativeInterface {
-
-    private static final boolean debugLoad = false;
 
     // User enabled debugging
     private static Debug debug = Debug.getInstance("jceplus");
@@ -74,14 +72,14 @@ final class NativeInterface {
     static String getOCKLoadPath() {
         String ockOverridePath = System.getProperty("ock.library.path");
         if (ockOverridePath != null) {
-            if (debugLoad) {
-                System.out.println("Loading ock library using value in property ock.library.path: "
-                        + ockOverridePath);
+            if (debug != null) {
+                debug.println("Loading ock library using value in property ock.library.path: "
+                    + ockOverridePath);
             }
             return ockOverridePath;
         }
-        if (debugLoad) {
-            System.out.println("Library path not found for ock, use java home directory.");
+        if (debug != null) {
+            debug.println("Library path not found for ock, use java home directory.");
         }
 
         String javaHome = System.getProperty("java.home");
@@ -94,8 +92,8 @@ final class NativeInterface {
             ockPath = javaHome + File.separator + "lib";
         }
 
-        if (debugLoad) {
-            System.out.println("Loading ock library using value: " + ockPath);
+        if (debug != null) {
+            debug.println("Loading ock library using value: " + ockPath);
         }
         return ockPath;
     }
@@ -103,15 +101,13 @@ final class NativeInterface {
     static String getJGskitLoadPath() {
         String jgskitOverridePath = System.getProperty("jgskit.library.path");
         if (jgskitOverridePath != null) {
-            if (debugLoad) {
-                System.out.println(
-                        "Loading jgskit library using value in property jgskit.library.path: "
-                                + jgskitOverridePath);
+            if (debug != null) {
+                debug.println("Loading jgskit library using value in property jgskit.library.path: " + jgskitOverridePath);
             }
             return jgskitOverridePath;
         }
-        if (debugLoad) {
-            System.out.println("Libpath not found for jgskit, use java home directory.");
+        if (debug != null) {
+            debug.println("Libpath not found for jgskit, use java home directory.");
         }
 
         String javaHome = System.getProperty("java.home");
@@ -124,8 +120,8 @@ final class NativeInterface {
             jgskitPath = javaHome + File.separator + "lib";
         }
 
-        if (debugLoad) {
-            System.out.println("Loading jgskit library using value: " + jgskitPath);
+        if (debug != null) {
+            debug.println("Loading jgskit library using value: " + jgskitPath);
         }
         return jgskitPath;
     }
@@ -325,18 +321,18 @@ final class NativeInterface {
             //
             try {
                 System.load(libraryName);
-                if (debugLoad) {
-                    System.out.println("Loaded : " + libraryName);
+                if (debug != null) {
+                    debug.println("Loaded : " + libraryName);
                 }
                 return true;
             } catch (Throwable t) {
-                if (debugLoad) {
-                    System.out.println("Failed to load : " + libraryName);
+                if (debug != null) {
+                    debug.println("Failed to load : " + libraryName);
                 }
             }
         } else {
-            if (debugLoad) {
-                System.out.println("Skipping load of " + libraryName);
+            if (debug != null) {
+                debug.println("Skipping load of " + libraryName);
             }
         }
         return false;
@@ -356,9 +352,9 @@ final class NativeInterface {
             String ockLoadPath = new File(getOCKLoadPath()).getCanonicalPath();
             String ockInstallPath = new File(context.getOCKInstallPath()).getCanonicalPath();
 
-            if (debugLoad) {
-                System.out.println("dependent library load path : " + ockLoadPath);
-                System.out.println("dependent library install path : " + ockInstallPath);
+            if (debug != null) {
+                debug.println("dependent library load path : " + ockLoadPath);
+                debug.println("dependent library install path : " + ockInstallPath);
             }
 
             if (ockInstallPath.startsWith(ockLoadPath) == false) {

--- a/src/main/native/jgskit.mac.mak
+++ b/src/main/native/jgskit.mac.mak
@@ -63,7 +63,9 @@ ${HOSTOUT}/%.o: %.c
 	gcc -fPIC ${DEBUG_FLAGS} -c -arch arm64 -pedantic -Wall -fstack-protector -I${TOPDIR}/src/main/native/ -I${GSKIT_HOME}/inc -I${JAVA_HOME}/include -I${JAVA_HOME}/include/darwin $< -o $@
 
 javah: dircreate
-	${JAVA_HOME}/bin/javac --add-exports java.base/jdk.internal.misc=openjceplus -cp ${JCE_CLASSPATH} \
+	${JAVA_HOME}/bin/javac \
+	--add-exports java.base/sun.security.util=openjceplus \
+	-cp ${JCE_CLASSPATH} \
 	${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java \
 	${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/FastJNIBuffer.java \
 	${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/OCKContext.java \

--- a/src/main/native/jgskit.mak
+++ b/src/main/native/jgskit.mak
@@ -184,7 +184,9 @@ ${HOSTOUT}/%.o: %.c
 	${CC} ${CFLAGS} ${DEBUG_FLAGS} -c -I${GSKIT_HOME}/inc -I${JAVA_HOME}/include -I${JAVA_HOME}/include/${OSINCLUDEDIR} $< -o $@
 
 javah: dircreate
-	${JAVA_HOME}/bin/javac --add-exports java.base/jdk.internal.misc=ALL-UNNAMED -cp ${JCE_CLASSPATH} \
+	${JAVA_HOME}/bin/javac \
+	--add-exports java.base/sun.security.util=openjceplus \
+	-cp ${JCE_CLASSPATH} \
 	${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java \
 	${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/FastJNIBuffer.java \
 	${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/OCKContext.java \

--- a/src/main/native/jgskit.win64.cygwin.mak
+++ b/src/main/native/jgskit.win64.cygwin.mak
@@ -58,7 +58,8 @@ dircreate:
 	-@mkdir -p $(HOSTOUT) 2>nul
 
 javah: dircreate
-	$(JAVA_HOME)\bin\javac --add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
+	$(JAVA_HOME)\bin\javac \
+	--add-exports java.base/sun.security.util=openjceplus \
 	$(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\ock\NativeInterface.java \
 	$(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\ock\FastJNIBuffer.java \
 	$(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\ock\OCKContext.java \

--- a/src/main/native/jgskit.win64.mak
+++ b/src/main/native/jgskit.win64.mak
@@ -59,7 +59,9 @@ dircreate:
 	-@mkdir -p $(HOSTOUT) 2>nul
 
 javah: dircreate
-	$(JAVA_HOME)/bin/javac --add-exports java.base/jdk.internal.misc=ALL-UNNAMED -cp $(JCE_CLASSPATH) \
+	$(JAVA_HOME)/bin/javac \
+	--add-exports java.base/sun.security.util=openjceplus \
+	-cp $(JCE_CLASSPATH) \
 	$(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java \
 	$(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/ock/FastJNIBuffer.java \
 	$(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/ock/OCKContext.java \

--- a/src/test/java/ibm/jceplus/junit/base/certificateutils/CertAndKeyGen.java
+++ b/src/test/java/ibm/jceplus/junit/base/certificateutils/CertAndKeyGen.java
@@ -8,7 +8,6 @@
 
 package ibm.jceplus.junit.base.certificateutils;
 
-import com.ibm.misc.Debug;
 import java.io.IOException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;

--- a/src/test/java/ibm/jceplus/junit/base/certificateutils/CertificationRequest.java
+++ b/src/test/java/ibm/jceplus/junit/base/certificateutils/CertificationRequest.java
@@ -8,7 +8,6 @@
 
 package ibm.jceplus.junit.base.certificateutils;
 
-import com.ibm.misc.Debug;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/src/test/java/ibm/jceplus/junit/base/certificateutils/CertificationRequestInfo.java
+++ b/src/test/java/ibm/jceplus/junit/base/certificateutils/CertificationRequestInfo.java
@@ -8,7 +8,6 @@
 
 package ibm.jceplus.junit.base.certificateutils;
 
-import com.ibm.misc.Debug;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigInteger;

--- a/src/test/java/ibm/jceplus/junit/base/certificateutils/Debug.java
+++ b/src/test/java/ibm/jceplus/junit/base/certificateutils/Debug.java
@@ -6,7 +6,7 @@
  * in the file LICENSE in the source distribution.
  */
 
-package com.ibm.misc;
+package ibm.jceplus.junit.base.certificateutils;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -27,23 +27,6 @@ public class Debug {
     private String prefix;
     private static String args;
     private static SimpleConsoleLogger tl = null;
-
-    // TODO: is this needed? it is not referenced in any place
-    //private static boolean isLogging           = false;
-
-    //private static Object ch                   = null;
-    //private static Object tl                   = null;
-    /*private static Object levelFiner           = null;
-    private static Object levelAll             = null;
-    private static Method logMethod            = null;
-    private static Method logThrowableMethod   = null;
-    private static Method logpMethod           = null;
-    private static Method logpParmsMethod      = null;
-    private static Method enteringMethod       = null;
-    private static Method enteringParmsMethod  = null;
-    private static Method exitingMethod        = null;
-    private static Method exitingObjectMethod  = null;
-    */
 
     static {
         args = java.security.AccessController
@@ -328,62 +311,6 @@ public class Debug {
 
             tl = SimpleConsoleLogger.makeSimpleLogger(name);
             tl.setPlatformLevel(PlatformLogger.Level.ALL);
-
-            //              this.isLogging = true;
-
-            /*
-              //A Charlie Foxtrot to do the following "real" java code because
-            //Austin insists on a single version of code for all levels of 
-            //java.
-              
-            Class  consoleHandlerClass  = null;
-            Class  handlerClass  = null;
-            Class  loggerClass  = null;
-            Class  levelClass   = null;
-            Method getLoggerMethod = null;
-            Method addHandlerMethod = null;
-            Method loggerSetLevelMethod = null;
-            Method consoleHandlerSetLevelMethod = null;
-            
-            try {
-                
-                //   Find the three classes we need to do the job
-                
-                loggerClass = Class.forName("java.util.logging.Logger");
-                handlerClass = Class.forName("java.util.logging.Handler");
-                consoleHandlerClass = Class.forName("java.util.logging.ConsoleHandler");
-                levelClass = Class.forName("java.util.logging.Level");
-                levelFiner = levelClass.getField("FINER").get(null);
-                levelAll = levelClass.getField("ALL").get(null);
-            
-                if ((loggerClass != null) && (consoleHandlerClass != null) && (levelClass != null)) {
-                    getLoggerMethod = loggerClass.getMethod("getLogger", new Class[] {String.class});
-                    ch = consoleHandlerClass.getConstructor(new Class[] {}).newInstance(new Object[] {});
-                    loggerSetLevelMethod = loggerClass.getMethod("setLevel", new Class[] {levelClass});
-                    consoleHandlerSetLevelMethod = consoleHandlerClass.getMethod("setLevel", new Class[] {levelClass});
-                    tl = getLoggerMethod.invoke(null, new Object[] {name});
-                    addHandlerMethod = loggerClass.getMethod("addHandler", new Class[] {handlerClass});
-                    addHandlerMethod.invoke(tl, new Object[] {ch});
-                    loggerSetLevelMethod.invoke(tl, new Object[] {levelAll});
-                    consoleHandlerSetLevelMethod.invoke(ch, new Object[] {levelAll});
-            
-                    logMethod = loggerClass.getMethod("log", new Class[] {levelClass, String.class, Object[].class});
-                    logThrowableMethod = loggerClass.getMethod("log", new Class[] {levelClass, String.class, Throwable.class});
-                    logpMethod = loggerClass.getMethod("logp", new Class[] {levelClass, String.class, String.class, String.class});
-                    logpParmsMethod = loggerClass.getMethod("logp", new Class[] {levelClass, String.class, String.class, String.class, Object[].class});
-                    enteringMethod = loggerClass.getMethod("entering", new Class[] {String.class, String.class,});
-                    enteringParmsMethod = loggerClass.getMethod("entering", new Class[] {String.class, String.class, Object[].class});
-                    exitingMethod = loggerClass.getMethod("exiting", new Class[] {String.class, String.class});
-                    exitingObjectMethod = loggerClass.getMethod("exiting", new Class[] {String.class, String.class, Object.class});
-                    this.isLogging = true;
-                }
-                //
-                // If we got an exception, no logging gets done.
-                //
-            } catch (Exception e) {
-                tl = null;
-            }
-            */
         }
     }
 
@@ -452,42 +379,15 @@ public class Debug {
     public void data(long type, Object loggingClass, String loggingMethod, byte[] data) {
         Object[] parms = {data};
         tl.log(PlatformLogger.Level.FINER, (String) loggingClass + " " + loggingMethod, parms);
-        /*
-        try {
-            if (tl != null)
-                logMethod.invoke(tl, new Object[] {levelFiner, (String)loggingClass+" "+loggingMethod, parms});
-            else
-                System.out.println((String)loggingClass+" "+loggingMethod+" data: "+data.toString());
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void entry(long type, Object loggingClass, String loggingMethod) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "ENTRY");
-
-        /*
-        try {
-            if (tl != null)
-                enteringMethod.invoke(tl, new Object[] {(String)loggingClass, loggingMethod});
-            else
-                System.out.println("Entry "+(String)loggingClass+" "+loggingMethod);
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void entry(long type, Object loggingClass, String loggingMethod, Object parm1) {
         //Object[] parms = {parm1};
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "ENTRY");
-        /*try {
-            if (tl != null)
-                enteringParmsMethod.invoke(tl, new Object[] {(String)loggingClass, loggingMethod, parms});
-            else
-                System.out.println("Entry "+(String)loggingClass+" "+loggingMethod+getParms(parms));
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void entry(long type, Object loggingClass, String loggingMethod, Object parm1,
@@ -495,182 +395,71 @@ public class Debug {
         Object[] parms = {parm1, parm2};
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "ENTRY {0} {1}",
                 parms);
-        /*try {
-            if (tl != null)
-                enteringParmsMethod.invoke(tl, new Object[] {(String)loggingClass, loggingMethod, parms});
-            else
-                System.out.println("Entry "+(String)loggingClass+" "+loggingMethod+getParms(parms));
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void entry(long type, Object loggingClass, String loggingMethod, Object[] parms) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "ENTRY {0}",
                 parms);
-        /*
-         try {
-            if (tl != null)
-                enteringParmsMethod.invoke(tl, new Object[] {(String)loggingClass, loggingMethod, parms});
-            else
-                System.out.println("Entry "+(String)loggingClass+" "+loggingMethod+getParms(parms));
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void exception(long type, Object loggingClass, String loggingMethod,
             Throwable throwable) {
         tl.log(PlatformLogger.Level.FINER, (String) loggingClass + " " + loggingMethod, throwable);
-        /*try {
-            if (tl != null)
-                logThrowableMethod.invoke(tl, new Object[] {levelFiner, (String)loggingClass+" "+loggingMethod, throwable});
-            else
-                System.out.println("Exception "+(String)loggingClass+" "+loggingMethod+" "+throwable.toString());
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void exit(long type, Object loggingClass, String loggingMethod) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "RETURN");
-        /*try {
-            if (tl != null)
-                exitingMethod.invoke(tl, new Object[] {(String)loggingClass, loggingMethod});
-            else
-                System.out.println("Exit "+(String)loggingClass+" "+loggingMethod);
-        } catch (Exception e) {
-        }*/
     }
 
     public void exit(long type, Object loggingClass, String loggingMethod, byte retValue) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "RETURN {0}",
                 new Byte(retValue));
-        /*try {
-            if (tl != null)
-                exitingObjectMethod.invoke(tl, new Object[] {(String)loggingClass, loggingMethod, new Byte(retValue)});
-            else
-                System.out.println("Exit "+(String)loggingClass+" "+loggingMethod+" "+new Byte(retValue).toString());
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void exit(long type, Object loggingClass, String loggingMethod, short retValue) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "RETURN {0}",
                 new Short(retValue));
-        /*try {
-            if (tl != null)
-                exitingObjectMethod.invoke(tl, new Object[] {(String)loggingClass, loggingMethod, new Short(retValue)});
-            else
-                System.out.println("Exit "+(String)loggingClass+" "+loggingMethod+" "+new Short(retValue).toString());
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void exit(long type, Object loggingClass, String loggingMethod, int retValue) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "RETURN {0}",
                 new Integer(retValue));
-        /*
-        try {
-            if (tl != null)
-                exitingObjectMethod.invoke(tl, new Object[] {(String)loggingClass, loggingMethod, new Integer(retValue)});
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void exit(long type, Object loggingClass, String loggingMethod, long retValue) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "RETURN {0}",
                 new Long(retValue));
-        /*try {
-            if (tl != null)
-                exitingObjectMethod.invoke(tl, new Object[] {(String)loggingClass, loggingMethod, new Long(retValue)});
-            else
-                System.out.println("Exit "+(String)loggingClass+" "+loggingMethod+" "+new Long(retValue).toString());
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void exit(long type, Object loggingClass, String loggingMethod, float retValue) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "RETURN {0}",
                 new Float(retValue));
-        /*try {
-            if (tl != null)
-                exitingObjectMethod.invoke(tl, new Object[] {(String)loggingClass, loggingMethod, new Float(retValue)});
-            else
-                System.out.println("Exit "+(String)loggingClass+" "+loggingMethod+" "+new Float(retValue).toString());
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void exit(long type, Object loggingClass, String loggingMethod, double retValue) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "RETURN {0}",
                 new Double(retValue));
-        /*try {
-            if (tl != null)
-                exitingObjectMethod.invoke(tl, new Object[] {(String)loggingClass, loggingMethod, new Double(retValue)});
-            else
-                System.out.println("Exit "+(String)loggingClass+" "+loggingMethod+" "+new Double(retValue).toString());
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void exit(long type, Object loggingClass, String loggingMethod, char retValue) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "RETURN {0}",
                 new Character(retValue));
-        /*try {
-            if (tl != null)
-                exitingObjectMethod.invoke(tl, new Object[] {(String)loggingClass, loggingMethod, new Character(retValue)});
-            else
-                System.out.println("Exit "+(String)loggingClass+" "+loggingMethod+" "+new Character(retValue).toString());
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void exit(long type, Object loggingClass, String loggingMethod, boolean retValue) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "RETURN {0}",
                 new Boolean(retValue));
-        /*try {
-            if (tl != null)
-                exitingObjectMethod.invoke(tl, new Object[] {(String)loggingClass, loggingMethod, new Boolean(retValue)});
-            else
-                System.out.println("Exit "+(String)loggingClass+" "+loggingMethod+" "+new Boolean(retValue).toString());
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void exit(long type, Object loggingClass, String loggingMethod, Object retValue) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "RETURN {0}",
                 retValue);
-        /*try {
-            if (tl != null)
-                exitingObjectMethod.invoke(tl, new Object[] {(String)loggingClass, loggingMethod, retValue});
-            else
-                System.out.println("Exit "+(String)loggingClass+" "+loggingMethod+" "+retValue.toString());
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void stackTrace(long type, Object loggingClass, String loggingMethod) {
         StringWriter sw = new StringWriter();
         new Throwable().printStackTrace(new PrintWriter(sw));
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, sw.toString());
-        /*try {
-            if (tl != null)
-                logpMethod.invoke(tl, new Object[] {levelFiner, (String)loggingClass, loggingMethod, sw.toString()});
-            else
-                System.out.println("Stack Trace "+(String)loggingClass+" "+loggingMethod+"\r\n"+sw.toString());
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void stackTrace(long type, Object loggingClass, String loggingMethod, String text) {
@@ -678,68 +467,27 @@ public class Debug {
         new Throwable(text).printStackTrace(new PrintWriter(sw));
         Object[] parms = {sw.toString()};
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, text, parms);
-        /*try {
-            if (tl != null)
-                logpParmsMethod.invoke(tl, new Object[] {levelFiner, (String)loggingClass, loggingMethod, text, parms});
-            else
-                System.out.println("Stack Trace "+(String)loggingClass+" "+loggingMethod+" "+text+"\r\n"+sw.toString());
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void text(long type, Object loggingClass, String loggingMethod, String text) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, text);
-        /*try {
-            if (tl != null)
-                logpMethod.invoke(tl, new Object[] {levelFiner, (String)loggingClass, loggingMethod, text});
-            else
-                System.out.println((String)loggingClass+" "+loggingMethod+" "+text);
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void text(long type, Object loggingClass, String loggingMethod, String text,
             Object parm1) {
         Object[] parms = {parm1};
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, text, parms);
-        /*try {
-            if (tl != null)
-                logpParmsMethod.invoke(tl, new Object[] {levelFiner, (String)loggingClass, loggingMethod, text, parms});
-            else
-                System.out.println((String)loggingClass+" "+loggingMethod+" "+text+getParms(parms));
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void text(long type, Object loggingClass, String loggingMethod, String text,
             Object parm1, Object parm2) {
         Object[] parms = {parm1, parm2};
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, text, parms);
-        /*try {
-            if (tl != null)
-                logpParmsMethod.invoke(tl, new Object[] {levelFiner, (String)loggingClass, loggingMethod, text, parms});
-            else
-                System.out.println((String)loggingClass+" "+loggingMethod+" "+text+getParms(parms));
-        } catch (Exception e) {
-        }
-        */
     }
 
     public void text(long type, Object loggingClass, String loggingMethod, String text,
             Object[] parms) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, text, parms);
-        /*
-        try {
-            if (tl != null)
-                logpParmsMethod.invoke(tl, new Object[] {levelFiner, (String)loggingClass, loggingMethod, text, parms});
-            else
-                System.out.println((String)loggingClass+" "+loggingMethod+" "+text+getParms(parms));
-        } catch (Exception e) {
-        }
-        */
     }
 
     /**

--- a/src/test/java/ibm/jceplus/junit/base/certificateutils/PKCSDerObject.java
+++ b/src/test/java/ibm/jceplus/junit/base/certificateutils/PKCSDerObject.java
@@ -8,7 +8,6 @@
 
 package ibm.jceplus.junit.base.certificateutils;
 
-import com.ibm.misc.Debug;
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;

--- a/src/test/java/ibm/jceplus/junit/base/certificateutils/X500Signer.java
+++ b/src/test/java/ibm/jceplus/junit/base/certificateutils/X500Signer.java
@@ -8,7 +8,6 @@
 
 package ibm.jceplus.junit.base.certificateutils;
 
-import com.ibm.misc.Debug;
 import java.security.NoSuchAlgorithmException;
 import java.security.Signature;
 import java.security.SignatureException;


### PR DESCRIPTION
This update eliminates the use of the last existing class in the `com.ibm.misc` package, which is used for debug traces. Code will for the time being make use of the `sun.security.util.Debug` class instead.

The provider code that currently uses the `com.ibm.misc.Debug` class now makes direct use of the `sun.security.util.Debug` class.

The test code that has more advanced use of the current `Debug` class now contains its own copy of the `Debug` class that once resided in the `com.ibm.misc` package.

Closes #225

Signed-off-by: Jason Katonica <katonica@us.ibm.com>
