### PR TITLE
Use appropriate OID in RSA key generation

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/RSAKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAKeyPairGenerator.java
@@ -34,6 +34,7 @@ abstract class RSAKeyPairGenerator extends KeyPairGeneratorSpi {
     RSAKeyPairGenerator(OpenJCEPlusProvider provider, KeyType type, int keySize) {
         this.provider = provider;
         this.type = type;
+        this.rsaId = RSAUtil.createAlgorithmId(type, null);
         this.keysize = keySize;
     }
 
@@ -117,8 +118,8 @@ abstract class RSAKeyPairGenerator extends KeyPairGeneratorSpi {
         try {
             RSAKey rsaKey = RSAKey.generateKeyPair(provider.getOCKContext(), this.keysize,
                     this.publicExponent);
-            java.security.interfaces.RSAPrivateKey privKey = new RSAPrivateCrtKey(provider, rsaKey);
-            java.security.interfaces.RSAPublicKey pubKey = new RSAPublicKey(provider, rsaKey);
+            java.security.interfaces.RSAPrivateKey privKey = new RSAPrivateCrtKey(rsaId, provider, rsaKey);
+            java.security.interfaces.RSAPublicKey pubKey = new RSAPublicKey(rsaId, provider, rsaKey);
             return new KeyPair(pubKey, privKey);
         } catch (Exception e) {
             throw provider.providerException("Failure in generateKeyPair", e);


### PR DESCRIPTION
When generating `RSA` keys, the type of key needs to be checked in order to differentiate between `legacy RSA` and `RSAPSS` and select the appropriate `OID`.

Fixes: https://github.com/IBM/OpenJCEPlus/issues/365

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>