### PR TITLE
Add FIPS platforms check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@
  */
 
 import groovy.json.JsonOutput;
-import groovy.transform.Field
+import groovy.transform.Field;
 
 @Field boolean PPC64_AIX
 @Field boolean X86_64_LINUX


### PR DESCRIPTION
Print the error message indicating that OpenJCEPlusFIPS is not supported on the non FIPS platforms, but do not exit.