### PR TITLE
Update the DH key size check to include the exponent size check

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/DHKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHKeyFactory.java
@@ -10,7 +10,6 @@ package com.ibm.crypto.plus.provider;
 
 import java.io.IOException;
 import java.security.InvalidKeyException;
-import java.security.InvalidParameterException;
 import java.security.Key;
 import java.security.KeyFactorySpi;
 import java.security.PrivateKey;
@@ -30,10 +29,6 @@ import javax.crypto.spec.DHPublicKeySpec;
 public final class DHKeyFactory extends KeyFactorySpi {
 
     private OpenJCEPlusProvider provider;
-    public final static int MIN_KEYSIZE_NONFIPS = 512;
-    public final static int MAX_KEYSIZE_NONFIPS = 8192;
-    public final static int MIN_KEYSIZE_FIPS = 2048;
-    public final static int MAX_KEYSIZE_FIPS = 8192;
 
     static DHKey toDHKey(OpenJCEPlusProvider provider, Key key) throws InvalidKeyException {
         return (DHKey) new DHKeyFactory(provider).engineTranslateKey(key);
@@ -225,35 +220,4 @@ public final class DHKeyFactory extends KeyFactorySpi {
             throw new InvalidKeyException("Cannot translate key", e);
         }
     }
-
-    /**
-     * Check the length of an RSA key modulus/exponent to make sure it is not
-     * too short or long. Some impls have their own min and max key sizes that
-     * may or may not match with a system defined value.
-     *
-     * @param modulusLen
-     *            the bit length of the RSA modulus.
-     * @param exponent
-     *            the RSA exponent
-     * @param minModulusLen
-     *            if > 0, check to see if modulusLen is at least this long,
-     *            otherwise unused.
-     * @param maxModulusLen
-     *            caller will allow this max number of bits. Allow the smaller
-     *            of the system-defined maximum and this param.
-     *
-     * @throws InvalidKeyException
-     *             if any of the values are unacceptable.
-     */
-    static void checkKeyLengths(int keysize, int minsize, int maxsize)
-            throws InvalidParameterException {
-
-        if ((keysize < minsize) || (keysize > maxsize) || ((keysize & 0x3F) != 0)) {
-            throw new InvalidParameterException(
-                    "DH key size must be multiple of 64, and can only range "
-                            + "from 512 to 8192 (inclusive). " + "The specific key size " + keysize
-                            + " is not supported");
-        }
-    }
-
 }

--- a/src/main/java/com/ibm/crypto/plus/provider/DHKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHKeyPairGenerator.java
@@ -25,8 +25,12 @@ public final class DHKeyPairGenerator extends KeyPairGeneratorSpi {
     private int keySize = 2048;
     private DHParameterSpec params;
 
-    public DHKeyPairGenerator(OpenJCEPlusProvider provider) {
+    public final static int MIN_KEYSIZE_NONFIPS = 512;
+    public final static int MAX_KEYSIZE_NONFIPS = 8192;
+    public final static int MIN_KEYSIZE_FIPS = 2048;
+    public final static int MAX_KEYSIZE_FIPS = 8192;
 
+    public DHKeyPairGenerator(OpenJCEPlusProvider provider) {
 
         if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
             throw new SecurityException("Integrity check failed for: " + provider.getName());
@@ -36,7 +40,6 @@ public final class DHKeyPairGenerator extends KeyPairGeneratorSpi {
         initialize(2048, null);
 
     }
-
 
     /**
      * Initialize the receiver to use a given secure random generator, and
@@ -71,11 +74,9 @@ public final class DHKeyPairGenerator extends KeyPairGeneratorSpi {
     private void initialize(int keySize, boolean genParams, java.security.SecureRandom random) {
 
         if (provider.isFIPS()) {
-            DHKeyFactory.checkKeyLengths(keySize, DHKeyFactory.MIN_KEYSIZE_FIPS,
-                    DHKeyFactory.MAX_KEYSIZE_FIPS);
+            checkKeySize(keySize, MIN_KEYSIZE_FIPS, MAX_KEYSIZE_FIPS, 0);
         } else {
-            DHKeyFactory.checkKeyLengths(keySize, DHKeyFactory.MIN_KEYSIZE_NONFIPS,
-                    DHKeyFactory.MAX_KEYSIZE_NONFIPS);
+            checkKeySize(keySize, MIN_KEYSIZE_NONFIPS, MAX_KEYSIZE_NONFIPS, 0);
         }
 
         if (genParams) {
@@ -116,11 +117,9 @@ public final class DHKeyPairGenerator extends KeyPairGeneratorSpi {
             throws InvalidParameterException {
         int keySize = params.getP().bitLength();
         if (provider.isFIPS()) {
-            DHKeyFactory.checkKeyLengths(keySize, DHKeyFactory.MIN_KEYSIZE_FIPS,
-                    DHKeyFactory.MAX_KEYSIZE_FIPS);
+            checkKeySize(keySize, MIN_KEYSIZE_FIPS, MAX_KEYSIZE_FIPS, params.getL());
         } else {
-            DHKeyFactory.checkKeyLengths(keySize, DHKeyFactory.MIN_KEYSIZE_NONFIPS,
-                    DHKeyFactory.MAX_KEYSIZE_NONFIPS);
+            checkKeySize(keySize, MIN_KEYSIZE_NONFIPS, MAX_KEYSIZE_NONFIPS, params.getL());
         }
         this.keySize = keySize;
         this.params = params;
@@ -165,6 +164,40 @@ public final class DHKeyPairGenerator extends KeyPairGeneratorSpi {
             return new KeyPair(pubKey, privKey);
         } catch (Exception e) {
             throw provider.providerException("Failure in generateKeyPair", e);
+        }
+    }
+
+    /**
+     * Check the length of an DH key modulus/exponent to make sure it is not
+     * too short or long. Some impls have their own min and max key sizes that
+     * may or may not match with a system defined value.
+     *
+     * @param keySize
+     *                the bit length of the modulus.
+     * @param minSize
+     *                the minimum length of the modulus.
+     * @param maxSize
+     *                the maximum length of the modulus.
+     * @param expSize
+     *                the bit length of the exponent.
+     *
+     * @throws InvalidParameterException
+     *                             if any of the values are unacceptable.
+     */
+    static void checkKeySize(int keySize, int minSize, int maxSize, int expSize)
+            throws InvalidParameterException {
+
+        if ((keySize < minSize) || (keySize > maxSize) || ((keySize & 0x3F) != 0)) {
+            throw new InvalidParameterException(
+                    "DH key size must be multiple of 64, and can only range " +
+                            "from " + minSize + " to " + maxSize + " (inclusive). " +
+                            "The specific key size " + keySize + " is not supported");
+        }
+
+        // optional, could be 0 if not specified
+        if ((expSize < 0) || (expSize > keySize)) {
+            throw new InvalidParameterException("Exponent size must be positive and no larger than" +
+                    " modulus size");
         }
     }
 


### PR DESCRIPTION
This is a back-port PR from PR https://github.com/IBM/OpenJCEPlus/pull/423

Move the checkKeyLengths() method from DHKeyFactory to DHKeyPairGenerator, rename it to checkKeySize(), and add a check for the exponent size, same as OpenJDK did.

Fixes #418

Signed-off-by: Tao Liu <tao.liu@ibm.com>