### PR TITLE
Use non-bundled OCK library in AIX

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -216,6 +216,15 @@ def getJava(hardware, software) {
             returnStdout: true
         ).trim()
         fileOperations([folderRenameOperation(destination: 'jdk', source: "$java_folder")])
+
+        // AIX always loads the bundled version of native libraries. We delete them to
+        // ensure that the one provided by the user is utilized.
+        if (software == "aix") {
+            fileOperations([fileDeleteOperation(excludes: '', includes: 'jdk/lib/libjgsk8iccs_64.so'),
+                            fileDeleteOperation(excludes: '', includes: 'jdk/lib/libjgskit.so'),
+                            folderDeleteOperation('jdk/lib/C'),
+                            folderDeleteOperation('jdk/lib/N')])
+        }
     }
 }
 
@@ -524,7 +533,7 @@ pipeline {
                 font-style: italic;
             """
         )
-        booleanParam(name: 'ppc64_aix', defaultValue: false, description: '\
+        booleanParam(name: 'ppc64_aix', defaultValue: true, description: '\
             Build for ppc64_aix platform')
         booleanParam(name: 'x86_64_linux', defaultValue: true, description: '\
             Build for x86-64_linux platform')

--- a/README.md
+++ b/README.md
@@ -141,11 +141,21 @@ Tests are available within the `OpenJCEPlus` repository. These Junit tests can b
 
 ### Run all tests
 
-On AIX you must set an additional setting for the `LIBPATH` environment variable:
+On AIX:
 
-```console
-export LIBPATH="$PROJECT_HOME/OCK/:$PROJECT_HOME/OCK/jgsk_sdk"
-```
+   * You must set an additional setting for the `LIBPATH` environment variable:
+
+   ```console
+    export LIBPATH="$PROJECT_HOME/OCK/:$PROJECT_HOME/OCK/jgsk_sdk"
+   ```
+
+   * If you are using a JDK that bundles `OpenJCEPlus`, like `Semeru`, and you want to make sure that you use an `OCK` library different than the one bundled with the JDK, you need to delete the bundled one. More specifically you need to run:
+
+   ```console
+    rm $JAVA_INSTALL_DIRECTORY/jdk-$JAVA_VERSION/lib/libjgsk8iccs_64.so
+    rm -rf $JAVA_INSTALL_DIRECTORY/jdk-$JAVA_VERSION/lib/C
+    rm -rf $JAVA_INSTALL_DIRECTORY/jdk-$JAVA_VERSION/lib/N
+   ```
 
 On all platforms set the following environment variables and execute all the tests using `mvn`. You must set your JAVA_HOME value to Java version 11 when using code located in the `java11` branch.
 


### PR DESCRIPTION
If there is a version of `OCK` that is bundled with the utilized `JDK`, it is always preferred over what the current run provides. To avoid that, the bundled version is deleted.

`AIX` is, also, enabled to be in the default platforms that are run.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/339

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>