### PR TITLE
Eliminate extra JNI header generations

### DIFF
--- a/src/main/native/jgskit.mac.mak
+++ b/src/main/native/jgskit.mac.mak
@@ -99,9 +99,7 @@ headers :
 		-d ${JAVACLASSDIR} \
 		-h ${TOPDIR}/src/main/native/ \
 		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/FastJNIBuffer.java \
-		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java \
-		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/OCKContext.java \
-		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/OCKException.java
+		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
 
 endif # ! EXTERNAL_HEADERS
 

--- a/src/main/native/jgskit.mak
+++ b/src/main/native/jgskit.mak
@@ -180,9 +180,7 @@ headers :
 		-d ${JAVACLASSDIR} \
 		-h ${TOPDIR}/src/main/native/ \
 		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/FastJNIBuffer.java \
-		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java \
-		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/OCKContext.java \
-		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/OCKException.java
+		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
 
 endif # ! EXTERNAL_HEADERS
 

--- a/src/main/native/jgskit.win64.cygwin.mak
+++ b/src/main/native/jgskit.win64.cygwin.mak
@@ -94,10 +94,8 @@ headers :
 		--add-exports java.base/sun.security.util=ALL-UNNAMED \
 		-d $(JAVACLASSDIR) \
 		-h $(TOPDIR)\src\main\native\ \
-		$(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\ock\NativeInterface.java \
 		$(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\ock\FastJNIBuffer.java \
-		$(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\ock\OCKContext.java \
-		$(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\ock\OCKException.java
+		$(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\ock\NativeInterface.java
 
 clean :
 	-@del $(HOSTOUT)\*.obj

--- a/src/main/native/jgskit.win64.mak
+++ b/src/main/native/jgskit.win64.mak
@@ -94,10 +94,8 @@ headers :
 		--add-exports java.base/sun.security.util=ALL-UNNAMED \
 		-d $(JAVACLASSDIR) \
 		-h $(TOPDIR)/src/main/native/ \
-		$(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java \
 		$(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/ock/FastJNIBuffer.java \
-		$(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/ock/OCKContext.java \
-		$(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/ock/OCKException.java
+		$(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
 
 endif # ! EXTERNAL_HEADERS
 


### PR DESCRIPTION
Two extra header files appear to be generated from the classes `OCKContext.java` and `OCKException.java`. This is an unecessary step. While making this change the order of the FastJNIBuffer.java and NativeInterface.java was forced to match and also be alphabetical.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>