### PR TITLE
Add int declaration to rc variable in Utils.c

### DIFF
--- a/src/main/native/Utils.c
+++ b/src/main/native/Utils.c
@@ -199,7 +199,7 @@ throwOCKException( JNIEnv *env, int code, const char* msg )
 
         strcpy(msgCopy,msg);
 #ifdef __MVS__
-        rc = __etoa(msgCopy);
+        int rc = __etoa(msgCopy);
         if (rc < 1) {
             gslogError("_etoa failed in %s",__FUNCTION__);
         }


### PR DESCRIPTION
The `rc` variable in `Utils.c` is never declared. This update declares it as an `int`.

Fixes https://github.com/IBM/OpenJCEPlus/issues/242

Signed-off-by: Tom Ginader <thomas.ginader@ibm.com>