### PR TITLE
Enable aarch64_linux platform

### DIFF
--- a/buildNative.sh
+++ b/buildNative.sh
@@ -10,7 +10,7 @@
 #
 ###############################################################################
 
-PLATFORMS=(x86-linux64 x86-linux32 s390-linux64 s390-linux31 ppc-linux64 ppc-linux32 ppcle-linux64 ppc-aix64 ppc-aix32 s390-zos31 s390-zos64)
+PLATFORMS=(arm-linux64 x86-linux64 x86-linux32 s390-linux64 s390-linux31 ppc-linux64 ppc-linux32 ppcle-linux64 ppc-aix64 ppc-aix32 s390-zos31 s390-zos64)
 
 if [ -z "$JAVA_HOME" ]; 
   then 

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,20 @@
     </properties>
         <profiles>
           <profile>
+            <id>Profile for linux aarch64</id>
+            <activation>
+              <os>
+                <name>linux</name>
+                <arch>aarch64</arch>
+              </os>
+            </activation>
+            <properties>
+                <build.native.file>${basedir}/buildNative.sh</build.native.file>
+                <build.platform.value>arm-linux64</build.platform.value>
+                <build.target.jgskitlib.dir>${project.basedir}/target/jgskit-xr-64/</build.target.jgskitlib.dir>
+            </properties>
+          </profile>
+          <profile>
             <id>Profile for linux amd64</id>
             <activation>
               <os>

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
@@ -175,8 +175,7 @@ final class NativeInterface {
         // aix64_ppc: lib<ockCoreLibraryName>_64.so
         // hpux32_ia64: lib<ockCoreLibraryName>_32.so
         // hpux64_ia64: lib<ockCoreLibraryName>_64.so
-        // linux-arm32: lib<ockCoreLibraryName>.so
-        // linux-arm64: lib<ockCoreLibraryName>_64.so
+        // linux-aarch64: lib<ockCoreLibraryName>_64.so
         // linux31_s390: lib<ockCoreLibraryName>.so
         // linux32_ppc: lib<ockCoreLibraryName>.so
         // linux32_x86: lib<ockCoreLibraryName>.so
@@ -222,6 +221,9 @@ final class NativeInterface {
                 loadFile = new File(ockPath, "lib" + libraryToLoad + ".so");
             } else if (osArch.equals("s390x")) {
                 // linux64_s390
+                loadFile = new File(ockPath, "lib" + libraryToLoad + "_64.so");
+            } else if (osArch.equals("aarch64")) {
+                // linux-aarch64
                 loadFile = new File(ockPath, "lib" + libraryToLoad + "_64.so");
             }
         } else if (osName.equals("AIX") || osName.equals("OS/400")) {

--- a/src/main/native/jgskit.mak
+++ b/src/main/native/jgskit.mak
@@ -17,7 +17,13 @@ LDFLAGS= -shared
 IS64SYSTEM=
 AIX_LIBPATH = /usr/lib:/lib
 
-ifeq (${PLATFORM},ppc-aix32)
+ifeq (${PLATFORM},arm-linux64)
+  PLAT=xr
+  CFLAGS+= -DLINUX -Werror -std=gnu99 -pedantic -Wall -fstack-protector
+  LDFLAGS+= -DLINUX
+  IS64SYSTEM=64
+  OSINCLUDEDIR=linux
+else ifeq (${PLATFORM},ppc-aix32)
   PLAT=ap
   CC=xlc
   CFLAGS= -qcpluscmt -q32 -qpic -DAIX


### PR DESCRIPTION
The `Linux` on `aarch64` platform is being enabled.
That includes additional:
* maven profile in the `pom.xml`
* option in the makefile

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>