### PR TITLE
Enable AIX build by default in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -524,7 +524,7 @@ pipeline {
                 font-style: italic;
             """
         )
-        booleanParam(name: 'ppc64_aix', defaultValue: false, description: '\
+        booleanParam(name: 'ppc64_aix', defaultValue: true, description: '\
             Build for ppc64_aix platform')
         booleanParam(name: 'x86_64_linux', defaultValue: true, description: '\
             Build for x86-64_linux platform')


### PR DESCRIPTION
The Jenkins builds by default should enable AIX. This is at this time only recommended on Java 17 release not other releases or branches.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>