### PR TITLE
Makefile improvements

### DIFF
--- a/src/main/native/jgskit.mac.mak
+++ b/src/main/native/jgskit.mac.mak
@@ -8,9 +8,10 @@
 #
 ###############################################################################
 
-TOPDIR=./../../..
+TOPDIR=../../..
 
 PLAT=mac
+CFLAGS= -arch arm64 -pedantic -Wall -fstack-protector
 #Setting this flag will result non key material such as handle to OCK Objects etc being logged to the trace file.
 #This flag must be disabled before building production version
 #DEBUG_FLAGS += -DDEBUG
@@ -27,7 +28,8 @@ HOSTOUT = ${BUILDTOP}/aarch64
 OPENJCEPLUS_HEADER_FILES ?= ${TOPDIR}/src/main/native
 JAVACLASSDIR=${TOPDIR}/target/classes
 
-OBJS= ${HOSTOUT}/BasicRandom.o \
+OBJS= \
+	${HOSTOUT}/BasicRandom.o \
 	${HOSTOUT}/BuildDate.o \
 	${HOSTOUT}/CCM.o \
 	${HOSTOUT}/Digest.o \
@@ -52,30 +54,44 @@ OBJS= ${HOSTOUT}/BasicRandom.o \
 
 TARGET = ${HOSTOUT}/libjgskit.dylib
 
-all: headers ${TARGET}
+all : ${TARGET}
 
-noheaders: ${TARGET}
-
-dircreate:
-	mkdir -p ${HOSTOUT} 2>/dev/null
-
-headers: | dircreate
-	${JAVA_HOME}/bin/javac \
-	--add-exports java.base/sun.security.util=openjceplus \
-	--add-exports java.base/sun.security.util=ALL-UNNAMED \
-	${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java \
-	${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/FastJNIBuffer.java \
-	${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/OCKContext.java \
-	${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/OCKException.java \
-	-d ${JAVACLASSDIR} -h ${TOPDIR}/src/main/native/ 
-
-${TARGET}: ${OBJS}
+${TARGET} : ${OBJS}
 	gcc -shared -m64 -arch arm64 -o ${TARGET} -DMAC ${OBJS} -L ${GSKIT_HOME}/lib64 -l jgsk8iccs
 
-${HOSTOUT}/%.o: %.c | dircreate
-	gcc -fPIC ${DEBUG_FLAGS} -c -arch arm64 -pedantic -Wall -fstack-protector -I${TOPDIR}/src/main/native/ -I${GSKIT_HOME}/inc -I${JAVA_HOME}/include -I${JAVA_HOME}/include/darwin -I${OPENJCEPLUS_HEADER_FILES} $< -o $@
+${HOSTOUT}/%.o : %.c
+	test -d ${@D} || mkdir -p ${@D} 2>/dev/null
+	gcc \
+		-fPIC \
+		${DEBUG_FLAGS} \
+		${CFLAGS} \
+		-c \
+		-I${TOPDIR}/src/main/native/ \
+		-I${GSKIT_HOME}/inc \
+		-I${JAVA_HOME}/include \
+		-I${JAVA_HOME}/include/darwin \
+		-I${OPENJCEPLUS_HEADER_FILES} \
+		-o $@ \
+		$<
 
-clean:
+ifneq (${EXTERNAL_HEADERS},true)
+
+${OBJS} : | headers
+
+headers :
+	echo "Compiling OpenJCEPlus headers"
+	${JAVA_HOME}/bin/javac \
+		--add-exports java.base/sun.security.util=openjceplus \
+		-d ${JAVACLASSDIR} \
+		-h ${TOPDIR}/src/main/native/ \
+		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java \
+		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/FastJNIBuffer.java \
+		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/OCKContext.java \
+		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/OCKException.java
+
+endif # ! EXTERNAL_HEADERS
+
+clean :
 	rm -f ${HOSTOUT}/*.o
 	rm -f ${HOSTOUT}/*.so
 	rm -f ${TOPDIR}/src/main/native/com_ibm_crypto_plus_provider_ock_NativeInterface.h
@@ -83,4 +99,4 @@ clean:
 	rm -f ${TOPDIR}/src/main/native/com_ibm_crypto_plus_provider_ock_OCKContext.h
 	rm -f ${TOPDIR}/src/main/native/com_ibm_crypto_plus_provider_ock_OCKException.h
 
-.PHONY: all dircreate headers clean
+.PHONY : all headers clean

--- a/src/main/native/jgskit.mak
+++ b/src/main/native/jgskit.mak
@@ -1,4 +1,3 @@
-
 ###############################################################################
 #
 # Copyright IBM Corp. 2023, 2024
@@ -9,7 +8,7 @@
 #
 ###############################################################################
 
-TOPDIR=./../../..
+TOPDIR=../../..
 
 PLAT=x86
 CC=gcc
@@ -18,122 +17,99 @@ LDFLAGS= -shared
 IS64SYSTEM=
 AIX_LIBPATH = /usr/lib:/lib
 
-ifeq (${PLATFORM},x86-linux64)
-      PLAT=xa
-      CFLAGS+= -DLINUX -Werror -std=gnu99 -pedantic -Wall -fstack-protector
-      LDFLAGS+= -m64
-      IS64SYSTEM=64
-      OSINCLUDEDIR=linux
-endif
-
-ifeq (${PLATFORM},x86-linux32)
-      PLAT=xi
-      CFLAGS+= -m32 -DLINUX
-      LDFLAGS+= -m32
-endif
-
-ifeq (${PLATFORM},s390-linux64)
-      PLAT=xz
-      LDFLAGS+= -m64
-      CFLAGS+= -DS390_PLATFORM -DLINUX -Werror
-      IS64SYSTEM=64
-      OSINCLUDEDIR=linux
-endif
-
-ifeq (${PLATFORM},s390-linux31)
-      PLAT=xz
-      CFLAGS+= -m31 -DS390_PLATFORM -DLINUX
-      LDFLAGS+= -m31
-endif
-
-
-ifeq (${PLATFORM},s390-zos64)
-      CC=xlc
-      PLAT=mz
-      CFLAGS= -DS390
-#      CFLAGS+= -DPKCS11_DEBUG
-      CFLAGS+= -O3 -W"c,strict,hgpr,hot"
-      CFLAGS+= -Wc,XPLINK,LP64,DLL,exportall
-      LDFLAGS= -Wl,XPLINK,LP64,DLL,AMODE=64
-      ICCARCHIVE = ${GSKIT_HOME}/libjgsk8iccs_64.x
-      IS64SYSTEM=64
-      OSINCLUDEDIR=zos
-endif
-
-ifeq (${PLATFORM},s390-zos31)
-      CC=xlc
-      PLAT=mz
-
-      CFLAGS= -DS390
-#      CFLAGS+= -DPKCS11_DEBUG
-      CFLAGS+= -O3 -W"c,strict,hgpr,hot"
-      CFLAGS+= -W "c,xplink,dll,exportall"
-
-      LDFLAGS= -W "l,xplink,dll"
-      ICCARCHIVE = ${GSKIT_HOME}/libjgsk8iccs.x
-      OSINCLUDEDIR=zos
-endif
-
-
-ifeq (${PLATFORM},ppc-linux64)
-      PLAT=xp
-      CFLAGS+= -DLINUX
-      LDFLAGS+= -m64
-      IS64SYSTEM=64
-      OSINCLUDEDIR=linux
-endif
-
-ifeq (${PLATFORM},ppc-linux32)
-      PLAT=xp
-      CFLAGS+= -m32 -DLINUX
-      LDFLAGS+= -m32
-endif
-
-ifeq (${PLATFORM},ppcle-linux64)
-      PLAT=xl
-      CFLAGS+= -DLINUX -Werror
-      LDFLAGS+= -m64
-      IS64SYSTEM=64
-      OSINCLUDEDIR=linux
-endif
-
-ifeq (${PLATFORM},ppc-aix64)
-      PLAT=ap
-      CC=xlc
-      CFLAGS= -qcpluscmt -q64  -qpic -DAIX -qhalt=w
-      LDFLAGS= -G -q64 -blibpath:$(AIX_LIBPATH)
-      IS64SYSTEM=64
-      OSINCLUDEDIR=aix
-endif
-
 ifeq (${PLATFORM},ppc-aix32)
-      PLAT=ap
-      CC=xlc
-      CFLAGS= -qcpluscmt -q32  -qpic -DAIX
-      LDFLAGS= -G -q32 -blibpath:${AIX_LIBPATH}
+  PLAT=ap
+  CC=xlc
+  CFLAGS= -qcpluscmt -q32 -qpic -DAIX
+  LDFLAGS= -G -q32 -blibpath:${AIX_LIBPATH}
+else ifeq (${PLATFORM},ppc-aix64)
+  PLAT=ap
+  CC=xlc
+  CFLAGS= -qcpluscmt -q64 -qpic -DAIX -qhalt=w
+  LDFLAGS= -G -q64 -blibpath:${AIX_LIBPATH}
+  IS64SYSTEM=64
+  OSINCLUDEDIR=aix
+else ifeq (${PLATFORM},ppc-linux32)
+  PLAT=xp
+  CFLAGS+= -m32 -DLINUX
+  LDFLAGS+= -m32
+else ifeq (${PLATFORM},ppc-linux64)
+  PLAT=xp
+  CFLAGS+= -DLINUX
+  LDFLAGS+= -m64
+  IS64SYSTEM=64
+  OSINCLUDEDIR=linux
+else ifeq (${PLATFORM},ppcle-linux64)
+  PLAT=xl
+  CFLAGS+= -DLINUX -Werror
+  LDFLAGS+= -m64
+  IS64SYSTEM=64
+  OSINCLUDEDIR=linux
+else ifeq (${PLATFORM},s390-linux31)
+  PLAT=xz
+  CFLAGS+= -m31 -DS390_PLATFORM -DLINUX
+  LDFLAGS+= -m31
+else ifeq (${PLATFORM},s390-linux64)
+  PLAT=xz
+  LDFLAGS+= -m64
+  CFLAGS+= -DS390_PLATFORM -DLINUX -Werror
+  IS64SYSTEM=64
+  OSINCLUDEDIR=linux
+else ifeq (${PLATFORM},s390-zos31)
+  CC=xlc
+  PLAT=mz
+  CFLAGS= -DS390
+# CFLAGS+= -DPKCS11_DEBUG
+  CFLAGS+= -O3 -Wc,strict,hgpr,hot
+  CFLAGS+= -Wc,xplink,dll,exportall
+  LDFLAGS= -Wl,xplink,dll
+  ICCARCHIVE = ${GSKIT_HOME}/libjgsk8iccs.x
+  OSINCLUDEDIR=zos
+else ifeq (${PLATFORM},s390-zos64)
+  CC=xlc
+  PLAT=mz
+  CFLAGS= -DS390
+# CFLAGS+= -DPKCS11_DEBUG
+  CFLAGS+= -O3 -Wc,strict,hgpr,hot
+  CFLAGS+= -Wc,XPLINK,LP64,DLL,exportall
+  LDFLAGS= -Wl,XPLINK,LP64,DLL,AMODE=64
+  ICCARCHIVE = ${GSKIT_HOME}/libjgsk8iccs_64.x
+  IS64SYSTEM=64
+  OSINCLUDEDIR=zos
+else ifeq (${PLATFORM},x86-linux32)
+  PLAT=xi
+  CFLAGS+= -m32 -DLINUX
+  LDFLAGS+= -m32
+else ifeq (${PLATFORM},x86-linux64)
+  PLAT=xa
+  CFLAGS+= -DLINUX -Werror -std=gnu99 -pedantic -Wall -fstack-protector
+  LDFLAGS+= -m64
+  IS64SYSTEM=64
+  OSINCLUDEDIR=linux
 endif
 
 #Setting this flag will result non key material such as handle to OCK Objects etc being logged to the trace file.
 #This flag must be disabled before building production version
 #DEBUG_FLAGS += -DDEBUG
-#DEBUG_DETAIL = -DDEBUG_RANDOM_DETAIL -DDEBUG_RAND_DETAIL -DDEBUG_DH_DETAIL -DDEBUG_DSA_DETAIL -DDEBUG_DIGEST_DETAIL -DDEBUG_EC_DETAIL  -DDEBUG_EXTENDED_RANDOM_DETAIL -DDEBUG_GCM_DETAIL -DDEBUG_CCM_DETAIL -DDEBUG_HMAC_DETAIL -DDEBUG_PKEY_DETAIL -DDEBUG_CIPHER_DETAIL -DDEBUG_RSA_DETAIL -DDEBUG_SIGNATURE_DETAIL -DDEBUG_SIGNATURE_DSANONE_DETAIL -DDEBUG_SIGNATURE_RSASSL_DETAIL -DDEBUG_HKDF_DETAIL -DDEBUG_RSAPSS_DETAIL
+#DEBUG_DETAIL = -DDEBUG_RANDOM_DETAIL -DDEBUG_RAND_DETAIL -DDEBUG_DH_DETAIL -DDEBUG_DSA_DETAIL -DDEBUG_DIGEST_DETAIL -DDEBUG_EC_DETAIL -DDEBUG_EXTENDED_RANDOM_DETAIL -DDEBUG_GCM_DETAIL -DDEBUG_CCM_DETAIL -DDEBUG_HMAC_DETAIL -DDEBUG_PKEY_DETAIL -DDEBUG_CIPHER_DETAIL -DDEBUG_RSA_DETAIL -DDEBUG_SIGNATURE_DETAIL -DDEBUG_SIGNATURE_DSANONE_DETAIL -DDEBUG_SIGNATURE_RSASSL_DETAIL -DDEBUG_HKDF_DETAIL -DDEBUG_RSAPSS_DETAIL
 
 #Setting this flag will result sensitive key material such as private/public key bytes/parameter bytes being logged to the trace file.
-#Please warn the customer know that it not suitable to deploy jgskit library on production system,  enabling this flag.
+#Please warn the customer know that it not suitable to deploy jgskit library on production system, enabling this flag.
 #This flag must be disabled before building production version
-#DEBUG_DATA =  -DDEBUG_DH_DATA -DDEBUG_DSA_DATA -DDEBUG_EC_DATA -DDEBUG_GCM_DATA -DDEBUG_CCM_DATA -DDEBUG_HMAC_DATA -DDEBUG_CIPHER_DATA -DDEBUG_RSA_DATA -DDEBUG_SIGNATURE_DATA -DDEBUG_SIGNATURE_DSANONE_DATA -DDEBUG_SIGNATURE_RSASSL_DATA -DDEBUG_HKDF_DATA -DDEBUG_RSAPSS_DATA
-#DEBUG_FLAGS+= -g ${DEBUG_DETAIL}  ${DEBUG_DATA}
+#DEBUG_DATA = -DDEBUG_DH_DATA -DDEBUG_DSA_DATA -DDEBUG_EC_DATA -DDEBUG_GCM_DATA -DDEBUG_CCM_DATA -DDEBUG_HMAC_DATA -DDEBUG_CIPHER_DATA -DDEBUG_RSA_DATA -DDEBUG_SIGNATURE_DATA -DDEBUG_SIGNATURE_DSANONE_DATA -DDEBUG_SIGNATURE_RSASSL_DATA -DDEBUG_HKDF_DATA -DDEBUG_RSAPSS_DATA
+#DEBUG_FLAGS+= -g ${DEBUG_DETAIL} ${DEBUG_DATA}
 
 BUILDTOP = ${TOPDIR}/target
 ifeq (${IS64SYSTEM},64)
-      HOSTOUT = ${BUILDTOP}/jgskit-${PLAT}-64
+  HOSTOUT = ${BUILDTOP}/jgskit-${PLAT}-64
 else
-      HOSTOUT = ${BUILDTOP}/jgskit-${PLAT}
+  HOSTOUT = ${BUILDTOP}/jgskit-${PLAT}
 endif
 OPENJCEPLUS_HEADER_FILES ?= ${TOPDIR}/src/main/native
-JAVACLASSDIR=${TOPDIR}/target/classes
+JAVACLASSDIR=${BUILDTOP}/classes
 
-OBJS= ${HOSTOUT}/BasicRandom.o \
+OBJS = \
+	${HOSTOUT}/BasicRandom.o \
 	${HOSTOUT}/BuildDate.o \
 	${HOSTOUT}/CCM.o \
 	${HOSTOUT}/Digest.o \
@@ -161,46 +137,61 @@ TARGET = ${HOSTOUT}/libjgskit.so
 GSK8ICCS64=jgsk8iccs_64
 GSK8ICCS=jgsk8iccs
 
-all: headers ${TARGET}
+all : ${TARGET}
 
-noheaders: ${TARGET}
-
-dircreate:
-	mkdir -p ${HOSTOUT}
-
-headers: | dircreate
-	${JAVA_HOME}/bin/javac \
-	--add-exports java.base/sun.security.util=openjceplus \
-	--add-exports java.base/sun.security.util=ALL-UNNAMED \
-	${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java \
-	${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/FastJNIBuffer.java \
-	${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/OCKContext.java \
-	${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/OCKException.java \
-	-d ${JAVACLASSDIR} -h ${TOPDIR}/src/main/native/
-
-ifeq (${PLAT},mz)
-${TARGET}: ${OBJS}
-	${CC} ${LDFLAGS} -o ${TARGET} ${OBJS} ${ICCARCHIVE}
+ifneq (,$(filter s390-zos31 s390-zos64,${PLATFORM}))
+  TARGET_LIBS := ${ICCARCHIVE}
 else
-${TARGET}: ${OBJS}
-	${CC} ${LDFLAGS} -o ${TARGET} ${OBJS} -L ${GSKIT_HOME}/lib${IS64SYSTEM} -l ${GSK8ICCS${IS64SYSTEM}}
+  TARGET_LIBS := -L ${GSKIT_HOME}/lib${IS64SYSTEM} -l ${GSK8ICCS${IS64SYSTEM}}
 endif
 
-# Force BuildDate to be recompiled every time
+${TARGET} : ${OBJS}
+	${CC} ${LDFLAGS} -o ${TARGET} ${OBJS} ${TARGET_LIBS}
+
+${HOSTOUT}/%.o : %.c
+	test -d ${@D} || mkdir -p ${@D}
+	${CC} \
+		${CFLAGS} \
+		${DEBUG_FLAGS} \
+		-c \
+		-I${GSKIT_HOME}/inc \
+		-I${JAVA_HOME}/include \
+		-I${JAVA_HOME}/include/${OSINCLUDEDIR} \
+		-I${OPENJCEPLUS_HEADER_FILES} \
+		-o $@ \
+		$<
+
+# Force BuildDate to be compiled every time.
 #
-${HOSTOUT}/BuildDate.o: FORCE | dircreate
+${HOSTOUT}/BuildDate.o : FORCE
 
-FORCE:
+FORCE :
 
-${HOSTOUT}/%.o: %.c | dircreate
-	${CC} ${CFLAGS} ${DEBUG_FLAGS} -c -I${GSKIT_HOME}/inc -I${JAVA_HOME}/include -I${JAVA_HOME}/include/${OSINCLUDEDIR} -I${OPENJCEPLUS_HEADER_FILES} $< -o $@
+ifneq (${EXTERNAL_HEADERS},true)
 
-clean:
+${OBJS} : | headers
+
+headers :
+	echo "Compiling OpenJCEPlus headers"
+	${JAVA_HOME}/bin/javac \
+		--add-exports java.base/sun.security.util=openjceplus \
+		--add-exports java.base/sun.security.util=ALL-UNNAMED \
+		-d ${JAVACLASSDIR} \
+		-h ${TOPDIR}/src/main/native/ \
+		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/FastJNIBuffer.java \
+		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java \
+		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/OCKContext.java \
+		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/OCKException.java
+
+endif # ! EXTERNAL_HEADERS
+
+clean :
 	rm -f ${HOSTOUT}/*.o
 	rm -f ${HOSTOUT}/*.so
-cleanAll:
-	rm -rf ${TOPDIR}/target
-	rm -f com_ibm_crypto_plus_provider_ock_NativeInterface.h
-	rm -f com_ibm_crypto_plus_provider_ock_FastJNIBuffer.h
 
-.PHONY: all noheaders dircreate headers clean cleanAll
+cleanAll :
+	rm -rf ${BUILDTOP}
+	rm -f com_ibm_crypto_plus_provider_ock_FastJNIBuffer.h
+	rm -f com_ibm_crypto_plus_provider_ock_NativeInterface.h
+
+.PHONY : all headers clean cleanAll FORCE

--- a/src/main/native/jgskit.win64.cygwin.mak
+++ b/src/main/native/jgskit.win64.cygwin.mak
@@ -11,6 +11,7 @@
 TOPDIR = $(MAKEDIR)\..\..\..
 
 PLAT = win
+CFLAGS= -nologo -DWINDOWS
 
 #DEBUG_DETAIL = -DDEBUG_RANDOM_DETAIL -DDEBUG_RAND_DETAIL -DDEBUG_DH_DETAIL -DDEBUG_DSA_DETAIL -DDEBUG_DIGEST_DETAIL -DDEBUG_EC_DETAIL  -DDEBUG_EXTENDED_RANDOM_DETAIL -DDEBUG_GCM_DETAIL -DDEBUG_CCM_DETAIL -DDEBUG_HMAC_DETAIL -DDEBUG_PKEY_DETAIL -DDEBUG_CIPHER_DETAIL -DDEBUG_RSA_DETAIL -DDEBUG_SIGNATURE_DETAIL -DDEBUG_SIGNATURE_DSANONE_DETAIL -DDEBUG_SIGNATURE_RSASSL_DETAIL -DDEBUG_HKDF_DETAIL -DDEBUG_RSAPSS_DETAIL
 
@@ -23,7 +24,9 @@ PLAT = win
 BUILDTOP = $(TOPDIR)\target\build$(PLAT)
 HOSTOUT = $(BUILDTOP)\host64
 JAVACLASSDIR = $(TOPDIR)\target\classes
-OBJS= BasicRandom.obj \
+
+OBJS= \
+	BasicRandom.obj \
 	BuildDate.obj \
 	CCM.obj \
 	Digest.obj \
@@ -51,47 +54,54 @@ TARGET = libjgskit_64.dll
 JGSKIT_RC_SRC = jgskit_resource.rc
 JGSKIT_RC_OBJ = jgskit_resource.res
 
-all:  headers $(TARGET) copy
+all : copy
 
-dircreate:
+copy : $(TARGET)
 	-@mkdir -p $(HOSTOUT) 2>nul
-
-headers: dircreate
-	$(JAVA_HOME)\bin\javac \
-	--add-exports java.base/sun.security.util=openjceplus \
-	--add-exports java.base/sun.security.util=ALL-UNNAMED \
-	$(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\ock\NativeInterface.java \
-	$(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\ock\FastJNIBuffer.java \
-	$(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\ock\OCKContext.java \
-	$(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\ock\OCKException.java \
-	-d $(JAVACLASSDIR) -h $(TOPDIR)\src\main\native\
-
-$(TARGET): $(OBJS) $(JGSKIT_RC_OBJ)
-	-link -dll -out:$@ $(OBJS) $(JGSKIT_RC_OBJ) -LIBPATH:"$(GSKIT_HOME)/lib" jgsk8iccs_64.lib
-
-copy: dircreate
 	-@cp *.obj $(HOSTOUT)
 	-@cp jgskit_resource.res $(HOSTOUT)
 	-@cp libjgskit_64.dll $(HOSTOUT)
 
-# Force BuildDate to be recompiled every time
-#
-BuildDate.obj: FORCE
-
-FORCE:
-
-.c.obj:
-	-cl -nologo -DWINDOWS $(DEBUG_FLAGS) -c -I"$(GSKIT_HOME)/inc" -I"$(JAVA_HOME)/include" -I"$(JAVA_HOME)/include/win32" $*.c
+$(TARGET) : $(OBJS) $(JGSKIT_RC_OBJ)
+	link -dll -out:$@ $(OBJS) $(JGSKIT_RC_OBJ) -LIBPATH:"$(GSKIT_HOME)/lib" jgsk8iccs_64.lib
 
 $(JGSKIT_RC_OBJ) : $(JGSKIT_RC_SRC)
-	-@rc $(BUILD_CFLAGS) -Fo$@ $(JGSKIT_RC_SRC)
+	rc $(BUILD_CFLAGS) -Fo$@ $(JGSKIT_RC_SRC)
 
+.c.obj :
+	cl \
+		$(DEBUG_FLAGS) \
+		$(CFLAGS) \
+		-c \
+		-I"$(GSKIT_HOME)/inc" \
+		-I"$(JAVA_HOME)/include" \
+		-I"$(JAVA_HOME)/include/win32" \
+		$*.c
 
-clean:
+# Force BuildDate to be recompiled every time
+#
+BuildDate.obj : FORCE
+
+FORCE :
+
+$(OBJS) : headers
+
+headers :
+	echo "Compiling OpenJCEPlus headers"
+	$(JAVA_HOME)\bin\javac \
+		--add-exports java.base/sun.security.util=openjceplus \
+		-d $(JAVACLASSDIR) \
+		-h $(TOPDIR)\src\main\native\ \
+		$(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\ock\NativeInterface.java \
+		$(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\ock\FastJNIBuffer.java \
+		$(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\ock\OCKContext.java \
+		$(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\ock\OCKException.java
+
+clean :
 	-@del $(HOSTOUT)\*.obj
 	-@del $(HOSTOUT)\*.exp
 	-@del $(HOSTOUT)\*.lib
 	-@del $(HOSTOUT)\*.dll
 	-@del $(HOSTOUT)\*.res
 
-.PHONY: all dircreate headers copy clean
+.PHONY : all clean copy headers

--- a/src/main/native/jgskit.win64.mak
+++ b/src/main/native/jgskit.win64.mak
@@ -11,6 +11,7 @@
 TOPDIR = $(MAKEDIR)../../..
 
 PLAT = win
+CFLAGS= -nologo -DWINDOWS
 
 #DEBUG_DETAIL = -DDEBUG_RANDOM_DETAIL -DDEBUG_RAND_DETAIL -DDEBUG_DH_DETAIL -DDEBUG_DSA_DETAIL -DDEBUG_DIGEST_DETAIL -DDEBUG_EC_DETAIL  -DDEBUG_EXTENDED_RANDOM_DETAIL -DDEBUG_GCM_DETAIL -DDEBUG_CCM_DETAIL -DDEBUG_HMAC_DETAIL -DDEBUG_PKEY_DETAIL -DDEBUG_CIPHER_DETAIL -DDEBUG_RSA_DETAIL -DDEBUG_SIGNATURE_DETAIL -DDEBUG_SIGNATURE_DSANONE_DETAIL -DDEBUG_SIGNATURE_RSASSL_DETAIL -DDEBUG_HKDF_DETAIL -DDEBUG_RSAPSS_DETAIL
 
@@ -25,7 +26,8 @@ HOSTOUT = $(BUILDTOP)/host64
 OPENJCEPLUS_HEADER_FILES ?= $(TOPDIR)/src/main/native
 JAVACLASSDIR = $(TOPDIR)/target/classes
 
-OBJS= $(HOSTOUT)/BasicRandom.obj \
+OBJS= \
+	$(HOSTOUT)/BasicRandom.obj \
 	$(HOSTOUT)/BuildDate.obj \
 	$(HOSTOUT)/CCM.obj \
 	$(HOSTOUT)/Digest.obj \
@@ -53,40 +55,51 @@ TARGET = $(HOSTOUT)/libjgskit_64.dll
 JGSKIT_RC_SRC = jgskit_resource.rc
 JGSKIT_RC_OBJ = $(HOSTOUT)/jgskit_resource.res
 
-all: headers $(TARGET)
+all : $(TARGET)
 
-noheaders: $(TARGET)
-
-dircreate:
-	-@mkdir -p $(HOSTOUT) 2>nul
-
-headers: dircreate
-	$(JAVA_HOME)/bin/javac \
-	--add-exports java.base/sun.security.util=openjceplus \
-	--add-exports java.base/sun.security.util=ALL-UNNAMED \
-	$(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java \
-	$(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/ock/FastJNIBuffer.java \
-	$(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/ock/OCKContext.java \
-	$(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/ock/OCKException.java \
-	-d $(JAVACLASSDIR) -h $(TOPDIR)/src/main/native/
-
-$(TARGET): $(OBJS) $(JGSKIT_RC_OBJ)
+$(TARGET) : $(OBJS) $(JGSKIT_RC_OBJ)
 	link -dll -out:$@ $(OBJS) $(JGSKIT_RC_OBJ) -LIBPATH:"$(GSKIT_HOME)/lib" jgsk8iccs_64.lib
+
+$(JGSKIT_RC_OBJ) : $(JGSKIT_RC_SRC)
+	rc $(BUILD_CFLAGS) -Fo$@ $(JGSKIT_RC_SRC)
+
+$(HOSTOUT)/%.obj : %.c
+	-@mkdir -p $(HOSTOUT) 2>nul
+	cl \
+		$(DEBUG_FLAGS) \
+		$(CFLAGS) \
+		-c \
+		-I"$(GSKIT_HOME)/inc" \
+		-I"$(JAVA_HOME)/include" \
+		-I"$(JAVA_HOME)/include/win32" \
+		-I"$(OPENJCEPLUS_HEADER_FILES)" \
+		-Fo$@ \
+		$<
 
 # Force BuildDate to be recompiled every time
 #
-$(HOSTOUT)/BuildDate.obj: FORCE dircreate
+$(HOSTOUT)/BuildDate.obj : FORCE
 
-FORCE:
+FORCE :
 
-$(HOSTOUT)/%.obj: %.c dircreate
-	cl -nologo -DWINDOWS $(DEBUG_FLAGS) -c -I"$(GSKIT_HOME)/inc" -I"$(JAVA_HOME)/include" -I"$(JAVA_HOME)/include/win32" -I"$(OPENJCEPLUS_HEADER_FILES)" $< -Fo$@
+ifneq (${EXTERNAL_HEADERS},true)
 
-$(JGSKIT_RC_OBJ) : $(JGSKIT_RC_SRC) dircreate
-	-@rc $(BUILD_CFLAGS) -Fo$@ $(JGSKIT_RC_SRC)
+$(OBJS) : | headers
 
+headers :
+	echo "Compiling OpenJCEPlus headers"
+	$(JAVA_HOME)/bin/javac \
+		--add-exports java.base/sun.security.util=openjceplus \
+		-d $(JAVACLASSDIR) \
+		-h $(TOPDIR)/src/main/native/ \
+		$(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java \
+		$(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/ock/FastJNIBuffer.java \
+		$(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/ock/OCKContext.java \
+		$(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/ock/OCKException.java
 
-clean:
+endif # ! EXTERNAL_HEADERS
+
+clean :
 	-@del $(HOSTOUT)/*.obj
 	-@del $(HOSTOUT)/*.exp
 	-@del $(HOSTOUT)/*.lib


### PR DESCRIPTION
* consider platforms alphabetically
* correct link command for z/OS
* reuse macros
* fix parallel builds
* improve command readability
* support EXTERNAL_HEADERS=true in all platforms

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/274

Co-authored-by: Keith W. Campbell <keithc@ca.ibm.com>
Co-authored-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>
    
Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>