### PR TITLE
Allow debug compilation to pass and add DH detail

### DIFF
--- a/src/main/native/CCM.c
+++ b/src/main/native/CCM.c
@@ -375,8 +375,8 @@ int CCM_encrypt_core(JNIEnv* env, ICC_CTX* ockCtx,
     unsigned char* iv    , int ivLen,
     unsigned char* aad   , int aadLen,
     int tagLen,
-    unsigned char* plain , int plaintextLen,
-    unsigned char* cipher, unsigned long  ciphertextLen) {
+    unsigned char* plainText , int plaintextLen,
+    unsigned char* cipherText, unsigned long  ciphertextLen) {
     int             rc               = ICC_OSSL_SUCCESS;
     static const char * functionName = "NativeInterface.CCM_encrypt_core";
 
@@ -385,20 +385,20 @@ int CCM_encrypt_core(JNIEnv* env, ICC_CTX* ockCtx,
     }
 #ifdef DEBUG_CCM_DATA
     if ( debug ) {
-        gslogMessagePrefix ("DATA_CCM ivNative : ");
-        gslogMessageHex (ivNative, 0, (int) ivLen, 0, 0, NULL);
+        gslogMessagePrefix ("DATA_CCM iv : ");
+        gslogMessageHex ((char*) iv, 0, (int) ivLen, 0, 0, NULL);
 
-        gslogMessagePrefix ("DATA_CCM keyNative : ");
-        gslogMessageHex (keyNative, 0, (int) keyLen, 0, 0, NULL);
+        gslogMessagePrefix ("DATA_CCM key : ");
+        gslogMessageHex ((char*) key, 0, (int) keyLen, 0, 0, NULL);
 
-        gslogMessagePrefix ("DATA_CCM iphertextNative : ");
-        gslogMessageHex (plaintextNative, 0, (int) plaintextLen, 0, 0, NULL);
+        gslogMessagePrefix ("DATA_CCM plainText : ");
+        gslogMessageHex ((char*) plainText, 0, (int) plaintextLen, 0, 0, NULL);
 
-        gslogMessagePrefix ("DATA_CCM aadNative : ");
-        gslogMessageHex (aadNative, 0, (int) aadLen, 0, 0, NULL);
+        gslogMessagePrefix ("DATA_CCM aad : ");
+        gslogMessageHex ((char*) aad, 0, (int) aadLen, 0, 0, NULL);
     }
 #endif
-    rc = ICC_AES_CCM_Encrypt(ockCtx, iv, ivLen, key, keyLen, aad, aadLen, plain, plaintextLen, cipher, &ciphertextLen, tagLen);
+    rc = ICC_AES_CCM_Encrypt(ockCtx, iv, ivLen, key, keyLen, aad, aadLen, plainText, plaintextLen, cipherText, &ciphertextLen, tagLen);
 
     if (rc != ICC_OSSL_SUCCESS) {
         ockCheckStatus(ockCtx);

--- a/src/main/native/DHKey.c
+++ b/src/main/native/DHKey.c
@@ -107,6 +107,12 @@ JNIEXPORT jbyteArray JNICALL Java_com_ibm_crypto_plus_provider_ock_NativeInterfa
     gslogFunctionEntry(functionName);
   }
 
+#ifdef DEBUG_DH_DETAIL
+    if (debug) {
+      gslogMessage("DETAIL_DH ICC_DH_generate_parameters");
+    }
+#endif
+
   ockDH = ICC_DH_generate_parameters(ockCtx, (int)numBits, 2, NULL, NULL);
   if( ockDH == NULL ) {
     ockCheckStatus(ockCtx);
@@ -233,11 +239,22 @@ JNIEXPORT jlong JNICALL Java_com_ibm_crypto_plus_provider_ock_NativeInterface_DH
     const unsigned char * pBytes = (const unsigned char *)parmBytesNative;
 #ifdef DEBUG_DH_DETAIL
     if ( debug ) {
-      gslogMessage("DETAIL_DH DHKey_generate(params) size=%d", (int) size);
+      gslogMessage("DETAIL_DH DHKey_generate ICC_d2i_DHparams(ockCtx) : %d", (long) ockCtx);
+      gslogMessage("DETAIL_DH DHKey_generate(params) ICC_d2i_DHparams(NULL)");
+#ifdef DEBUG_DH_DATA
+      gslogMessagePrefix ("DETAIL_DH DHKey_generate ICC_d2i_DHparams(pBytes) : ");
+      gslogMessageHex ((char *) pBytes, 0, size, 0, 0, NULL);
+#endif
+      gslogMessagePrefix ("DETAIL_DH DHKey_generate ICC_d2i_DHparams(size) : %d\n", (int) size);
     }
 #endif
 
     ockDH = ICC_d2i_DHparams(ockCtx, NULL, &pBytes, size);
+#ifdef DEBUG_DH_DETAIL
+    if ( debug ) {
+      gslogMessage("DETAIL_DH DHKey_generate ICC_d2i_DHparams returned : %d\n", (long) ockDH);
+    }
+#endif
     if ( ockDH == NULL ) {
       ockCheckStatus(ockCtx);
 #ifdef DEBUG_DH_DETAIL
@@ -247,6 +264,12 @@ JNIEXPORT jlong JNICALL Java_com_ibm_crypto_plus_provider_ock_NativeInterface_DH
 #endif
       throwOCKException(env, 0, "NULL from ICC_d2i_DHparams");
     } else {
+#ifdef DEBUG_DH_DETAIL
+      if ( debug ) {
+        gslogMessage("DETAIL_DH DHKey_generate ICC_DH_generate_key(ockCtx) : %d", (long) ockCtx);
+        gslogMessage("DETAIL_DH DHKey_generate ICC_DH_generate_key(ockDH) : %d", (long) ockDH);
+      }
+#endif
       int rc = ICC_DH_generate_key(ockCtx, ockDH);
       if( rc != ICC_OSSL_SUCCESS ) {
         ockCheckStatus(ockCtx);

--- a/src/main/native/ECKey.c
+++ b/src/main/native/ECKey.c
@@ -1125,7 +1125,7 @@ JNIEXPORT jlong JNICALL Java_com_ibm_crypto_plus_provider_ock_NativeInterface_XE
     if ( debug ) {
       gslogMessage ("DATA_XEC size=%d", (int) size);
       gslogMessagePrefix ("DATA_EC privateKeyBytes : ");
-      gslogMessageHex (pBytes, 0, size, 0, 0, NULL);
+      gslogMessageHex ((char*) pBytes, 0, size, 0, 0, NULL);
    }
 #endif
     ICC_d2i_PrivateKey(ockCtx, ICC_EVP_PKEY_EC, &ockEVPKey, (unsigned char**) &pBytes, (long)size);
@@ -1329,7 +1329,7 @@ JNIEXPORT jlong JNICALL Java_com_ibm_crypto_plus_provider_ock_NativeInterface_XE
     if ( debug ) {
      
       gslogMessagePrefix ("DATA_XEC publicKeyBytes : ");
-      gslogMessageHex (pBytes, 0, size, 0, 0, NULL);
+      gslogMessageHex ((char*) pBytes, 0, size, 0, 0, NULL);
     }
 #endif
     ptr = keyBytesNative;

--- a/src/main/native/GCM.c
+++ b/src/main/native/GCM.c
@@ -339,15 +339,15 @@ int GCM_InitForUpdateEncrypt_core(JNIEnv* env, ICC_CTX* ockCtx, ICC_AES_GCM_CTX*
 
 #ifdef DEBUG_GCM_DATA
     if ( debug ) {
-        gslogMessagePrefix ("DATA_GCM ivNative : ");
-        gslogMessageHex (ivNative, 0, (int) ivLen, 0, 0, NULL);
+        gslogMessagePrefix ("DATA_GCM iv : ");
+        gslogMessageHex ((char*) iv, 0, (int) ivLen, 0, 0, NULL);
 
-        gslogMessagePrefix ("DATA_GCM keyNative : ");
-        gslogMessageHex (keyNative, 0, (int) keyLen, 0, 0, NULL);
+        gslogMessagePrefix ("DATA_GCM key : ");
+        gslogMessageHex ((char*) key, 0, (int) keyLen, 0, 0, NULL);
 
 
-        gslogMessagePrefix ("DATA_GCM aadNative : ");
-        gslogMessageHex (aadNative, 0, (int) aadLen, 0, 0, NULL);
+        gslogMessagePrefix ("DATA_GCM aad : ");
+        gslogMessageHex ((char*) aad, 0, (int) aadLen, 0, 0, NULL);
     }
 #endif
 #ifdef DEBUG_GCM_DETAIL
@@ -450,8 +450,8 @@ int GCM_UpdForUpdateEncrypt_core(JNIEnv* env, ICC_CTX* ockCtx, ICC_AES_GCM_CTX* 
 
 #ifdef DEBUG_GCM_DATA
     if ( debug ) {
-        gslogMessagePrefix ("DATA_GCM dataNative : ");
-        gslogMessageHex (datatNative, 0, (int) dataLen, 0, 0, NULL);
+        gslogMessagePrefix ("DATA_GCM data : ");
+        gslogMessageHex ((char*) data, 0, (int) dataLen, 0, 0, NULL);
 
 //        gslogMessagePrefix ("DATA_GCM aadNative : ");
 //        gslogMessageHex (aadNative, 0, (int) aadLen, 0, 0, NULL);
@@ -663,8 +663,8 @@ int GCM_FinalForUpdateEncrypt_core(JNIEnv* env, ICC_CTX* ockCtx, ICC_AES_GCM_CTX
 
 #ifdef DEBUG_GCM_DATA
     if ( debug ) {
-        gslogMessagePrefix ("DATA_GCM aadNative : ");
-        gslogMessageHex (tagNative, 0, (int) tagLen, 0, 0, NULL);
+        gslogMessagePrefix ("DATA_GCM tagNative : ");
+        gslogMessageHex ((char*) tagNative, 0, (int) tagLen, 0, 0, NULL);
     }
 #endif
     //if(gcmCtx == 0) gcmCtx = getOrfreeGCMContext(ockCtx, keyLen);
@@ -1141,16 +1141,16 @@ int GCM_encrypt_core(JNIEnv* env, ICC_CTX* ockCtx, ICC_AES_GCM_CTX* gcmCtx,
 #ifdef DEBUG_GCM_DATA
     if ( debug ) {
         gslogMessagePrefix ("DATA_GCM ivNative : ");
-        gslogMessageHex (ivNative, 0, (int) ivLen, 0, 0, NULL);
+        gslogMessageHex ((char*) ivNative, 0, (int) ivLen, 0, 0, NULL);
 
         gslogMessagePrefix ("DATA_GCM keyNative : ");
-        gslogMessageHex (keyNative, 0, (int) keyLen, 0, 0, NULL);
+        gslogMessageHex ((char*) keyNative, 0, (int) keyLen, 0, 0, NULL);
 
         gslogMessagePrefix ("DATA_GCM iphertextNative : ");
-        gslogMessageHex (plaintextNative, 0, (int) plaintextLen, 0, 0, NULL);
+        gslogMessageHex ((char*) plaintextNative, 0, (int) plaintextLen, 0, 0, NULL);
 
         gslogMessagePrefix ("DATA_GCM aadNative : ");
-        gslogMessageHex (aadNative, 0, (int) aadLen, 0, 0, NULL);
+        gslogMessageHex ((char*) aadNative, 0, (int) aadLen, 0, 0, NULL);
     }
 #endif
     if (gcmCtx == 0) {
@@ -1539,7 +1539,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_crypto_plus_provider_ock_NativeInterface_do_
 
 #ifdef DEBUG_GCM_DETAIL
     if ( debug ) {
-        gslogMessage ("NI do_GCM_UpdForUpdateEncrypt cls %x\n", cls);
+        gslogMessage ("NI do_GCM_UpdForUpdateEncrypt thisObj %x\n", thisObj);
     }
 #endif
 

--- a/src/main/native/StaticStub.c
+++ b/src/main/native/StaticStub.c
@@ -121,6 +121,7 @@ JNIEXPORT jlong JNICALL Java_com_ibm_crypto_plus_provider_ock_NativeInterface_in
 
     if( debug ) {
       gslogMessage("ICC_Status mode: %d", status.mode);
+      gslogMessage("ICC ockCtx : %d", (long) ockCtx);
     }
 
     if( debug ) {


### PR DESCRIPTION
When turning on all available debug information available with the c library via compilation options in the various makefiles certain code has been found to not compile. This update fixes compilation errors primarily associated with incorrectly named variables and also castings required to call helper methods to print debug messages.

This update also adds additional debug statements to the DH method `DHKEY.generate` since relevant information for other known issues was missing.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>