### PR TITLE
Enable x86-64_mac platform and fix gcc flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Build Status:
 | Windows Server 2022     | amd64       |
 | AIX                     | ppc64       |
 | Mac OS X*               | aarch64*    |
+| Mac OS X*               | amd64*      |
 * Mac OS X currently is only able to compile and run tests using the `OpenJCEPlus` provider, not `OpenJCEPlusFIPS`. The provider `OpenJCEPlusFIPS` will not load.
 
 Follow these steps to build the `OpenJCEPlus` and `OpenJCEPlusFIPS` providers along with a dependent Java Native Interface library. Keep in mind that `$PROJECT_HOME` can represent any directory on your system and will be referred to as such in the subsequent instructions. Also keep in mind that the value `$JAVA_VERSION` below must match the same version of the branch of OpenJCEPlus being built. For example if building the `java21` branch the `$JAVA_VERSION` must match the Java 21 SDK version such as `21.0.2+13`.
@@ -58,24 +59,22 @@ Follow these steps to build the `OpenJCEPlus` and `OpenJCEPlusFIPS` providers al
 
 1. Copy the OCK library referred to as ICC to the correct location:
 
-   Create the `lib64` directory and copy the `libjgsk8iccs_64.so` library to that location:
+    Based on the platform, the library file (i.e., `$LIBJGSKIT_LIBRARY`) is named differently. The  values are as follows:
+   * AIX/Linux: `libjgsk8iccs_64.so`
+   * Mac OS X: `libjgsk8iccs.dylib`
+   * Windows: `jgsk8iccs_64.dll`
+
+   Create the `lib64` directory and copy the `$LIBJGSKIT_LIBRARY` library to that location:
 
    ```console
    mkdir $PROJECT_HOME/OCK/jgsk_sdk/lib64
-   cp $PROJECT_HOME/OCK/libjgsk8iccs_64.so $PROJECT_HOME/OCK/jgsk_sdk/lib64
+   cp $PROJECT_HOME/OCK/$LIBJGSKIT_LIBRARY $PROJECT_HOME/OCK/jgsk_sdk/lib64
    ```
 
-   On AIX copy the library to the `jgsk_sdk` directory **in addition** to the `lib64` directory above.
+   On AIX also copy the library to the `jgsk_sdk` directory **in addition** to the `lib64` directory above.
 
    ```console
-   cp $PROJECT_HOME/OCK/libjgsk8iccs_64.so $PROJECT_HOME/OCK/jgsk_sdk
-   ```
-
-   On Mac:
-
-   ```console
-   mkdir $PROJECT_HOME/OCK/jgsk_crypto_sdk/jgsk_sdk/lib64
-   cp $PROJECT_HOME/OCK/jgsk_crypto/libjgsk8iccs_64.so $PROJECT_HOME/OCK/jgsk_crypto_sdk/jgsk_sdk/lib64
+   cp $PROJECT_HOME/OCK/$LIBJGSKIT_LIBRARY $PROJECT_HOME/OCK/jgsk_sdk
    ```
 
 1. Install `Maven` and place the command in your `PATH`. These instructions are OS dependant. It is recommended to make use of version `3.9.2`, although other versions of `Maven` are known to work.
@@ -109,12 +108,6 @@ You can test your installation by issuing `mvn --version`. For example:
     ```console
     export GSKIT_HOME="$PROJECT_HOME/OCK/jgsk_sdk"
     ```
-
-   On Mac:
-
-   ```console
-   export GSKIT_HOME="$PROJECT_HOME/OCK/jgsk_crypto_sdk/jgsk_sdk"
-   ```
 
 1. **(Only for Windows)** Some additional environment variables need to be set in Windows. There are certain header files and libraries that are required to build the `OpenJCEPlus` and `OpenJCEPlusFIPS` providers in a Windows environment and those files are found in the exported directories. It is assumed that you are running through a `CYGWIN` prompt.
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,8 +101,22 @@
             </activation>
             <properties>
                 <build.native.file>${basedir}/buildNativeMac.sh</build.native.file>
-                <build.platform.value>Mac</build.platform.value>
-                <build.target.jgskitlib.dir>${project.basedir}/target/buildmac/aarch64/</build.target.jgskitlib.dir>
+                <build.platform.value>aarch64-mac</build.platform.value>
+                <build.target.jgskitlib.dir>${project.basedir}/target/jgskit-aarch64-mac/</build.target.jgskitlib.dir>
+            </properties>
+          </profile>
+          <profile>
+            <id>Profile for Mac OS X x86-64</id>
+            <activation>
+              <os>
+                <name>Mac OS X</name>
+                <arch>x86_64</arch>
+              </os>
+            </activation>
+            <properties>
+                <build.native.file>${basedir}/buildNativeMac.sh</build.native.file>
+                <build.platform.value>x86_64-mac</build.platform.value>
+                <build.target.jgskitlib.dir>${project.basedir}/target/jgskit-x86_64-mac/</build.target.jgskitlib.dir>
             </properties>
           </profile>
           <profile>

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -139,43 +139,7 @@ final class NativeInterface {
                 // win64_x86
                 loadFile = new File(jgskitPath, "libjgskit_64.dll");
             }
-        } else if ((osArch.equals("aarch64")) && (osName.equals("Mac OS X"))) {
-            loadFile = new File(jgskitPath, "libjgskit.dylib");
-        } else {
-            loadFile = new File(jgskitPath, "libjgskit.so");
-        }
-
-
-        boolean jgskitLibraryPreloaded = loadIfExists(loadFile);
-        if (jgskitLibraryPreloaded == false) {
-            String exceptionMessage = "Could not load dependent jgskit library";
-
-            if (debug != null) {
-                // Do not use loadFile or libraryName in message in an effort to hide OCK usage
-                // from users
-                //
-                exceptionMessage = "Could not load dependent jgskit library for os.name=" + osName
-                        + ", os.arch=" + osArch;
-            }
-
-            throw new ProviderException(exceptionMessage);
-        }
-    }
-
-    static void preloadOCK(String libraryToLoad) {
-        osName = System.getProperty("os.name");
-        osArch = System.getProperty("os.arch");
-        String jgskitPath = getJGskitLoadPath();
-        File loadFile = null;
-        if (osName.startsWith("Windows")) {
-            if (osArch.equals("x86")) {
-                // win32_x86
-                loadFile = new File(jgskitPath, "libjgskit.dll");
-            } else {
-                // win64_x86
-                loadFile = new File(jgskitPath, "libjgskit_64.dll");
-            }
-        } else if ((osArch.equals("aarch64")) && (osName.equals("Mac OS X"))) {
+        } else if (osName.equals("Mac OS X")) {
             loadFile = new File(jgskitPath, "libjgskit.dylib");
         } else {
             loadFile = new File(jgskitPath, "libjgskit.so");
@@ -269,17 +233,7 @@ final class NativeInterface {
                 loadFile = new File(ockPath, "lib" + libraryToLoad + "_64.so");
             }
         } else if (osName.equals("Mac OS X")) {
-            // FIXME - remove when we will be officially supporting MAC
-            //
-            requirePreloadOCK = false;
-
-            if (osArch.equals("x86_64")) {
-                loadFile = new File(ockPath, "lib" + libraryToLoad + ".dylib");
-            }
-
-            if (osArch.equals("aarch64")) {
-                loadFile = new File(ockPath, "lib" + libraryToLoad + ".dylib");
-            }
+            loadFile = new File(ockPath, "lib" + libraryToLoad + ".dylib");
         } else if (osName.equals("z/OS")) {
             if (osArch.equals("s390") || !add64) {
                 loadFile = new File(ockPath, "lib" + libraryToLoad + ".so");

--- a/src/main/native/jgskit.mac.mak
+++ b/src/main/native/jgskit.mac.mak
@@ -10,25 +10,32 @@
 
 TOPDIR=../../..
 
-PLAT=mac
-CFLAGS= -arch arm64 -pedantic -Wall -fstack-protector
+CFLAGS= -fPIC -DMAC -Werror -pedantic -Wall -fstack-protector
+LDFLAGS= -shared -m64 -DMAC
+
+ifeq (${PLATFORM},x86_64-mac)
+  ARCHFLAGS= -arch x86_64
+else ifeq (${PLATFORM},aarch64-mac)
+  ARCHFLAGS= -arch arm64
+endif
+
 #Setting this flag will result non key material such as handle to OCK Objects etc being logged to the trace file.
 #This flag must be disabled before building production version
 #DEBUG_FLAGS += -DDEBUG
-#DEBUG_DETAIL = -DDEBUG_RANDOM_DETAIL -DDEBUG_RAND_DETAIL -DDEBUG_DH_DETAIL -DDEBUG_DSA_DETAIL -DDEBUG_DIGEST_DETAIL -DDEBUG_EC_DETAIL  -DDEBUG_EXTENDED_RANDOM_DETAIL -DDEBUG_GCM_DETAIL -DDEBUG_CCM_DETAIL -DDEBUG_HMAC_DETAIL -DDEBUG_PKEY_DETAIL -DDEBUG_CIPHER_DETAIL -DDEBUG_RSA_DETAIL -DDEBUG_SIGNATURE_DETAIL -DDEBUG_SIGNATURE_DSANONE_DETAIL -DDEBUG_SIGNATURE_RSASSL_DETAIL -DDEBUG_HKDF_DETAIL -DDEBUG_RSAPSS_DETAIL
+#DEBUG_DETAIL = -DDEBUG_RANDOM_DETAIL -DDEBUG_RAND_DETAIL -DDEBUG_DH_DETAIL -DDEBUG_DSA_DETAIL -DDEBUG_DIGEST_DETAIL -DDEBUG_EC_DETAIL -DDEBUG_EXTENDED_RANDOM_DETAIL -DDEBUG_GCM_DETAIL -DDEBUG_CCM_DETAIL -DDEBUG_HMAC_DETAIL -DDEBUG_PKEY_DETAIL -DDEBUG_CIPHER_DETAIL -DDEBUG_RSA_DETAIL -DDEBUG_SIGNATURE_DETAIL -DDEBUG_SIGNATURE_DSANONE_DETAIL -DDEBUG_SIGNATURE_RSASSL_DETAIL -DDEBUG_HKDF_DETAIL -DDEBUG_RSAPSS_DETAIL
 
 #Setting this flag will result sensitive key material such as private/public key bytes/parameter bytes being logged to the trace file.
-#Please warn the customer know that it not suitable to deploy jgskit library on production system,  enabling this flag.
+#Please warn the customer know that it not suitable to deploy jgskit library on production system, enabling this flag.
 #This flag must be disabled before building production version
-#DEBUG_DATA =  -DDEBUG_DH_DATA -DDEBUG_DSA_DATA -DDEBUG_EC_DATA -DDEBUG_GCM_DATA -DDEBUG_CCM_DATA -DDEBUG_HMAC_DATA -DDEBUG_CIPHER_DATA -DDEBUG_RSA_DATA -DDEBUG_SIGNATURE_DATA -DDEBUG_SIGNATURE_DSANONE_DATA -DDEBUG_SIGNATURE_RSASSL_DATA -DDEBUG_HKDF_DATA -DDEBUG_RSAPSS_DATA
-#DEBUG_FLAGS+= -g ${DEBUG_DETAIL}  ${DEBUG_DATA}
+#DEBUG_DATA = -DDEBUG_DH_DATA -DDEBUG_DSA_DATA -DDEBUG_EC_DATA -DDEBUG_GCM_DATA -DDEBUG_CCM_DATA -DDEBUG_HMAC_DATA -DDEBUG_CIPHER_DATA -DDEBUG_RSA_DATA -DDEBUG_SIGNATURE_DATA -DDEBUG_SIGNATURE_DSANONE_DATA -DDEBUG_SIGNATURE_RSASSL_DATA -DDEBUG_HKDF_DATA -DDEBUG_RSAPSS_DATA
+#DEBUG_FLAGS+= -g ${DEBUG_DETAIL} ${DEBUG_DATA}
 
-BUILDTOP = ${TOPDIR}/target/build${PLAT}
-HOSTOUT = ${BUILDTOP}/aarch64
+BUILDTOP = ${TOPDIR}/target
+HOSTOUT = ${BUILDTOP}/jgskit-${PLATFORM}
 OPENJCEPLUS_HEADER_FILES ?= ${TOPDIR}/src/main/native
-JAVACLASSDIR=${TOPDIR}/target/classes
+JAVACLASSDIR=${BUILDTOP}/classes
 
-OBJS= \
+OBJS = \
 	${HOSTOUT}/BasicRandom.o \
 	${HOSTOUT}/BuildDate.o \
 	${HOSTOUT}/CCM.o \
@@ -57,22 +64,27 @@ TARGET = ${HOSTOUT}/libjgskit.dylib
 all : ${TARGET}
 
 ${TARGET} : ${OBJS}
-	gcc -shared -m64 -arch arm64 -o ${TARGET} -DMAC ${OBJS} -L ${GSKIT_HOME}/lib64 -l jgsk8iccs
+	gcc ${LDFLAGS} ${ARCHFLAGS} -o ${TARGET} ${OBJS} -L ${GSKIT_HOME}/lib64 -l jgsk8iccs
 
 ${HOSTOUT}/%.o : %.c
 	test -d ${@D} || mkdir -p ${@D} 2>/dev/null
 	gcc \
-		-fPIC \
-		${DEBUG_FLAGS} \
+		${ARCHFLAGS} \
 		${CFLAGS} \
+		${DEBUG_FLAGS} \
 		-c \
-		-I${TOPDIR}/src/main/native/ \
 		-I${GSKIT_HOME}/inc \
 		-I${JAVA_HOME}/include \
 		-I${JAVA_HOME}/include/darwin \
 		-I${OPENJCEPLUS_HEADER_FILES} \
 		-o $@ \
 		$<
+
+# Force BuildDate to be compiled every time.
+#
+${HOSTOUT}/BuildDate.o : FORCE
+
+FORCE :
 
 ifneq (${EXTERNAL_HEADERS},true)
 
@@ -85,8 +97,8 @@ headers :
 		--add-exports java.base/sun.security.util=ALL-UNNAMED \
 		-d ${JAVACLASSDIR} \
 		-h ${TOPDIR}/src/main/native/ \
-		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java \
 		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/FastJNIBuffer.java \
+		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java \
 		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/OCKContext.java \
 		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/OCKException.java
 
@@ -94,10 +106,8 @@ endif # ! EXTERNAL_HEADERS
 
 clean :
 	rm -f ${HOSTOUT}/*.o
-	rm -f ${HOSTOUT}/*.so
-	rm -f ${TOPDIR}/src/main/native/com_ibm_crypto_plus_provider_ock_NativeInterface.h
-	rm -f ${TOPDIR}/src/main/native/com_ibm_crypto_plus_provider_ock_FastJNIBuffer.h
-	rm -f ${TOPDIR}/src/main/native/com_ibm_crypto_plus_provider_ock_OCKContext.h
-	rm -f ${TOPDIR}/src/main/native/com_ibm_crypto_plus_provider_ock_OCKException.h
+	rm -f ${HOSTOUT}/*.dylib
+	rm -f com_ibm_crypto_plus_provider_ock_FastJNIBuffer.h
+	rm -f com_ibm_crypto_plus_provider_ock_NativeInterface.h
 
-.PHONY : all headers clean
+.PHONY : all headers clean FORCE

--- a/src/main/native/jgskit.mak
+++ b/src/main/native/jgskit.mak
@@ -188,10 +188,7 @@ endif # ! EXTERNAL_HEADERS
 clean :
 	rm -f ${HOSTOUT}/*.o
 	rm -f ${HOSTOUT}/*.so
-
-cleanAll :
-	rm -rf ${BUILDTOP}
 	rm -f com_ibm_crypto_plus_provider_ock_FastJNIBuffer.h
 	rm -f com_ibm_crypto_plus_provider_ock_NativeInterface.h
 
-.PHONY : all headers clean cleanAll FORCE
+.PHONY : all headers clean FORCE


### PR DESCRIPTION
The `Mac OS X` on `x86-64` platform is being enabled. That includes:
* additional maven profile in the `pom.xml`
* different options in the makefile

Some additional required flags are added to the gcc commands. This resolves some test failures that were observed when running on Mac.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/306

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>