### PR TITLE
Fix memory leak computing ECDH secrets

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
@@ -110,7 +110,7 @@ abstract class XDHKeyAgreement extends KeyAgreementSpi {
             this.secret = XECKey.computeECDHSecret(provider.getOCKContext(), genCtx,
                     ockXecKeyPub.getPKeyId(), ockXecKeyPriv.getPKeyId(), secrectBufferSize);
         } catch (OCKException e) {
-            throw new IllegalStateException(e.getMessage());
+            throw new IllegalStateException("Failed to generate secret", e);
         } catch (Exception e) {
             throw new InvalidKeyException("Failed to generate secret", e);
         }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
@@ -31,7 +31,7 @@ import java.security.spec.XECPublicKeySpec;
 import java.util.Arrays;
 import javax.crypto.KeyAgreement;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestXDH extends BaseTestJunit5 {
 
@@ -337,18 +337,10 @@ public class BaseTestXDH extends BaseTestJunit5 {
             throws Exception {
 
         try {
-            //System.out.println("Pub - "+b_pub);
             runDiffieHellmanTest(name, a_pri, b_pub, result);
-        } catch (InvalidKeyException ex) {
-            assertTrue(true);
+        } catch (IllegalStateException ex) {
             return;
-        } catch (InvalidKeySpecException ex) {
-            assertTrue(true);
-            return;
-        } catch (Exception e1) {
-            System.out.println(e1.getMessage());
         }
-
         throw new RuntimeException("No exception on small-order point");
     }
 


### PR DESCRIPTION
The context allocated in the method `XECKEY.computeECDHSecret` was never freed when a key was successfully generated. This update frees memory associated with the context prior to return of the secret key bytes.

Whitespace and formatting was also done to make use of brackets for if statements.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/393

Fixes #387

Signed-off-by: Jason Katonica <katonica@us.ibm.com>