### PR TITLE
Implement calculatePublicKey() in classes that extend PKCS8Key

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
@@ -14,6 +14,8 @@ import java.math.BigInteger;
 import java.security.AlgorithmParameters;
 import java.security.InvalidKeyException;
 import java.security.Key;
+import java.security.ProviderException;
+import java.security.PublicKey;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.InvalidParameterSpecException;
 import java.util.Arrays;
@@ -569,6 +571,16 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
 
     ECKey getOCKKey() {
         return this.ecKey;
+    }
+
+    @Override
+    public PublicKey calculatePublicKey() {
+        try {
+            return new ECPublicKey(provider, ecKey);
+        } catch (InvalidKeyException exc) {
+            throw new ProviderException(
+                    "Unexpected error calculating public key", exc);
+        }
     }
 
     /**

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyPairGenerator.java
@@ -11,7 +11,9 @@ import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
 import java.security.ProviderException;
+import java.security.PublicKey;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECGenParameterSpec;
@@ -20,7 +22,9 @@ import java.security.spec.ECPoint;
 import java.security.spec.EllipticCurve;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import sun.security.util.InternalPrivateKey;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class BaseTestECKeyPairGenerator extends BaseTestJunit5 {
 
@@ -99,6 +103,23 @@ public class BaseTestECKeyPairGenerator extends BaseTestJunit5 {
         assertTrue(ecurvePriv.getB().compareTo(ecurvePub.getB()) == 0);
         assertTrue(ecurvePriv.getField().getFieldSize() == ecurvePub.getField().getFieldSize());
 
+    }
+
+    @Test
+    public void testECPrivateKey_calculatePublicKey() throws Exception {
+        kpg.initialize(256);
+        KeyPair kp = kpg.generateKeyPair();
+
+        PublicKey ecpu = kp.getPublic();
+        PrivateKey ecpr = kp.getPrivate();
+
+        byte[] originalEncoded = ecpu.getEncoded();
+        byte[] calculatedEncoded = ((InternalPrivateKey) ecpr).calculatePublicKey().getEncoded();
+
+        System.out.println("---- Comparing EC public key from KeyPair vs calculated from private key ----");
+        System.out.println("EC public key from Keypair: " + BaseUtils.bytesToHex(originalEncoded));
+        System.out.println("EC public key from calculatePublicKey(): " + BaseUtils.bytesToHex(calculatedEncoded));
+        assertArrayEquals(originalEncoded, calculatedEncoded);
     }
 
     @Test

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyPairGenerator.java
@@ -10,11 +10,15 @@ package ibm.jceplus.junit.base;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.security.interfaces.XECPrivateKey;
 import java.security.interfaces.XECPublicKey;
 import java.security.spec.NamedParameterSpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import sun.security.util.InternalPrivateKey;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class BaseTestXDHKeyPairGenerator extends BaseTestJunit5 {
 
@@ -80,6 +84,23 @@ public class BaseTestXDHKeyPairGenerator extends BaseTestJunit5 {
         //System.out.println("---- EC keypair for key size " + keypairSize + "  ----");
         //System.out.println("ECPublic (x,y): (" + ecpu.getW().getAffineX() + ", " + ecpu.getW().getAffineY() + ")");
         //System.out.println("ECPrivate: " + ecpr.getS());
+    }
+
+    @Test
+    public void testXDHPrivateKey_calculatePublicKey() throws Exception {
+        kpg.initialize(255);
+        KeyPair kp = kpg.generateKeyPair();
+
+        PublicKey ecpu = kp.getPublic();
+        PrivateKey ecpr = kp.getPrivate();
+
+        byte[] originalEncoded = ecpu.getEncoded();
+        byte[] calculatedEncoded = ((InternalPrivateKey) ecpr).calculatePublicKey().getEncoded();
+
+        System.out.println("---- Comparing XDH public key from KeyPair vs calculated from private key ----");
+        System.out.println("XDH public key from Keypair: " + BaseUtils.bytesToHex(originalEncoded));
+        System.out.println("XDH public key from calculatePublicKey(): " + BaseUtils.bytesToHex(calculatedEncoded));
+        assertArrayEquals(originalEncoded, calculatedEncoded);
     }
 
     @Test


### PR DESCRIPTION
`PKCS8Key` implements the `InternalPrivateKey` interface that contains the `calculatePublicKey()` method. If not implemented, an `UnsupportedOperationException` is thrown. This functionality is implemented to support this operation instead of getting an exception.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/372

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>