### PR TITLE
Java 11 XDH private key parsing logic adjustment

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
@@ -311,11 +311,11 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
 
         // Read, convert, then write private key
         byte[] keyBytes = inputValue[2].getOctetString();
-        DerInputStream derStream = new DerInputStream(keyBytes);
         try {
             // XDH private key in SunEC new Java 17 design requires [octet-string[octet-string[key-bytes]]] format,
             // otherwise, it causes interop issue.
             if (isCorrectlyFormedOctetString(keyBytes)) {
+                DerInputStream derStream = new DerInputStream(keyBytes);
                 k = derStream.getOctetString(); // We know we are working with the format [octet-string[octet-string[key-bytes]]]
             } else {
                 k = keyBytes; // Try J11 format [octet-string[key-bytes]]


### PR DESCRIPTION
XDH encoded private keys can be of two different encoding formats:
1. [octet-string[octet-string[key-bytes]]] on Java 17 and higher.
2. [octet-string[key-bytes]] on Java 11 and lower.

When parsing the Java 11 version of the key encoding we currently incorrectly DER decode the key bytes assuming the Java 17 version of the key encoding format at all times. Occasionally the DER decoder fails to parse the non DER encoding and a failure with the message `Failed to create XEC private key` occurs.

This update attempts to parse the DER key bytes when we have already determined that the key bytes are of the Java 17 and higher key encoding format.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>