### PR TITLE
Avoid memory leak associated with symmetric init

### DIFF
--- a/src/main/native/SymmetricCipher.c
+++ b/src/main/native/SymmetricCipher.c
@@ -211,13 +211,23 @@ JNIEXPORT jlong JNICALL Java_com_ibm_crypto_plus_provider_ock_NativeInterface_CI
 
       if( rc == ICC_OSSL_SUCCESS ) {
         rc = ICC_EVP_CIPHER_CTX_set_padding(ockCtx, ockCipher->cipherCtx, ockPadType);
-        if(ockCipher->copy_context == 0) {
-          ockCipher->cached_context = ICC_EVP_CIPHER_CTX_new(ockCtx);
-          ICC_EVP_CIPHER_CTX_copy(ockCtx, ockCipher->cached_context, ockCipher->cipherCtx);
-        }
         if( rc != ICC_OSSL_SUCCESS ) {
           ockCheckStatus(ockCtx);
           throwOCKException(env, 0, "ICC_EVP_set_padding failed");
+        }
+        if (0 == ockCipher->copy_context) {
+          if (NULL == ockCipher->cached_context) {
+            ockCipher->cached_context = ICC_EVP_CIPHER_CTX_new(ockCtx);
+          }
+          if (NULL == ockCipher->cached_context) {
+            ockCheckStatus(ockCtx);
+            throwOCKException(env, 0, "ICC_EVP_CIPHER_CTX_new failed for CIPHER_init cached context");
+          }
+          rc = ICC_EVP_CIPHER_CTX_copy(ockCtx, ockCipher->cached_context, ockCipher->cipherCtx);
+          if( rc != ICC_OSSL_SUCCESS ) {
+            ockCheckStatus(ockCtx);
+            throwOCKException(env, 0, "ICC_EVP_CIPHER_CTX_copy failed for CIPHER_init");
+          }
         }
       }
     }


### PR DESCRIPTION
The `NativeInterface.CIPHER_init` method initializes a given context such that it is ready to perform encryption and decryption for a given Cipher.

As part of the initialization method a `ockCipher->cached_context` can be optionally created in addition to the context being used. While allocating the `ockCipher->cached_context` the logic did not account for any previously created contexts that were previously stored in the `ockCipher->cached_context` location. This caused a leak of context objects for each initialization done on objects that already contained a context.

Additional error checking was done for the calls to `ICC_EVP_CIPHER_CTX_new` and `ICC_EVP_CIPHER_CTX_copy` to ensure that the method worked as expected.