### PR TITLE
Eliminate older junit dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -548,9 +548,9 @@
             <version>3.5.2</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAES.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAES.java
@@ -29,8 +29,8 @@ import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestAES extends BaseTestCipher {
 
@@ -795,10 +795,9 @@ public class BaseTestAES extends BaseTestCipher {
             AlgorithmParameters params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((blockSize > 0) && (message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((blockSize > 0) && (message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             // Verify the text
@@ -806,18 +805,17 @@ public class BaseTestAES extends BaseTestCipher {
             byte[] newPlainText = cp.doFinal(cipherText);
 
             boolean success = Arrays.equals(newPlainText, message);
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
 
             // Verify the text again
             cp.init(Cipher.DECRYPT_MODE, key, params);
             byte[] newPlainText2 = cp.doFinal(cipherText, 0, cipherText.length);
             success = Arrays.equals(newPlainText2, message);
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 
@@ -839,10 +837,9 @@ public class BaseTestAES extends BaseTestCipher {
             AlgorithmParameters params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             // Verify the text
@@ -859,12 +856,11 @@ public class BaseTestAES extends BaseTestCipher {
             System.arraycopy(newPlainText2, 0, newPlainText, l, newPlainText2.length);
 
             boolean success = Arrays.equals(newPlainText, message);
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 
@@ -888,10 +884,9 @@ public class BaseTestAES extends BaseTestCipher {
             AlgorithmParameters params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             // Verify the text
@@ -908,13 +903,11 @@ public class BaseTestAES extends BaseTestCipher {
             System.arraycopy(newPlainText2, 0, newPlainText, l, newPlainText2.length);
 
             boolean success = Arrays.equals(newPlainText, message);
-            assertTrue("Decrypted text does not match expected, partial msglen=" + message.length,
-                    success);
+            assertTrue(success, "Decrypted text does not match expected, partial msglen=" + message.length);
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 
@@ -938,32 +931,30 @@ public class BaseTestAES extends BaseTestCipher {
             AlgorithmParameters params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((blockSize > 0) && (message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((blockSize > 0) && (message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             // Verify that the cipher object can be used to encrypt again without re-init
             byte[] cipherText2 = cp.doFinal(message);
             boolean success = Arrays.equals(cipherText2, cipherText);
-            assertTrue("Re-encrypted text does not match", success);
+            assertTrue(success, "Re-encrypted text does not match");
 
             // Verify the text
             cp.init(Cipher.DECRYPT_MODE, key, params);
             byte[] newPlainText = cp.doFinal(cipherText);
             success = Arrays.equals(newPlainText, message);
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
 
             // Verify that the cipher object can be used to decrypt again without re-init
             byte[] newPlainText2 = cp.doFinal(cipherText, 0, cipherText.length);
             success = Arrays.equals(newPlainText2, newPlainText);
-            assertTrue("Re-decrypted text does not match", success);
+            assertTrue(success, "Re-decrypted text does not match");
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 
@@ -992,14 +983,13 @@ public class BaseTestAES extends BaseTestCipher {
             AlgorithmParameters params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((blockSize > 0) && (message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((blockSize > 0) && (message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             boolean success = Arrays.equals(cipherText, cipherText0);
-            assertTrue("Encrypted text does not match expected result", success);
+            assertTrue(success, "Encrypted text does not match expected result");
 
             // Verify the text
             cp.init(Cipher.DECRYPT_MODE, key, params);
@@ -1008,12 +998,11 @@ public class BaseTestAES extends BaseTestCipher {
             byte[] newPlainText = Arrays.copyOf(resultBuffer, resultLen);
 
             success = Arrays.equals(newPlainText, message);
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 
@@ -1045,14 +1034,13 @@ public class BaseTestAES extends BaseTestCipher {
             AlgorithmParameters params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((blockSize > 0) && (message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((blockSize > 0) && (message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             boolean success = Arrays.equals(cipherText, cipherText0);
-            assertTrue("Encrypted text does not match expected result", success);
+            assertTrue(success, "Encrypted text does not match expected result");
 
             // Verify the text
             cp.init(Cipher.DECRYPT_MODE, key, params);
@@ -1065,12 +1053,11 @@ public class BaseTestAES extends BaseTestCipher {
             System.arraycopy(plainText2, 0, newPlainText, plainText1Len, plainText2.length);
 
             success = Arrays.equals(newPlainText, message);
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCM.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCM.java
@@ -18,7 +18,7 @@ import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 // This test case exercises the AES/CCM cipher using a CCMParameterSpec object
@@ -196,7 +196,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                                         + iterationCounter);
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } else {
                     if (printJunitTrace)
                         System.out.println(toHexString(cipherText));
@@ -209,7 +209,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                                     + iterationCounter);
                 RuntimeException rtex = new RuntimeException();
                 rtex.printStackTrace(System.out);
-                Assert.fail();
+                Assertions.fail();
             }
 
 
@@ -248,7 +248,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                             "BaseTestAESCCM.java:  testAESCCM():   The decryptedText bytes are: ");
                 if (printJunitTrace)
                     System.out.println(toHexString(decryptedText.getBytes()));
-                Assert.fail();
+                Assertions.fail();
             } else {
                 plainText = null;
                 decryptedText = null;
@@ -360,7 +360,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                                 "BaseTestAESCCM.java:  encrypt():  ERROR.  An exception should have been thrown.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (ProviderException proex) {
                     // do nothing.  This exception is expected because AES/CCM does not support cipher.update().
                 }
@@ -383,7 +383,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                                 "BaseTestAESCCM.java:  encrypt():  ERROR.  An exception should have been thrown.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (ProviderException proex) {
                     // do nothing.  This exception is expected because AES/CCM does not support cipher.update().
                 }
@@ -413,7 +413,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                                 "BaseTestAESCCM.java:  encrypt():  ERROR.  An exception should have been thrown.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (ProviderException proex) {
                     // do nothing.  This exception is expected because AES/CCM does not support cipher.update().
                 }
@@ -428,7 +428,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                                 "BaseTestAESCCM.java:  encrypt():  ERROR:  cipherText2Length is not equal to cipherText2.length.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 // All the encryption was performed on Cipher.doFinal( )
@@ -454,7 +454,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                                 "BaseTestAESCCM.java:  encrypt():  ERROR.  An exception should have been thrown.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (ProviderException proex) {
                     // do nothing.  This exception is expected because AES/CCM does not support cipher.update().
                 }
@@ -470,7 +470,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                                 "BaseTestAESCCM.java:  encrypt():  ERROR:  cipherText2Length is not equal to cipherText2.length.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 // All the encryption was performed on Cipher.doFinal( )
@@ -493,7 +493,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                                 "BaseTestAESCCM.java:  encrypt():  ERROR.  An exception should have been thrown.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (ProviderException proex) {
                     // do nothing.  This exception is expected because AES/CCM does not support cipher.update().
                 }
@@ -511,7 +511,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                                 "BaseTestAESCCM.java:  encrypt():  ERROR:  cipherText2Length is not equal to cipherText2.length.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 // All the encryption was performed on Cipher.doFinal( )
@@ -524,7 +524,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                 System.out.println(
                         "BaseTestAESCCM.java:  encrypt():  ERROR:  The following exception was thrown.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         if (printJunitTrace)
@@ -619,7 +619,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                                 "BaseTestAESCCM.java:  decrypt():  ERROR:  Cipher.update( ) should have thrown a RuntimeException.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (RuntimeException rtex) {
                     // Do nothing.  Cipher.update() for decryption is not supported.
                 }
@@ -643,7 +643,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                                 "BaseTestAESCCM.java:  decrypt():   ERROR:  Cipher.update( ) should have thrown a RuntimeException.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (RuntimeException rtex) {
                     // Do nothing.  Cipher.update() for decryption is not supported.
                 }
@@ -673,7 +673,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                                 "BaseTestAESCCM.java:  decrypt():   ERROR:  Cipher.update( ) should have thrown a RuntimeException.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (RuntimeException rtex) {
                     // Do nothing.  Cipher.update() for decryption is not supported.
                 }
@@ -689,7 +689,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                                 "BaseTestAESCCM.java:  decrypt():  ERROR:  decryptedText2Length is not equal to decryptedText2.length.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 // All the decryption was performed on Cipher.doFinal( )
@@ -714,7 +714,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                                 "BaseTestAESCCM.java:  decrypt():  ERROR:  Cipher.update( ) should have thrown a RuntimeException.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (RuntimeException rtex) {
                     // Do nothing.  Cipher.update() for decryption is not supported.
                 }
@@ -730,7 +730,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                                 "BaseTestAESCCM.java:  decrypt():  ERROR:  decryptedText2Length is not equal to decryptedText2.length.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 // All the decryption was performed on Cipher.doFinal( )
@@ -759,7 +759,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                                 "BaseTestAESCCM.java:  decrypt():  ERROR:  Cipher.update( ) should have thrown a RuntimeException.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (RuntimeException rtex) {
                     // Do nothing.  Cipher.update() for decryption is not supported.
                 }
@@ -773,7 +773,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                                 "BaseTestAESCCM.java:  decrypt():  ERROR:  decryptedText2Length is not equal to decryptedText2.length.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 // All the decryption was performed on Cipher.doFinal( )
@@ -786,13 +786,13 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                 System.out.println(
                         "BaseTestAESCCM.java:  decrypt():  ERROR:  The following AEADBadTagException was thrown on the cipher.doFinal() call.");
             abte.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         } catch (Exception ex) {
             if (printJunitTrace)
                 System.out.println(
                         "BaseTestAESCCM.java:  decrypt():  ERROR:  The following exception was thrown.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         synchronized (myMutexObject) {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCM2.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCM2.java
@@ -19,7 +19,7 @@ import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 // This test case exercises the AES/CCM cipher using a CCMParameters object
@@ -197,7 +197,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                                         + iterationCounter);
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } else {
                     if (printJunitTrace)
                         System.out.println(toHexString(cipherText));
@@ -210,7 +210,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                                     + iterationCounter);
                 RuntimeException rtex = new RuntimeException();
                 rtex.printStackTrace(System.out);
-                Assert.fail();
+                Assertions.fail();
             }
 
 
@@ -249,7 +249,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                             "BaseTestAESCCM2.java:  testAESCCM():   The decryptedText bytes are: ");
                 if (printJunitTrace)
                     System.out.println(toHexString(decryptedText.getBytes()));
-                Assert.fail();
+                Assertions.fail();
             } else {
                 plainText = null;
                 decryptedText = null;
@@ -343,7 +343,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                 System.out.println(
                         "BaseTestAESCCM2ForAESCCMParameters.java:  encrypt():  ERROR:  The unexpected exception below was thrown while creating a CCMParameters object.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         // Initialize Cipher for ENCRYPT_MODE
@@ -377,7 +377,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                                 "BaseTestAESCCM2.java:  encrypt():  ERROR:  An exception should have been thrown.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (ProviderException proex) {
                     // do nothing.  This exception is expected because AES/CCM does not support cipher.update().
                 }
@@ -400,7 +400,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                                 "BaseTestAESCCM2.java:  encrypt():  ERROR:  An exception should have been thrown.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (ProviderException proex) {
                     // do nothing.  This exception is expected because AES/CCM does not support cipher.update().
                 }
@@ -430,7 +430,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                                 "BaseTestAESCCM2.java:  encrypt():  ERROR:  An exception should have been thrown.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (ProviderException proex) {
                     // do nothing.  This exception is expected because AES/CCM does not support cipher.update().
                 }
@@ -445,7 +445,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                                 "BaseTestAESCCM2.java:  encrypt():  ERROR:  cipherText2Length is not equal to cipherText2.length.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 // All the encryption was performed on Cipher.doFinal( )
@@ -471,7 +471,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                                 "BaseTestAESCCM2.java:  encrypt():  ERROR.  An exception should have been thrown.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (ProviderException proex) {
                     // do nothing.  This exception is expected because AES/CCM does not support cipher.update().
                 }
@@ -487,7 +487,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                                 "BaseTestAESCCM2.java:  encrypt():  ERROR:  cipherText2Length is not equal to cipherText2.length.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 // All the encryption was performed on Cipher.doFinal( )
@@ -510,7 +510,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                                 "BaseTestAESCCM2.java:  encrypt():  ERROR.  An exception should have been thrown.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (ProviderException proex) {
                     // do nothing.  This exception is expected because AES/CCM does not support cipher.update().
                 }
@@ -528,7 +528,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                                 "BaseTestAESCCM2.java:  encrypt():  ERROR:  cipherText2Length is not equal to cipherText2.length.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 // All the encryption was performed on Cipher.doFinal( )
@@ -541,7 +541,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                 System.out.println(
                         "BaseTestAESCCM2.java:  encrypt():  ERROR:  The following exception was thrown.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         if (printJunitTrace)
@@ -617,7 +617,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                 System.out.println(
                         "BaseTestAESCCM2ForAESCCMParameters.java:  decrypt():  ERROR:  The unexpected exception below was thrown while creating a CCMParameters object.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         // Initialize Cipher for DECRYPT_MODE
@@ -651,7 +651,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                                 "BaseTestAESCCM2.java:  decrypt():  ERROR.  Cipher.update( ) should have thrown a RuntimeException.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (RuntimeException rtex) {
                     // Do nothing.  Cipher.update() for decryption is not supported.
                 }
@@ -675,7 +675,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                                 "BaseTestAESCCM2.java:  decrypt():  ERROR.  Cipher.update( ) should have thrown a RuntimeException.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (RuntimeException rtex) {
                     // Do nothing.  Cipher.update() for decryption is not supported.
                 }
@@ -705,7 +705,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                                 "BaseTestAESCCM2.java:  decrypt():  ERROR.  Cipher.update( ) should have thrown a RuntimeException.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (RuntimeException rtex) {
                     // Do nothing.  Cipher.update() for decryption is not supported.
                 }
@@ -721,7 +721,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                                 "BaseTestAESCCM2.java:  decrypt():  ERROR:  decryptedText2Length is not equal to decryptedText2.length.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 // All the decryption was performed on Cipher.doFinal( )
@@ -746,7 +746,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                                 "BaseTestAESCCM2.java:  decrypt():  ERROR.  Cipher.update( ) should have thrown a RuntimeException.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (RuntimeException rtex) {
                     // Do nothing.  Cipher.update() for decryption is not supported.
                 }
@@ -762,7 +762,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                                 "BaseTestAESCCM2.java:  decrypt():  ERROR:  decryptedText2Length is not equal to decryptedText2.length.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 // All the decryption was performed on Cipher.doFinal( )
@@ -791,7 +791,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                                 "BaseTestAESCCM2.java:  decrypt():  ERROR.  Cipher.update( ) should have thrown a RuntimeException.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } catch (RuntimeException rtex) {
                     // Do nothing.  Cipher.update() for decryption is not supported.
                 }
@@ -805,7 +805,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                                 "BaseTestAESCCM2.java:  decrypt():  ERROR:  decryptedText2Length is not equal to decryptedText2.length.  ");
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 // All the decryption was performed on Cipher.doFinal( )
@@ -818,13 +818,13 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                 System.out.println(
                         "BaseTestAESCCM2.java:  decrypt():  ERROR:  The following AEADBadTagException was thrown on the cipher.doFinal() call.");
             abte.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         } catch (Exception ex) {
             if (printJunitTrace)
                 System.out.println(
                         "BaseTestAESCCM2.java:  decrypt():  ERROR:  The following exception was thrown.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         synchronized (myMutexObject) {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCMInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCMInteropBC.java
@@ -16,7 +16,7 @@ import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -221,7 +221,7 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                                         + iterationCounter);
                     RuntimeException rtex = new RuntimeException();
                     rtex.printStackTrace(System.out);
-                    Assert.fail();
+                    Assertions.fail();
                 } else {
                     if (printJunitTrace)
                         System.out.println(toHexString(cipherText));
@@ -234,7 +234,7 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                                     + iterationCounter);
                 RuntimeException rtex = new RuntimeException();
                 rtex.printStackTrace(System.out);
-                Assert.fail();
+                Assertions.fail();
             }
 
 
@@ -273,7 +273,7 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                             "BaseTestInteropBC.java:  testAESCCM():   The decryptedText bytes are: ");
                 if (printJunitTrace)
                     System.out.println(toHexString(decryptedText.getBytes()));
-                Assert.fail();
+                Assertions.fail();
             } else {
                 plainText = null;
                 decryptedText = null;
@@ -421,7 +421,7 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                                     "BaseTestInteropBC.java:  encrypt():  ERROR:  cipherText2Length is not equal to cipherText2.length.  ");
                         RuntimeException rtex = new RuntimeException();
                         rtex.printStackTrace(System.out);
-                        Assert.fail();
+                        Assertions.fail();
                     }
 
                     // All the encryption was performed on Cipher.doFinal( )
@@ -450,7 +450,7 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                                     "BaseTestInteropBC.java:  encrypt():  ERROR:  cipherText2Length is not equal to cipherText2.length.  ");
                         RuntimeException rtex = new RuntimeException();
                         rtex.printStackTrace(System.out);
-                        Assert.fail();
+                        Assertions.fail();
                     }
 
                     // All the encryption was performed on Cipher.doFinal( )
@@ -481,7 +481,7 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                                     "BaseTestInteropBC.java:  encrypt():  ERROR:  cipherText2Length is not equal to cipherText2.length.  ");
                         RuntimeException rtex = new RuntimeException();
                         rtex.printStackTrace(System.out);
-                        Assert.fail();
+                        Assertions.fail();
                     }
 
                     // All the encryption was performed on Cipher.doFinal( )
@@ -493,7 +493,7 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                     System.out.println(
                             "BaseTestInteropBC.java:  encrypt():  ERROR:  The following exception was thrown.  ");
                 ex.printStackTrace(System.out);
-                Assert.fail();
+                Assertions.fail();
             }
 
             if (printJunitTrace)
@@ -677,7 +677,7 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                                     "BaseTestInteropBC.java:  decrypt():  ERROR:  decryptedText2Length is not equal to decryptedText2.length.  ");
                         RuntimeException rtex = new RuntimeException();
                         rtex.printStackTrace(System.out);
-                        Assert.fail();
+                        Assertions.fail();
                     }
 
                     // All the decryption was performed on Cipher.doFinal( )
@@ -706,7 +706,7 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                                     "BaseTestInteropBC.java:  decrypt():  ERROR:  decryptedText2Length is not equal to decryptedText2.length.  ");
                         RuntimeException rtex = new RuntimeException();
                         rtex.printStackTrace(System.out);
-                        Assert.fail();
+                        Assertions.fail();
                     }
 
                     // All the decryption was performed on Cipher.doFinal( )
@@ -738,7 +738,7 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                                     "BaseTestInteropBC.java:  decrypt():  ERROR:  decryptedText2Length is not equal to decryptedText2.length.  ");
                         RuntimeException rtex = new RuntimeException();
                         rtex.printStackTrace(System.out);
-                        Assert.fail();
+                        Assertions.fail();
                     }
 
                     // All the decryption was performed on Cipher.doFinal( )
@@ -750,13 +750,13 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                     System.out.println(
                             "BaseTestInteropBC.java:  decrypt():  ERROR:  The following AEADBadTagException was thrown on the cipher.doFinal() call.");
                 abte.printStackTrace(System.out);
-                Assert.fail();
+                Assertions.fail();
             } catch (Exception ex) {
                 if (printJunitTrace)
                     System.out.println(
                             "BaseTestInteropBC.java:  decrypt():  ERROR:  The following exception was thrown.  ");
                 ex.printStackTrace(System.out);
-                Assert.fail();
+                Assertions.fail();
             }
 
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCMParameters.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCMParameters.java
@@ -14,7 +14,7 @@ import java.security.AlgorithmParameters;
 import java.security.Provider;
 import java.security.SecureRandom;
 import java.security.Security;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class BaseTestAESCCMParameters extends BaseTestJunit5 {
@@ -54,7 +54,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameterSpec():  ERROR:  The unexpected exception below was thrown.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         try {
@@ -63,7 +63,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameterSpec():  ERROR:  The unexpected exception below was thrown.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         try {
@@ -74,7 +74,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameterSpec():  ERROR:  The unexpected exception below was thrown.  ");
             iaex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         try {
@@ -85,7 +85,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameterSpec():  ERROR:  The unexpected exception below was thrown.  ");
             iaex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         try {
@@ -96,7 +96,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameterSpec():  ERROR:  The unexpected exception below was thrown.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         //-----------------------------------------------------------------------
@@ -109,7 +109,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameterSpec():  ERROR:  The unexpected exception below was thrown.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         try {
@@ -122,7 +122,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameterSpec():  ERROR:  The unexpected exception below was thrown.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         try {
@@ -135,7 +135,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameterSpec():  ERROR:  The unexpected exception below was thrown.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         try {
@@ -148,7 +148,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameterSpec():  ERROR:  The unexpected exception below was thrown.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         try {
@@ -161,7 +161,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameterSpec():  ERROR:  The unexpected exception below was thrown.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         try {
@@ -174,7 +174,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameterSpec():  ERROR:  The unexpected exception below was thrown.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         CCMParameterSpec ccmParameterSpec = new CCMParameterSpec(tagLenGood, ivBufferGood,
@@ -185,7 +185,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     + ") was read from the CCMParameterSpec object.  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
         byte[] iv = ccmParameterSpec.getIV();
         if (iv.length != ivBufferGood.length) {
@@ -194,7 +194,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                             + iv.length + ") was read from the CCMParameterSpec object.  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
         for (int i = 0; i < iv.length; i++) {
             if (iv[i] != ivBufferGood[i]) {
@@ -202,7 +202,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                         "testAESCCMParameterSpec():  ERROR:  Unexpected IV bytes were read from the CCMParameterSpec object.  ");
                 RuntimeException rtex = new RuntimeException();
                 rtex.printStackTrace(System.out);
-                Assert.fail();
+                Assertions.fail();
             }
         }
 
@@ -239,7 +239,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameters():  ERROR:  The following exception was thrown while instantiating a CCMParameterSpec object.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
 
@@ -251,7 +251,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameters():  ERROR:  The unexpected exception below was thrown while creating a CCMParameters object.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
 
@@ -259,7 +259,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println("testAESCCMParameters():  ERROR:  ccmParameters1 is null.  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
 
@@ -268,7 +268,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameters():  ERROR:  ccmParameters1.getAlgorithm() did not return the string \"CCM\".  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
 
@@ -277,7 +277,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameters():  ERROR:  ccmParameters1.getProvider().getname() did not return the string \"OpenJCEPlus\".  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         // Obtain a CCMParameterSpec object from the CCMParameters object
@@ -289,7 +289,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameters():  ERROR:  The following exception was thrown while encoding and decoding CCMParameters.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         if (ccmParameterSpec1.getTLen() != newCCMParameterSpec.getTLen()) {
@@ -297,7 +297,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameters():  ERROR:  CCMParameterSpec with a bad tagLen was produced.  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         if (ccmParameterSpec1.getIV().length != newCCMParameterSpec.getIV().length) {
@@ -305,7 +305,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameters():  ERROR:  CCMParameterSpec with a bad IV length was produced.");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         byte[] originalIV = ccmParameterSpec1.getIV();
@@ -317,7 +317,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                         "testAESCCMParameters():  ERROR:  CCMParameterSpec with a bad IV was produced.  ");
                 RuntimeException rtex = new RuntimeException();
                 rtex.printStackTrace(System.out);
-                Assert.fail();
+                Assertions.fail();
             }
         }
 
@@ -331,7 +331,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameters():  ERROR:  ccmParameters1.getEncoded() threw the following exception.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
 
@@ -345,7 +345,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameters():  ERROR:  The unexpected exception below was thrown while getting a CCMParameters object.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
 
@@ -354,7 +354,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameters():  ERROR:  ccmParameters2.getAlgorithm() did not return the string \"CCM\".  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         if (!(ccmParameters2.getProvider().getName().equals(getProviderName()))) {
@@ -362,7 +362,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameters():  ERROR:  ccmParameters2.getProvider() did not return the string \"OpenJCEPlus\".  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         String ccmParameters2String = ccmParameters2.toString();
@@ -379,7 +379,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameters():  ERROR:  The unexpected exception below was thrown while getting a CCMParameters object.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
 
@@ -388,7 +388,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameters():  ERROR:  ccmParameters3.getAlgorithm() did not return the string \"CCM\".  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         if (!(ccmParameters3.getProvider().getName().equals(getProviderName()))) {
@@ -396,7 +396,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameters():  ERROR:  ccmParameters3.getProvider() did not return the string \"OpenJCEPlus\".  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         String ccmParameters3String = ccmParameters3.toString();
@@ -407,7 +407,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameters():  ERROR:  ccmParameters is not equal to ccmParameters2.  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         if (!(ccmParameters1String.equals(ccmParameters3String))) {
@@ -415,7 +415,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameters():  ERROR:  ccmParameters is not equal to ccmParameters3.  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         synchronized (myMutexObject) {
@@ -456,7 +456,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameterGenerator():  ERROR:  The OpenJCEPlus provider was not found in the provider's list.  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
 
@@ -467,7 +467,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameterGenerator():  ERROR:  The unexpected exception below was thrown while getting a CCMParameterGenerator object.  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
 
@@ -476,7 +476,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameterGenerator():  ERROR:  The CCMParameterGenerator is null.  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
 
@@ -485,7 +485,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameterGenerator():  ERROR:  CCMParameterGenerator.getAlgorithm() did not return \"CCM\".  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
 
@@ -494,7 +494,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameterGenerator():  ERROR:  ccmParameterGenerator.getProvider().getName() did not return the string \"OpenJCEPlus\".  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         //-----------------------------------
@@ -507,7 +507,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameterGenerator():  ERROR:  The unexpected exception below was thrown while executing CCMParameterGenerator.init( tagLen ).  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
 
@@ -518,7 +518,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameterGenerator():  ERROR:  The unexpected exception below was thrown while executing CCMParameterGenerator.generateParameters().  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         if (algorithmParameters == null) {
@@ -526,7 +526,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameterGenerator():  ERROR:  The generated algorithmParameters are null.  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
 
@@ -536,7 +536,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameterGenerator():  ERROR:  algorithmParameters.getClass().getName() did not return the string \"java.security.AlgorithmParameters\".  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
 
@@ -545,7 +545,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameterGenerator():  ERROR:  algorithmParameters.getProvider().getName() did not return the string \"OpenJCEPlus\".  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
 
@@ -554,7 +554,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameterGenerator():  ERROR:  algorithmParameters.getAlgorithm() did not return the string \"CCM\".  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         String algorithmParametersClassName = algorithmParameters.getClass().getName();
@@ -564,7 +564,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(algorithmParametersClassName);
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         // Get a CCMParametersSpec object from the generated algorithmParameters (CCMParameters) object
@@ -576,7 +576,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameters():  ERROR:  The following exception was thrown while encoding and decoding AlgorithmParameters(CCMParameters).  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         // Verify the tagLen within the CCMParameterSpec object
@@ -585,7 +585,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameters():  ERROR:  CCMParameterSpec with a bad tagLen was produced.  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         // Verify the IV within the CCMParameterSpec object
@@ -594,7 +594,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameters():  ERROR:  CCMParameterSpec with a bad IV length was produced.  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         byte[] iv = ccmParameterSpec.getIV();
@@ -614,7 +614,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameterGenerator():  ERROR:  The unexpected exception below was thrown while executing CCMParameterGenerator.init(int size).  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         algorithmParameters = null;
@@ -624,7 +624,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameterGenerator():  ERROR:  The unexpected exception below was thrown while executing CCMParameterGenerator.generateParameters().  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         if (algorithmParameters == null) {
@@ -632,7 +632,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameterGenerator():  ERROR:  The generated algorithmParameters are null.  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         if (!(algorithmParameters.getClass().getName()
@@ -641,7 +641,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameterGenerator():  ERROR:  algorithmParameters.getClass().getName() did not return the string \"java.security.AlgorithmParameters\".  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         if (!(algorithmParameters.getProvider().getName().equals(getProviderName()))) {
@@ -649,7 +649,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameterGenerator():  ERROR:  algorithmParameters.getProvider().getName() did not return the string \"OpenJCEPlus\".  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         if (!(algorithmParameters.getAlgorithm().equals("CCM"))) {
@@ -657,7 +657,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameterGenerator():  ERROR:  algorithmParameters.getAlgorithm() did not return the string \"CCM\".  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         algorithmParametersClassName = algorithmParameters.getClass().getName();
@@ -667,7 +667,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(algorithmParametersClassName);
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         // Get a CCMParametersSpec object from the generated algorithmParameters (CCMParameters) object
@@ -679,7 +679,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
             System.out.println(
                     "testAESCCMParameterGenerator():  ERROR:  The following exception was thrown while encoding and decoding AlgorithmParameters(CCMParameters).  ");
             ex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         // Verify the tagLen within the CCMParameterSpec object
@@ -688,7 +688,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameterGenerator():  ERROR:  CCMParameterSpec with a bad tagLen was produced.  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         // Verify the IV within the CCMParameterSpec object
@@ -697,7 +697,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                     "testAESCCMParameterGenerator():  ERROR:  CCMParameterSpec with a bad IV length was produced.  ");
             RuntimeException rtex = new RuntimeException();
             rtex.printStackTrace(System.out);
-            Assert.fail();
+            Assertions.fail();
         }
 
         iv = ccmParameterSpec.getIV();
@@ -713,7 +713,7 @@ public class BaseTestAESCCMParameters extends BaseTestJunit5 {
                 }
                 RuntimeException rtex = new RuntimeException();
                 rtex.printStackTrace(System.out);
-                Assert.fail();
+                Assertions.fail();
             }
         }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESCipherInputStreamExceptions.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESCipherInputStreamExceptions.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM.java
@@ -30,7 +30,7 @@ import javax.crypto.spec.RC2ParameterSpec;
 import javax.crypto.spec.RC5ParameterSpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestAESGCM extends BaseTestJunit5 {
@@ -186,8 +186,8 @@ public class BaseTestAESGCM extends BaseTestJunit5 {
         byte[] decrypted = new byte[cp.getOutputSize(encryptLength)];
         cp.doFinal(encrypted, offset, encryptLength, decrypted, 0);
 
-        assertTrue("Decrypted text does not match expected",
-                byteEqual(plainText, 0, decrypted, 0, plainText.length));
+        assertTrue(byteEqual(plainText, 0, decrypted, 0, plainText.length),
+              "Decrypted text does not match expected");
     }
 
     @Test
@@ -222,8 +222,8 @@ public class BaseTestAESGCM extends BaseTestJunit5 {
         byte[] decrypted = new byte[cp.getOutputSize(encryptLength) + offset];
         cp.doFinal(encrypted, 0, encryptLength, decrypted, offset);
 
-        assertTrue("Decrypted text does not match expected",
-                byteEqual(plainText, 0, decrypted, offset, plainText.length));
+        assertTrue(byteEqual(plainText, 0, decrypted, offset, plainText.length),
+            "Decrypted text does not match expected");
     }
 
     @Test
@@ -247,13 +247,13 @@ public class BaseTestAESGCM extends BaseTestJunit5 {
         int encryptLength = cp.doFinal(plainText, 0, plainText.length, encrypted, 0);
 
         if (expected_encryptLength != encryptLength) {
-            assertTrue("Failure -\n" + "Actual   encrypt output length from Cipher.doFinal: "
+            assertTrue(false, "Failure -\n" + "Actual   encrypt output length from Cipher.doFinal: "
                     + encryptLength + "\n" + "Expected encrypt output length from Cipher.doFinal: "
                     + expected_encryptLength + "\n"
                     + "Buffer encrypt length passed to Cipher.doFinal:     " + encrypted.length
-                    + "\n", false);
+                    + "\n");
         } else {
-            assertTrue("Passed - Output encrypt with large buffer", true);
+            assertTrue(true, "Passed - Output encrypt with large buffer");
         }
     }
 
@@ -287,13 +287,13 @@ public class BaseTestAESGCM extends BaseTestJunit5 {
         int decryptLength = cp.doFinal(encrypted, 0, encryptLength, decrypted, 0);
 
         if (expected_decryptLength != decryptLength) {
-            assertTrue("Failure -\n" + "Actual   decrypt output length from Cipher.doFinal: "
+            assertTrue(false, "Failure -\n" + "Actual   decrypt output length from Cipher.doFinal: "
                     + decryptLength + "\n" + "Expected decrypt output length from Cipher.doFinal: "
                     + expected_decryptLength + "\n"
                     + "Buffer decrypt length passed to Cipher.doFinal:     " + decrypted.length
-                    + "\n", false);
+                    + "\n");
         } else {
-            assertTrue("Passed - Output encrypt with large buffer", true);
+            assertTrue(true, "Passed - Output encrypt with large buffer");
         }
     }
 
@@ -311,8 +311,8 @@ public class BaseTestAESGCM extends BaseTestJunit5 {
         cp.init(Cipher.DECRYPT_MODE, key, params);
         byte[] newPlainText1 = cp.doFinal(cipherText1);
 
-        assertTrue("Decrypted text does not match expected",
-                byteEqual(plainText, 0, newPlainText1, 0, plainText.length));
+        assertTrue(byteEqual(plainText, 0, newPlainText1, 0, plainText.length),
+            "Decrypted text does not match expected");
     }
 
     @Test
@@ -338,8 +338,8 @@ public class BaseTestAESGCM extends BaseTestJunit5 {
         cp.init(Cipher.DECRYPT_MODE, key, params); // call init again
         newPlainText1 = cp.doFinal(cipherText1); // call final again
 
-        assertTrue("Decrypted text does not match expected",
-                byteEqual(plainText, 0, newPlainText1, 0, plainText.length));
+        assertTrue(byteEqual(plainText, 0, newPlainText1, 0, plainText.length),
+            "Decrypted text does not match expected");
     }
 
     @Test
@@ -353,11 +353,11 @@ public class BaseTestAESGCM extends BaseTestJunit5 {
             params = cp.getParameters();
             cp.doFinal();
         } catch (Exception ex) {
-            assertTrue("Failed - Should not have been exception: \n" + ex.getStackTrace(), false);
+            assertTrue(false, "Failed - Should not have been exception: \n" + ex.getStackTrace());
             return;
         }
 
-        assertTrue("Passed - Cipher.doFinal() encrypt empty text", true);
+        assertTrue(true, "Passed - Cipher.doFinal() encrypt empty text");
     }
 
     @Test
@@ -369,14 +369,12 @@ public class BaseTestAESGCM extends BaseTestJunit5 {
             cp.init(Cipher.DECRYPT_MODE, key);
             cp.doFinal();
         } catch (Exception ex) {
-            assertTrue(
-                    "Passed - Cipher.doFinal() decrypt without parameters throws expected exception",
-                    true);
+            assertTrue(true,
+                    "Passed - Cipher.doFinal() decrypt without parameters throws expected exception");
             return;
         }
-        assertTrue(
-                "Failed - Cipher.doFinal() decrypt without parameters should have thrown exception",
-                false);
+        assertTrue(false,
+                "Failed - Cipher.doFinal() decrypt without parameters should have thrown exception");
     }
 
     @Test
@@ -394,11 +392,10 @@ public class BaseTestAESGCM extends BaseTestJunit5 {
             params = cp.getParameters();
             cp.doFinal();
         } catch (Exception ex) {
-            assertTrue("Passed - Cipher.doFinal() decrypt empty text throws expected exception",
-                    true);
+            assertTrue(true, "Passed - Cipher.doFinal() decrypt empty text throws expected exception");
             return;
         }
-        assertTrue("Failed - Cipher.doFinal() decrypt should have thrown exception", false);
+        assertTrue(false, "Failed - Cipher.doFinal() decrypt should have thrown exception");
     }
 
     @Test
@@ -418,14 +415,14 @@ public class BaseTestAESGCM extends BaseTestJunit5 {
             cp.doFinal(plainText);
         } catch (Exception ex) {
             if (ex.getClass().getSimpleName().equals("AEADBadTagException")) {
-                assertTrue("Passed - AEADBadTagException thrown on bad decrypt input", true);
+                assertTrue(true, "Passed - AEADBadTagException thrown on bad decrypt input");
             } else {
-                assertTrue("Failed - Expected AEADBadTagException:\n" + ex.getStackTrace(), false);
+                assertTrue(false, "Failed - Expected AEADBadTagException:\n" + ex.getStackTrace());
             }
             return;
         }
 
-        assertTrue("Failed - Expected AEADBadTagException", false);
+        assertTrue(false, "Failed - Expected AEADBadTagException");
     }
 
     @Test
@@ -439,7 +436,7 @@ public class BaseTestAESGCM extends BaseTestJunit5 {
             //cp.init(Cipher.ENCRYPT_MODE, key);
             //params = cp.getParameters();
             cp.update(plainText);
-            assertTrue("Failed - Did not get expected ProviderException", false);
+            assertTrue(false, "Failed - Did not get expected ProviderException");
         } catch (Exception ex) {
             System.out.println("caught " + ex.getMessage());
             //ex.printStackTrace();
@@ -449,11 +446,11 @@ public class BaseTestAESGCM extends BaseTestJunit5 {
                 }
                 throw ex;
             } else {
-                assertTrue("Unexpected Exception: " + ex.getStackTrace(), false);
+                assertTrue(false, "Unexpected Exception: " + ex.getStackTrace());
                 return;
             }
         }
-        assertTrue("Failed - Expected IllegalStateException", true);
+        assertTrue(true, "Failed - Expected IllegalStateException");
     }
 
     @Test
@@ -883,10 +880,9 @@ public class BaseTestAESGCM extends BaseTestJunit5 {
             params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((blockSize > 0) && (message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((blockSize > 0) && (message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             // Verify the text
@@ -894,19 +890,18 @@ public class BaseTestAESGCM extends BaseTestJunit5 {
             byte[] newPlainText = cp.doFinal(cipherText);
 
             boolean success = byteEqual(message, 0, newPlainText, 0, message.length);
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
 
             // Verify the text again
             cp.init(Cipher.DECRYPT_MODE, key, params);
             byte[] newPlainText2 = cp.doFinal(cipherText, 0, cipherText.length);
 
             success = byteEqual(message, 0, newPlainText2, 0, message.length);
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 
@@ -928,10 +923,9 @@ public class BaseTestAESGCM extends BaseTestJunit5 {
             params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             // Verify the text
@@ -948,12 +942,11 @@ public class BaseTestAESGCM extends BaseTestJunit5 {
             System.arraycopy(newPlainText2, 0, newPlainText, l, newPlainText2.length);
 
             boolean success = byteEqual(message, 0, newPlainText, 0, message.length);
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 
@@ -977,10 +970,9 @@ public class BaseTestAESGCM extends BaseTestJunit5 {
             params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             // Verify the text
@@ -997,13 +989,11 @@ public class BaseTestAESGCM extends BaseTestJunit5 {
             System.arraycopy(newPlainText2, 0, newPlainText, l, newPlainText2.length);
 
             boolean success = byteEqual(message, 0, newPlainText, 0, message.length);
-            assertTrue("Decrypted text does not match expected, partial msglen=" + message.length,
-                    success);
+            assertTrue(success, "Decrypted text does not match expected, partial msglen=" + message.length);
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMBufferIV.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMBufferIV.java
@@ -15,7 +15,7 @@ import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestAESGCMBufferIV extends BaseTestJunit5 {
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMCICOWithGCM.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMCICOWithGCM.java
@@ -17,7 +17,7 @@ import javax.crypto.CipherOutputStream;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestAESGCMCICOWithGCM extends BaseTestJunit5 {
     protected int specifiedKeySize = 128;
@@ -86,9 +86,9 @@ public class BaseTestAESGCMCICOWithGCM extends BaseTestJunit5 {
         byte[] recovered = baOutput.toByteArray();
 
         if (!Arrays.equals(plainText, recovered)) {
-            assertTrue("diff check failed!", false);
+            assertTrue(false, "diff check failed!");
         } else {
-            assertTrue("diff check passed", true);
+            assertTrue(true, "diff check passed");
         }
     }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMLong.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMLong.java
@@ -16,7 +16,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestAESGCMLong extends BaseTestJunit5 {
     private final static int GCM_IV_LENGTH = 12;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMUpdate.java
@@ -40,7 +40,7 @@ import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestAESGCMUpdate extends BaseTestJunit5 {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMUpdateInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMUpdateInteropBC.java
@@ -17,7 +17,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestAESGCMUpdateInteropBC extends BaseTestJunit5Interop {
     private final static int GCM_IV_LENGTH = 12;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMWithByteBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMWithByteBuffer.java
@@ -18,7 +18,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestAESGCMWithByteBuffer extends BaseTestJunit5 {
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMWithKeyAndIvCheck.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMWithKeyAndIvCheck.java
@@ -17,7 +17,7 @@ import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestAESGCMWithKeyAndIvCheck extends BaseTestJunit5 {
 
@@ -148,7 +148,7 @@ public class BaseTestAESGCMWithKeyAndIvCheck extends BaseTestJunit5 {
             // expected
         }
 
-        assertTrue("Test Passed!", true);
+        assertTrue(true, "Test Passed!");
     }
 
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM_IntIV.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM_IntIV.java
@@ -24,7 +24,7 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestAESGCM_IntIV extends BaseTestJunit5 {
@@ -87,8 +87,7 @@ public class BaseTestAESGCM_IntIV extends BaseTestJunit5 {
         byte[] plainTextDecrypt = new byte[plainTextEncrypt.length];
         cipherDecrypt.doFinal(cipherTextPlusT, 0, cipherTextPlusT.length, plainTextDecrypt, 0);
 
-        assertTrue("Plaintext did not match expected",
-                Arrays.equals(plainTextEncrypt, plainTextDecrypt));
+        assertTrue(Arrays.equals(plainTextEncrypt, plainTextDecrypt), "Plaintext did not match expected");
     }
 
     @Test
@@ -127,8 +126,7 @@ public class BaseTestAESGCM_IntIV extends BaseTestJunit5 {
             byte[] plainTextDecrypt = new byte[plainTextEncrypt.length];
             cipherDecrypt.doFinal(cipherTextPlusT, 0, cipherTextPlusT.length, plainTextDecrypt, 0);
 
-            assertTrue("Plaintext did not match expected",
-                    Arrays.equals(plainTextEncrypt, plainTextDecrypt));
+            assertTrue(Arrays.equals(plainTextEncrypt, plainTextDecrypt), "Plaintext did not match expected");
         }
     }
 
@@ -157,8 +155,7 @@ public class BaseTestAESGCM_IntIV extends BaseTestJunit5 {
         byte[] plainTextDecrypt = new byte[plainTextEncrypt.length];
         cipherDecrypt.doFinal(cipherTextPlusT, 0, cipherTextPlusT.length, plainTextDecrypt, 0);
 
-        assertTrue("Plaintext did not match expected",
-                Arrays.equals(plainTextEncrypt, plainTextDecrypt));
+        assertTrue(Arrays.equals(plainTextEncrypt, plainTextDecrypt), "Plaintext did not match expected");
     }
 
     @Test
@@ -187,8 +184,7 @@ public class BaseTestAESGCM_IntIV extends BaseTestJunit5 {
         byte[] plainTextDecrypt = new byte[plainTextEncrypt.length];
         cipherDecrypt.doFinal(cipherTextPlusT, 0, cipherTextPlusT.length, plainTextDecrypt, 0);
 
-        assertTrue("Plaintext did not match expected",
-                Arrays.equals(plainTextEncrypt, plainTextDecrypt));
+        assertTrue(Arrays.equals(plainTextEncrypt, plainTextDecrypt), "Plaintext did not match expected");
     }
 
     @Test
@@ -213,9 +209,9 @@ public class BaseTestAESGCM_IntIV extends BaseTestJunit5 {
             byte[] plainTextDecrypt = new byte[plainTextEncrypt.length];
             cipherDecrypt.doFinal(cipherTextPlusT, 0, cipherTextPlusT.length, plainTextDecrypt, 0);
         } catch (InvalidKeyException ex) {
-            assertTrue("Got expected invalid key exception", true);
+            assertTrue(true, "Got expected invalid key exception");
         } catch (RuntimeException rte) {
-            assertTrue("Got expected exception", true);
+            assertTrue(true, "Got expected exception");
         } catch (Exception e) {
             fail("Unexpected exception: " + e.getMessage());
         }
@@ -244,7 +240,7 @@ public class BaseTestAESGCM_IntIV extends BaseTestJunit5 {
             cipherDecrypt.doFinal(cipherTextPlusT, 0, cipherTextPlusT.length, plainTextDecrypt, 0);
 
         } catch (InvalidAlgorithmParameterException ipe) {
-            assertTrue("Got expected exception", true);
+            assertTrue(true, "Got expected exception");
         } catch (Exception e) {
             fail("Unexpected exception: " + e.getMessage());
         }
@@ -273,7 +269,7 @@ public class BaseTestAESGCM_IntIV extends BaseTestJunit5 {
             cipherDecrypt.doFinal(cipherTextPlusT, 0, cipherTextPlusT.length, plainTextDecrypt, 0);
 
         } catch (InvalidAlgorithmParameterException ipe) {
-            assertTrue("Got expected exception", true);
+            assertTrue(true, "Got expected exception");
         } catch (Exception e) {
             fail("Unexpected exception: " + e.getMessage());
         }
@@ -284,7 +280,7 @@ public class BaseTestAESGCM_IntIV extends BaseTestJunit5 {
 
         //Assume.assumeTrue(RUN_FULL_TEST_SUITE.equals("true"));
         if (!RUN_FULL_TEST_SUITE.equals("true")) {
-            assertTrue("Test skipped", true);
+            assertTrue(true, "Test skipped");
             return;
         }
 
@@ -324,7 +320,7 @@ public class BaseTestAESGCM_IntIV extends BaseTestJunit5 {
             }
 
         } catch (IllegalStateException ise) {
-            assertTrue("Got expected exception", true);
+            assertTrue(true, "Got expected exception");
         } catch (Exception e) {
             fail("Unexpected exception: " + e.getMessage());
         }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESInterop.java
@@ -25,7 +25,7 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestAESInterop extends BaseTestJunit5Interop {
@@ -631,10 +631,9 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
             params = cpA.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((blockSize > 0) && (message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((blockSize > 0) && (message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
             // System.err.println(
             // "cipherText length=" + cipherText.length + "CipherText=" +
@@ -655,7 +654,7 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
                 System.err
                         .println("message=" + message.length + " " + BaseUtils.bytesToHex(message));
             }
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
 
             // Verify the text again
 
@@ -671,12 +670,11 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
                 System.err
                         .println("message=" + message.length + " " + BaseUtils.bytesToHex(message));
             }
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 
@@ -699,10 +697,9 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
             params = cpA.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             // Verify the text
@@ -720,12 +717,11 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
             System.arraycopy(newPlainText2, 0, newPlainText, l, newPlainText2.length);
 
             boolean success = Arrays.equals(newPlainText, message);
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 
@@ -749,10 +745,9 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
             params = cpA.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             // Verify the text
@@ -770,13 +765,11 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
             System.arraycopy(newPlainText2, 0, newPlainText, l, newPlainText2.length);
 
             boolean success = Arrays.equals(newPlainText, message);
-            assertTrue("Decrypted text does not match expected, partial msglen=" + message.length,
-                    success);
+            assertTrue(success, "Decrypted text does not match expected, partial msglen=" + message.length);
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 
@@ -801,33 +794,31 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
             params = cpA.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((blockSize > 0) && (message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((blockSize > 0) && (message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             // Verify that the cipher object can be used to encrypt again without re-init
             byte[] cipherText2 = cpA.doFinal(message);
             boolean success = Arrays.equals(cipherText2, cipherText);
-            assertTrue("Re-encrypted text does not match", success);
+            assertTrue(success, "Re-encrypted text does not match");
 
             cpB = Cipher.getInstance(algorithm, providerB);
             // Verify the text
             cpB.init(Cipher.DECRYPT_MODE, key, params);
             byte[] newPlainText = cpB.doFinal(cipherText);
             success = Arrays.equals(newPlainText, message);
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
 
             // Verify that the cipher object can be used to decrypt again without re-init
             byte[] newPlainText2 = cpB.doFinal(cipherText, 0, cipherText.length);
             success = Arrays.equals(newPlainText2, newPlainText);
-            assertTrue("Re-decrypted text does not match", success);
+            assertTrue(success, "Re-decrypted text does not match");
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 
@@ -855,14 +846,13 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
             params = cpA.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((blockSize > 0) && (message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((blockSize > 0) && (message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             boolean success = Arrays.equals(cipherText, cipherText0);
-            assertTrue("Encrypted text does not match expected result", success);
+            assertTrue(success, "Encrypted text does not match expected result");
 
             // Verify the text
             cpB = Cipher.getInstance(algorithm, providerB);
@@ -872,12 +862,11 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
             byte[] newPlainText = Arrays.copyOf(resultBuffer, resultLen);
 
             success = Arrays.equals(newPlainText, message);
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 
@@ -909,14 +898,13 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
             params = cpA.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((blockSize > 0) && (message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((blockSize > 0) && (message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             boolean success = Arrays.equals(cipherText, cipherText0);
-            assertTrue("Encrypted text does not match expected result", success);
+            assertTrue(success,"Encrypted text does not match expected result");
 
             // Verify the text
             cpB = Cipher.getInstance(algorithm, providerB);
@@ -930,12 +918,11 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
             System.arraycopy(plainText2, 0, newPlainText, plainText1Len, plainText2.length);
 
             success = Arrays.equals(newPlainText, message);
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20.java
@@ -23,8 +23,8 @@ import javax.crypto.spec.ChaCha20ParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestChaCha20 extends BaseTestCipher implements ChaCha20Constants {
@@ -137,8 +137,7 @@ public class BaseTestChaCha20 extends BaseTestCipher implements ChaCha20Constant
         ChaCha20ParameterSpec chaCha20ParamSpec = new ChaCha20ParameterSpec(NONCE_12_BYTE, 0);
         cp = Cipher.getInstance(CHACHA20_ALGORITHM, getProviderName());
         cp.init(opMode, key, chaCha20ParamSpec);
-        assertTrue("ChaCha20 Block size must be: " + ChaCha20_BLOCK_SIZE,
-                (cp.getBlockSize() == ChaCha20_BLOCK_SIZE));
+        assertTrue((cp.getBlockSize() == ChaCha20_BLOCK_SIZE), "ChaCha20 Block size must be: " + ChaCha20_BLOCK_SIZE);
     }
 
     @Test
@@ -685,7 +684,7 @@ public class BaseTestChaCha20 extends BaseTestCipher implements ChaCha20Constant
             cp.init(Cipher.ENCRYPT_MODE, key, newNonceSpec);
             byte[] cipherText2 = cp.doFinal(PLAIN_TEXT);
             boolean sameCipher = Arrays.equals(cipherText2, cipherText1);
-            assertFalse("Re-encrypted text with diffent nonce is same", sameCipher);
+            assertFalse(sameCipher, "Re-encrypted text with diffent nonce is same");
         } catch (Exception e) {
             fail("Got unexpected exception on encrypt/decrypt...");
         }
@@ -711,7 +710,7 @@ public class BaseTestChaCha20 extends BaseTestCipher implements ChaCha20Constant
             paramSpec = CHACHA20_PARAM_SPEC_COUNTER_0;
 
             boolean success = Arrays.equals(cipherText, cipherText0);
-            assertTrue("Encrypted text does not match expected result", success);
+            assertTrue(success, "Encrypted text does not match expected result");
 
             // Verify the text
             cp = Cipher.getInstance(CHACHA20_ALGORITHM, getProviderName());
@@ -721,8 +720,7 @@ public class BaseTestChaCha20 extends BaseTestCipher implements ChaCha20Constant
             byte[] newPlainText = Arrays.copyOf(resultBuffer, resultLen);
 
             success = Arrays.equals(newPlainText, PLAIN_TEXT);
-            assertTrue("Decrypted text does not match expected, msglen=" + PLAIN_TEXT.length,
-                    success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + PLAIN_TEXT.length);
 
         } catch (Exception e) {
             fail("Got unexpected exception on encrypt/decrypt...");
@@ -754,7 +752,7 @@ public class BaseTestChaCha20 extends BaseTestCipher implements ChaCha20Constant
             paramSpec = CHACHA20_PARAM_SPEC_COUNTER_0;
 
             boolean success = Arrays.equals(cipherText12, cipherText0);
-            assertTrue("Encrypted text does not match expected result", success);
+            assertTrue(success, "Encrypted text does not match expected result");
 
             // Verify the text
             cp = Cipher.getInstance(CHACHA20_ALGORITHM, getProviderName());
@@ -769,8 +767,7 @@ public class BaseTestChaCha20 extends BaseTestCipher implements ChaCha20Constant
             System.arraycopy(plainText2, 0, plainText12, plainText1Len, plainText2.length);
 
             success = Arrays.equals(plainText12, PLAIN_TEXT);
-            assertTrue("Decrypted text does not match expected, msglen=" + PLAIN_TEXT.length,
-                    success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + PLAIN_TEXT.length);
 
         } catch (Exception e) {
             fail("Got unexpected exception on encrypt/decrypt...");

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20Poly1305.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20Poly1305.java
@@ -22,8 +22,8 @@ import javax.crypto.ShortBufferException;
 import javax.crypto.spec.IvParameterSpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestChaCha20Poly1305 extends BaseTestCipher implements ChaCha20Constants {
@@ -183,8 +183,7 @@ public class BaseTestChaCha20Poly1305 extends BaseTestCipher implements ChaCha20
         IvParameterSpec chaCha20ParamSpec = new IvParameterSpec(NONCE_12_BYTE);
         cp = Cipher.getInstance(CHACHA20_POLY1305_ALGORITHM, getProviderName());
         cp.init(opMode, key, chaCha20ParamSpec);
-        assertTrue("ChaCha20 Block size must be: " + ChaCha20_BLOCK_SIZE,
-                (cp.getBlockSize() == ChaCha20_BLOCK_SIZE));
+        assertTrue((cp.getBlockSize() == ChaCha20_BLOCK_SIZE), "ChaCha20 Block size must be: " + ChaCha20_BLOCK_SIZE);
     }
 
     @Test
@@ -870,7 +869,7 @@ public class BaseTestChaCha20Poly1305 extends BaseTestCipher implements ChaCha20
             byte[] cipherText2 = cp.doFinal(PLAIN_TEXT);
 
             boolean sameCipher = Arrays.equals(cipherText2, cipherText1);
-            assertFalse("Re-encrypted text with diffent nonce is same", sameCipher);
+            assertFalse(sameCipher, "Re-encrypted text with diffent nonce is same");
         } catch (Exception e) {
             fail("Got unexpected exception on encrypt/decrypt...");
         }
@@ -896,7 +895,7 @@ public class BaseTestChaCha20Poly1305 extends BaseTestCipher implements ChaCha20
             paramSpec = cp.getParameters().getParameterSpec(IvParameterSpec.class);;
 
             boolean success = Arrays.equals(cipherText, cipherText0);
-            assertTrue("Encrypted text does not match expected result", success);
+            assertTrue(success, "Encrypted text does not match expected result");
 
             // Verify the text
             cp = Cipher.getInstance(CHACHA20_POLY1305_ALGORITHM, getProviderName());
@@ -906,8 +905,7 @@ public class BaseTestChaCha20Poly1305 extends BaseTestCipher implements ChaCha20
             byte[] newPlainText = Arrays.copyOf(resultBuffer, resultLen);
 
             success = Arrays.equals(newPlainText, PLAIN_TEXT);
-            assertTrue("Decrypted text does not match expected, msglen=" + PLAIN_TEXT.length,
-                    success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + PLAIN_TEXT.length);
 
         } catch (Exception e) {
             fail("Got unexpected exception on encrypt/decrypt...");
@@ -938,7 +936,7 @@ public class BaseTestChaCha20Poly1305 extends BaseTestCipher implements ChaCha20
             paramSpec = cp.getParameters().getParameterSpec(IvParameterSpec.class);
 
             boolean success = Arrays.equals(cipherText12, cipherText0);
-            assertTrue("Encrypted text does not match expected result", success);
+            assertTrue(success, "Encrypted text does not match expected result");
 
             // Verify the text
             cp = Cipher.getInstance(CHACHA20_POLY1305_ALGORITHM, getProviderName());
@@ -953,8 +951,7 @@ public class BaseTestChaCha20Poly1305 extends BaseTestCipher implements ChaCha20
             System.arraycopy(plainText2, 0, plainText12, plainText1Len, plainText2.length);
 
             success = Arrays.equals(plainText12, PLAIN_TEXT);
-            assertTrue("Decrypted text does not match expected, msglen=" + PLAIN_TEXT.length,
-                    success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + PLAIN_TEXT.length);
 
         } catch (Exception e) {
             fail("Got unexpected exception on encrypt/decrypt...");

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20Poly1305ByteBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20Poly1305ByteBuffer.java
@@ -18,7 +18,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestChaCha20Poly1305ByteBuffer extends BaseTestJunit5 {
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20Poly1305ChunkUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20Poly1305ChunkUpdate.java
@@ -16,7 +16,7 @@ import javax.crypto.ShortBufferException;
 import javax.crypto.spec.IvParameterSpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestChaCha20Poly1305ChunkUpdate extends BaseTestCipher
         implements ChaCha20Constants {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDESede.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDESede.java
@@ -24,9 +24,9 @@ import javax.crypto.spec.RC2ParameterSpec;
 import javax.crypto.spec.RC5ParameterSpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestDESede extends BaseTestCipher {
 
@@ -1107,10 +1107,9 @@ public class BaseTestDESede extends BaseTestCipher {
             params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((blockSize > 0) && (message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((blockSize > 0) && (message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             // Verify the text
@@ -1121,19 +1120,18 @@ public class BaseTestDESede extends BaseTestCipher {
             byte[] newPlainText = cp.doFinal(cipherText);
 
             boolean success = Arrays.equals(newPlainText, message);
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
 
             // Verify the text again
             cp.init(Cipher.DECRYPT_MODE, key, params);
             byte[] newPlainText2 = cp.doFinal(cipherText, 0, cipherText.length);
 
             success = Arrays.equals(newPlainText2, message);
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 
@@ -1158,10 +1156,9 @@ public class BaseTestDESede extends BaseTestCipher {
             params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             // Verify the text
@@ -1181,12 +1178,11 @@ public class BaseTestDESede extends BaseTestCipher {
             System.arraycopy(newPlainText2, 0, newPlainText, l, newPlainText2.length);
 
             boolean success = Arrays.equals(newPlainText, message);
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 
@@ -1213,10 +1209,9 @@ public class BaseTestDESede extends BaseTestCipher {
             params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             // Verify the text
@@ -1236,13 +1231,11 @@ public class BaseTestDESede extends BaseTestCipher {
             System.arraycopy(newPlainText2, 0, newPlainText, l, newPlainText2.length);
 
             boolean success = Arrays.equals(newPlainText, message);
-            assertTrue("Decrypted text does not match expected, partial msglen=" + message.length,
-                    success);
+            assertTrue(success, "Decrypted text does not match expected, partial msglen=" + message.length);
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 
@@ -1270,17 +1263,16 @@ public class BaseTestDESede extends BaseTestCipher {
             params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((blockSize > 0) && (message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((blockSize > 0) && (message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             // Verify that the cipher object can be used to encrypt again
             // without re-init
             byte[] cipherText2 = cp.doFinal(message);
             boolean success = Arrays.equals(cipherText2, cipherText);
-            assertTrue("Re-encrypted text does not match", success);
+            assertTrue(success, "Re-encrypted text does not match");
 
             // Verify the text
             if (getProviderName().equals(encryptProviderName) == false) {
@@ -1289,18 +1281,17 @@ public class BaseTestDESede extends BaseTestCipher {
             cp.init(Cipher.DECRYPT_MODE, key, params);
             byte[] newPlainText = cp.doFinal(cipherText);
             success = Arrays.equals(newPlainText, message);
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
 
             // Verify that the cipher object can be used to decrypt again
             // without re-init
             byte[] newPlainText2 = cp.doFinal(cipherText, 0, cipherText.length);
             success = Arrays.equals(newPlainText2, newPlainText);
-            assertTrue("Re-decrypted text does not match", success);
+            assertTrue(success, "Re-decrypted text does not match");
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 
@@ -1332,14 +1323,13 @@ public class BaseTestDESede extends BaseTestCipher {
             params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((blockSize > 0) && (message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((blockSize > 0) && (message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             boolean success = Arrays.equals(cipherText, cipherText0);
-            assertTrue("Encrypted text does not match expected result", success);
+            assertTrue(success, "Encrypted text does not match expected result");
 
             // Verify the text
             if (getProviderName().equals(encryptProviderName) == false) {
@@ -1351,12 +1341,11 @@ public class BaseTestDESede extends BaseTestCipher {
             byte[] newPlainText = Arrays.copyOf(resultBuffer, resultLen);
 
             success = Arrays.equals(newPlainText, message);
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 
@@ -1393,14 +1382,13 @@ public class BaseTestDESede extends BaseTestCipher {
             params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((blockSize > 0) && (message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((blockSize > 0) && (message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             boolean success = Arrays.equals(cipherText, cipherText0);
-            assertTrue("Encrypted text does not match expected result", success);
+            assertTrue(success, "Encrypted text does not match expected result");
 
             // Verify the text
             if (getProviderName().equals(encryptProviderName) == false) {
@@ -1416,12 +1404,11 @@ public class BaseTestDESede extends BaseTestCipher {
             System.arraycopy(plainText2, 0, newPlainText, plainText1Len, plainText2.length);
 
             success = Arrays.equals(newPlainText, message);
-            assertTrue("Decrypted text does not match expected, msglen=" + message.length, success);
+            assertTrue(success, "Decrypted text does not match expected, msglen=" + message.length);
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDH.java
@@ -21,7 +21,7 @@ import javax.crypto.KeyAgreement;
 import javax.crypto.spec.DHParameterSpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestDH extends BaseTestJunit5 {
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDHInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDHInterop.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import javax.crypto.KeyAgreement;
 import javax.crypto.spec.DHParameterSpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestDHInterop extends BaseTestJunit5Interop {
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDHKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDHKeyPairGenerator.java
@@ -19,8 +19,8 @@ import javax.crypto.spec.DHParameterSpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import sun.security.util.KeyUtil;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestDHKeyPairGenerator extends BaseTestJunit5 {
@@ -317,12 +317,10 @@ public class BaseTestDHKeyPairGenerator extends BaseTestJunit5 {
         DHParameterSpec generatedDhPrivateKeyParams = ((DHKey) kp.getPrivate()).getParams();
 
         // if ((generated.getP().bitLength() != expKeySize) || (generated.getL() != expLSize))  original osb code used equality test not greater than or equal
-        assertTrue(
+        assertTrue(((generatedDhPrivateKeyParams.getP().bitLength() == expectedKeySize) &&
+                    (generatedDhPrivateKeyParams.getL() >= expectedMinimumPrivateKeyExponentBitLength)),
                 "Error: size check failed, got " + generatedDhPrivateKeyParams.getP().bitLength()
-                        + " and " + generatedDhPrivateKeyParams.getL(),
-                ((generatedDhPrivateKeyParams.getP().bitLength() == expectedKeySize)
-                        && (generatedDhPrivateKeyParams
-                                .getL() >= expectedMinimumPrivateKeyExponentBitLength)));
+                        + " and " + generatedDhPrivateKeyParams.getL());
 
         return generatedDhPrivateKeyParams;
     }
@@ -349,22 +347,19 @@ public class BaseTestDHKeyPairGenerator extends BaseTestJunit5 {
         BigInteger left = BigInteger.ONE;
         BigInteger right = p.subtract(BigInteger.ONE);
         BigInteger x = dhpr.getX();
-        assertFalse("Private exponent X outside range [2, p - 2]: x: " + x + " p: " + p,
-                ((x.compareTo(left) <= 0) || (x.compareTo(right) >= 0)));
+        assertFalse(((x.compareTo(left) <= 0) || (x.compareTo(right) >= 0)), "Private exponent X outside range [2, p - 2]: x: " + x + " p: " + p);
 
         BigInteger y = dhpu.getY();
-        assertFalse("Public exponent Y outside range [2, p - 2]: x: " + x + " p: " + p,
-                ((y.compareTo(left) <= 0) || (y.compareTo(right) >= 0)));
+        assertFalse(((y.compareTo(left) <= 0) || (y.compareTo(right) >= 0)), "Public exponent Y outside range [2, p - 2]: x: " + x + " p: " + p);
 
         //Exponent bit length does not have to be the exact same but private should be at least 1/2 of keysize
         //OpenJCEPlus will generate a private key with exponent bit length of keysize - 1
         @SuppressWarnings("restriction")
         int keysize = KeyUtil.getKeySize(dhpu);
         int minimumPrivateExponentBitLength = keysize - 1;
-        assertTrue(
+        assertTrue(dhpr.getParams().getL() >= minimumPrivateExponentBitLength,
                 "Minimum exponent bit length: " + minimumPrivateExponentBitLength + " not met by: "
-                        + dhpr.getParams().getL() + " for DH keysize: " + keysize,
-                dhpr.getParams().getL() >= minimumPrivateExponentBitLength);
+                        + dhpr.getParams().getL() + " for DH keysize: " + keysize);
 
         //the key parameter exponent length equality test was removed and replaced by the minimum exponent test above
         //        assertEquals("Invalid public key exponent bit length" , dhpu.getParams().getL(), dhpr.getParams().getL());

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDHMultiParty.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDHMultiParty.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
 import javax.crypto.KeyAgreement;
 import javax.crypto.spec.DHParameterSpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestDHMultiParty extends BaseTestJunit5 {
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDSAKey.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDSAKey.java
@@ -24,7 +24,7 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
 import java.util.Base64;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestDSAKey extends BaseTestJunit5 {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDSASignature.java
@@ -21,8 +21,8 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestDSASignature extends BaseTestJunit5Signature {
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDSASignatureInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDSASignatureInterop.java
@@ -21,8 +21,8 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestDSASignatureInterop extends BaseTestSignatureInterop {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDSASignatureInterop2.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDSASignatureInterop2.java
@@ -20,7 +20,7 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestDSASignatureInterop2 extends BaseTestSignatureInterop {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDH.java
@@ -28,9 +28,9 @@ import java.util.Arrays;
 import javax.crypto.KeyAgreement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestECDH extends BaseTestJunit5 {
 
@@ -283,8 +283,7 @@ public class BaseTestECDH extends BaseTestJunit5 {
 
         AlgorithmParameters algorithmParameters = AlgorithmParameters.getInstance("EC",
                 getProviderName());
-        assertNotNull("AlgorithmParameters EC not found in provider" + getProviderName(),
-                algorithmParameters);
+        assertNotNull(algorithmParameters, "AlgorithmParameters EC not found in provider" + getProviderName());
 
         AlgorithmParameterSpec algorithmParameterSpec = new ECGenParameterSpec(curveName);
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDHInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDHInterop.java
@@ -31,9 +31,9 @@ import java.util.Arrays;
 import javax.crypto.Cipher;
 import javax.crypto.KeyAgreement;
 import javax.crypto.spec.SecretKeySpec;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestECDHInterop extends BaseTestJunit5Interop {
 
@@ -44,7 +44,7 @@ public class BaseTestECDHInterop extends BaseTestJunit5Interop {
      *
      * @throws Exception
      */
-    @Ignore("Curve secp192k1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
+    @Disabled("Curve secp192k1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
     public void ignore_testECDH_secp192k1() throws Exception {
 
         String curveName = "secp192k1";
@@ -86,7 +86,7 @@ public class BaseTestECDHInterop extends BaseTestJunit5Interop {
 
     }
 
-    @Ignore("Curve secp256k1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
+    @Disabled("Curve secp256k1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
     public void ignore_testECDH_ECSpec() throws Exception {
         if (System.getProperty("os.name").equals("z/OS")) {
             System.out.println(

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDHMultiParty.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDHMultiParty.java
@@ -20,7 +20,7 @@ import java.security.spec.ECGenParameterSpec;
 import java.util.Arrays;
 import javax.crypto.KeyAgreement;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestECDHMultiParty extends BaseTestJunit5 {
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDSASignature.java
@@ -28,7 +28,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestECDSASignature extends BaseTestJunit5Signature {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDSASignatureInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDSASignatureInterop.java
@@ -13,15 +13,15 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.MessageDigest;
 import java.security.Signature;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestECDSASignatureInterop extends BaseTestSignatureInterop {
 
     static final byte[] origMsg = "this is the original message to be signed".getBytes();
 
-    @Ignore("Curve secp192r1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
+    @Disabled("Curve secp192r1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
     public void ignore_testSHA1withDSA_192() throws Exception {
         if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS does not support SHA-1 or P-192. So skip test
@@ -32,7 +32,7 @@ public class BaseTestECDSASignatureInterop extends BaseTestSignatureInterop {
     }
 
 
-    @Ignore("Curve secp224r1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
+    @Disabled("Curve secp224r1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
     public void ignore_testSHA1withDSA_224() throws Exception {
         if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS does not support SHA-1. So skip test
@@ -73,7 +73,7 @@ public class BaseTestECDSASignatureInterop extends BaseTestSignatureInterop {
     }
 
 
-    @Ignore("Curve secp192r1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
+    @Disabled("Curve secp192r1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
     public void ignore_testSHA224withECDSA_192() throws Exception {
         if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS does not support P-192. So skip test
@@ -84,7 +84,7 @@ public class BaseTestECDSASignatureInterop extends BaseTestSignatureInterop {
     }
 
 
-    @Ignore("Curve secp224r1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
+    @Disabled("Curve secp224r1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
     public void ignore_testSHA224withECDSA_224() throws Exception {
 
         KeyPair keyPair = generateKeyPair(224);
@@ -110,7 +110,7 @@ public class BaseTestECDSASignatureInterop extends BaseTestSignatureInterop {
     }
 
 
-    @Ignore("Curve secp192r1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
+    @Disabled("Curve secp192r1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
     public void ignore_testSHA256withECDSA_192() throws Exception {
 
         if (getProviderName().equals("OpenJCEPlusFIPS")) {
@@ -122,7 +122,7 @@ public class BaseTestECDSASignatureInterop extends BaseTestSignatureInterop {
     }
 
 
-    @Ignore("Curve secp224r1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
+    @Disabled("Curve secp224r1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
     public void ignore_testSHA256withECDSA_224() throws Exception {
 
         KeyPair keyPair = generateKeyPair(224);
@@ -148,7 +148,7 @@ public class BaseTestECDSASignatureInterop extends BaseTestSignatureInterop {
     }
 
 
-    @Ignore("Curve secp192r1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
+    @Disabled("Curve secp192r1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
     public void ignore_testDatawithECDSA_SHA1_192() throws Exception {
 
         if (getProviderName().equals("OpenJCEPlusFIPS")) {
@@ -164,7 +164,7 @@ public class BaseTestECDSASignatureInterop extends BaseTestSignatureInterop {
     }
 
 
-    @Ignore("Curve secp224r1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
+    @Disabled("Curve secp224r1 removed via https://bugs.openjdk.org/browse/JDK-8251547 in JDK16")
     public void ignore_testDatawithECDSA_SHA224_224() throws Exception {
         KeyPair keyPair = generateKeyPair(224);
         MessageDigest md = MessageDigest.getInstance("SHA-224", getProviderName());

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyImport.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyImport.java
@@ -24,7 +24,7 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestECKeyImport extends BaseTestJunit5 {
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyImportInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyImportInterop.java
@@ -24,7 +24,7 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestECKeyImportInterop extends BaseTestJunit5Interop {
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyPairGenerator.java
@@ -20,7 +20,7 @@ import java.security.spec.ECPoint;
 import java.security.spec.EllipticCurve;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestECKeyPairGenerator extends BaseTestJunit5 {
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestEdDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestEdDSASignature.java
@@ -29,7 +29,7 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestEdDSASignature extends BaseTestJunit5Signature {
 
@@ -267,7 +267,7 @@ public class BaseTestEdDSASignature extends BaseTestJunit5Signature {
         sig.initVerify(pubKey);
         sig.update(msgBytes);
 
-        assertTrue("Signature verification failed", sig.verify(computedSig));
+        assertTrue(sig.verify(computedSig), "Signature verification failed");
     }
 
     @Test
@@ -357,7 +357,7 @@ public class BaseTestEdDSASignature extends BaseTestJunit5Signature {
         msgSig = sig.sign();
         sig.initVerify(pubKey2);
         sig.update(testMessage);
-        assertTrue("Signature verification failed", sig.verify(msgSig));
+        assertTrue(sig.verify(msgSig), "Signature verification failed");
     }
 
     /*
@@ -527,7 +527,7 @@ public class BaseTestEdDSASignature extends BaseTestJunit5Signature {
         Signature verifying = Signature.getInstance(sigAlgo, getProviderName());
         verifying.initVerify(publicKey);
         verifying.update(message);
-        assertTrue("Signature verification failed", verifying.verify(signedBytes));
+        assertTrue(verifying.verify(signedBytes), "Signature verification failed");
     }
 
     private void reverseByteArray(byte[] arr) throws IOException {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestEdDSASignatureInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestEdDSASignatureInterop.java
@@ -25,7 +25,7 @@ import org.bouncycastle.crypto.params.Ed448PublicKeyParameters;
 import org.bouncycastle.crypto.signers.Ed25519Signer;
 import org.bouncycastle.crypto.signers.Ed448Signer;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestEdDSASignatureInterop extends BaseTestJunit5Signature {
 
@@ -79,7 +79,7 @@ public class BaseTestEdDSASignatureInterop extends BaseTestJunit5Signature {
         Signer signer = new Ed25519Signer();
         signer.init(false, publicKeyBC);
         signer.update(message, 0, message.length);
-        assertTrue("Signature verification failed ", signer.verifySignature(signedBytes));
+        assertTrue(signer.verifySignature(signedBytes), "Signature verification failed ");
     }
 
 
@@ -99,7 +99,7 @@ public class BaseTestEdDSASignatureInterop extends BaseTestJunit5Signature {
         Signer signer = new Ed448Signer(new byte[0]);
         signer.init(false, publicKeyBC);
         signer.update(message, 0, message.length);
-        assertTrue("Signature verification failed ", signer.verifySignature(signedBytes));
+        assertTrue(signer.verifySignature(signedBytes), "Signature verification failed ");
     }
 
     private static void reverseByteArray(byte[] arr) throws IOException {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHKDF.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHKDF.java
@@ -33,7 +33,7 @@ import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHKDF extends BaseTestJunit5 {
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHKDFInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHKDFInterop.java
@@ -33,7 +33,7 @@ import org.bouncycastle.crypto.digests.SHA256Digest;
 import org.bouncycastle.crypto.generators.HKDFBytesGenerator;
 import org.bouncycastle.crypto.params.HKDFParameters;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHKDFInterop extends BaseTestJunit5Interop {
     String HKDF_KA[][] = {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacMD5.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacMD5.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHmacMD5 extends BaseTestJunit5 {
     final byte[] key_1 = {(byte) 0x0b, (byte) 0x0b, (byte) 0x0b, (byte) 0x0b, (byte) 0x0b,
@@ -166,7 +166,7 @@ public class BaseTestHmacMD5 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
 
     }
 
@@ -178,7 +178,7 @@ public class BaseTestHmacMD5 extends BaseTestJunit5 {
         mac.update(data_2);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_2));
+        assertTrue(Arrays.equals(digest, digest_2), "Mac digest did not equal expected");
 
     }
 
@@ -191,7 +191,7 @@ public class BaseTestHmacMD5 extends BaseTestJunit5 {
         mac.update(data_3);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_3));
+        assertTrue(Arrays.equals(digest, digest_3), "Mac digest did not equal expected");
 
     }
 
@@ -204,7 +204,7 @@ public class BaseTestHmacMD5 extends BaseTestJunit5 {
         mac.update(data_4);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_4));
+        assertTrue(Arrays.equals(digest, digest_4), "Mac digest did not equal expected");
 
     }
 
@@ -217,7 +217,7 @@ public class BaseTestHmacMD5 extends BaseTestJunit5 {
         mac.update(data_5);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_5));
+        assertTrue(Arrays.equals(digest, digest_5), "Mac digest did not equal expected");
 
     }
 
@@ -230,7 +230,7 @@ public class BaseTestHmacMD5 extends BaseTestJunit5 {
         mac.update(data_6);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_6));
+        assertTrue(Arrays.equals(digest, digest_6), "Mac digest did not equal expected");
 
     }
 
@@ -243,7 +243,7 @@ public class BaseTestHmacMD5 extends BaseTestJunit5 {
         mac.update(data_7);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_7));
+        assertTrue(Arrays.equals(digest, digest_7), "Mac digest did not equal expected");
 
     }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacMD5Interop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacMD5Interop.java
@@ -13,7 +13,7 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHmacMD5Interop extends BaseTestJunit5Interop {
     final byte[] key_1 = {(byte) 0x0b, (byte) 0x0b, (byte) 0x0b, (byte) 0x0b, (byte) 0x0b,
@@ -244,7 +244,7 @@ public class BaseTestHmacMD5Interop extends BaseTestJunit5Interop {
         mac2.update(data);
         byte[] digest2 = mac2.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest2));
+        assertTrue(Arrays.equals(digest, digest2), "Mac digest did not equal expected");
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA1.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA1.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHmacSHA1 extends BaseTestJunit5 {
 
@@ -187,7 +187,7 @@ public class BaseTestHmacSHA1 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -198,7 +198,7 @@ public class BaseTestHmacSHA1 extends BaseTestJunit5 {
         mac.update(data_2);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_2));
+        assertTrue(Arrays.equals(digest, digest_2), "Mac digest did not equal expected");
     }
 
     @Test
@@ -209,7 +209,7 @@ public class BaseTestHmacSHA1 extends BaseTestJunit5 {
         mac.update(data_3);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_3));
+        assertTrue(Arrays.equals(digest, digest_3), "Mac digest did not equal expected");
     }
 
     @Test
@@ -220,7 +220,7 @@ public class BaseTestHmacSHA1 extends BaseTestJunit5 {
         mac.update(data_4);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_4));
+        assertTrue(Arrays.equals(digest, digest_4), "Mac digest did not equal expected");
     }
 
     @Test
@@ -231,7 +231,7 @@ public class BaseTestHmacSHA1 extends BaseTestJunit5 {
         mac.update(data_5);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_5));
+        assertTrue(Arrays.equals(digest, digest_5), "Mac digest did not equal expected");
     }
 
     @Test
@@ -242,7 +242,7 @@ public class BaseTestHmacSHA1 extends BaseTestJunit5 {
         mac.update(data_6);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_6));
+        assertTrue(Arrays.equals(digest, digest_6), "Mac digest did not equal expected");
     }
 
     @Test
@@ -253,7 +253,7 @@ public class BaseTestHmacSHA1 extends BaseTestJunit5 {
         mac.update(data_7);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_7));
+        assertTrue(Arrays.equals(digest, digest_7), "Mac digest did not equal expected");
     }
 
     @Test
@@ -266,7 +266,7 @@ public class BaseTestHmacSHA1 extends BaseTestJunit5 {
         mac.update(data_4);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_4));
+        assertTrue(Arrays.equals(digest, digest_4), "Mac digest did not equal expected");
     }
 
     @Test
@@ -277,12 +277,12 @@ public class BaseTestHmacSHA1 extends BaseTestJunit5 {
         mac.update(data_4);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_4));
+        assertTrue(Arrays.equals(digest, digest_4), "Mac digest did not equal expected");
 
         mac.update(data_4);
         byte[] digest2 = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest2, digest_4));
+        assertTrue(Arrays.equals(digest2, digest_4), "Mac digest did not equal expected");
     }
 
     @Test
@@ -290,7 +290,7 @@ public class BaseTestHmacSHA1 extends BaseTestJunit5 {
         Mac mac = Mac.getInstance("HmacSHA1", getProviderName());
         int macLength = mac.getMacLength();
         boolean isExpectedValue = (macLength == 20);
-        assertTrue("Unexpected mac length", isExpectedValue);
+        assertTrue(isExpectedValue, "Unexpected mac length");
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA1Interop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA1Interop.java
@@ -13,7 +13,7 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHmacSHA1Interop extends BaseTestJunit5Interop {
 
@@ -265,7 +265,7 @@ public class BaseTestHmacSHA1Interop extends BaseTestJunit5Interop {
         mac2.update(data);
         byte[] digest2 = mac2.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest2));
+        assertTrue(Arrays.equals(digest, digest2), "Mac digest did not equal expected");
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA224.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA224.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHmacSHA224 extends BaseTestJunit5 {
 
@@ -104,7 +104,7 @@ public class BaseTestHmacSHA224 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -115,7 +115,7 @@ public class BaseTestHmacSHA224 extends BaseTestJunit5 {
         mac.update(data_2);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_2));
+        assertTrue(Arrays.equals(digest, digest_2), "Mac digest did not equal expected");
     }
 
     @Test
@@ -126,7 +126,7 @@ public class BaseTestHmacSHA224 extends BaseTestJunit5 {
         mac.update(data_3);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_3));
+        assertTrue(Arrays.equals(digest, digest_3), "Mac digest did not equal expected");
     }
 
     @Test
@@ -140,7 +140,7 @@ public class BaseTestHmacSHA224 extends BaseTestJunit5 {
         int taglen = 16;
         byte[] truncatedDigest = new byte[taglen];
         System.arraycopy(digest, 0, truncatedDigest, 0, taglen);
-        assertTrue("Mac digest did not equal expected", Arrays.equals(truncatedDigest, digest_4));
+        assertTrue(Arrays.equals(truncatedDigest, digest_4), "Mac digest did not equal expected");
     }
 
     @Test
@@ -153,7 +153,7 @@ public class BaseTestHmacSHA224 extends BaseTestJunit5 {
         mac.update(data_3);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_3));
+        assertTrue(Arrays.equals(digest, digest_3), "Mac digest did not equal expected");
     }
 
     @Test
@@ -164,12 +164,12 @@ public class BaseTestHmacSHA224 extends BaseTestJunit5 {
         mac.update(data_3);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_3));
+        assertTrue(Arrays.equals(digest, digest_3), "Mac digest did not equal expected");
 
         mac.update(data_3);
         byte[] digest2 = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest2, digest_3));
+        assertTrue(Arrays.equals(digest2, digest_3), "Mac digest did not equal expected");
     }
 
     @Test
@@ -177,7 +177,7 @@ public class BaseTestHmacSHA224 extends BaseTestJunit5 {
         Mac mac = Mac.getInstance("HmacSHA224", getProviderName());
         int macLength = mac.getMacLength();
         boolean isExpectedValue = (macLength == 28);
-        assertTrue("Unexpected mac length", isExpectedValue);
+        assertTrue(isExpectedValue, "Unexpected mac length");
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA224Interop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA224Interop.java
@@ -13,7 +13,7 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHmacSHA224Interop extends BaseTestJunit5Interop {
 
@@ -157,7 +157,7 @@ public class BaseTestHmacSHA224Interop extends BaseTestJunit5Interop {
         mac2.update(data);
         byte[] digest2 = mac2.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest2));
+        assertTrue(Arrays.equals(digest, digest2), "Mac digest did not equal expected");
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA256.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA256.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHmacSHA256 extends BaseTestJunit5 {
 
@@ -277,7 +277,7 @@ public class BaseTestHmacSHA256 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -288,7 +288,7 @@ public class BaseTestHmacSHA256 extends BaseTestJunit5 {
         mac.update(data_2);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_2));
+        assertTrue(Arrays.equals(digest, digest_2), "Mac digest did not equal expected");
     }
 
     @Test
@@ -299,7 +299,7 @@ public class BaseTestHmacSHA256 extends BaseTestJunit5 {
         mac.update(data_3);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_3));
+        assertTrue(Arrays.equals(digest, digest_3), "Mac digest did not equal expected");
     }
 
     @Test
@@ -310,7 +310,7 @@ public class BaseTestHmacSHA256 extends BaseTestJunit5 {
         mac.update(data_4);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_4));
+        assertTrue(Arrays.equals(digest, digest_4), "Mac digest did not equal expected");
     }
 
     @Test
@@ -321,7 +321,7 @@ public class BaseTestHmacSHA256 extends BaseTestJunit5 {
         mac.update(data_5);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_5));
+        assertTrue(Arrays.equals(digest, digest_5), "Mac digest did not equal expected");
     }
 
     @Test
@@ -332,7 +332,7 @@ public class BaseTestHmacSHA256 extends BaseTestJunit5 {
         mac.update(data_6);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_6));
+        assertTrue(Arrays.equals(digest, digest_6), "Mac digest did not equal expected");
     }
 
     @Test
@@ -343,7 +343,7 @@ public class BaseTestHmacSHA256 extends BaseTestJunit5 {
         mac.update(data_7);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_7));
+        assertTrue(Arrays.equals(digest, digest_7), "Mac digest did not equal expected");
     }
 
     @Test
@@ -354,7 +354,7 @@ public class BaseTestHmacSHA256 extends BaseTestJunit5 {
         mac.update(data_8);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_8));
+        assertTrue(Arrays.equals(digest, digest_8), "Mac digest did not equal expected");
     }
 
     @Test
@@ -365,7 +365,7 @@ public class BaseTestHmacSHA256 extends BaseTestJunit5 {
         mac.update(data_9);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_9));
+        assertTrue(Arrays.equals(digest, digest_9), "Mac digest did not equal expected");
     }
 
     @Test
@@ -376,7 +376,7 @@ public class BaseTestHmacSHA256 extends BaseTestJunit5 {
         mac.update(data_10);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_10));
+        assertTrue(Arrays.equals(digest, digest_10), "Mac digest did not equal expected");
     }
 
     @Test
@@ -389,7 +389,7 @@ public class BaseTestHmacSHA256 extends BaseTestJunit5 {
         mac.update(data_4);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_4));
+        assertTrue(Arrays.equals(digest, digest_4), "Mac digest did not equal expected");
     }
 
     @Test
@@ -400,12 +400,12 @@ public class BaseTestHmacSHA256 extends BaseTestJunit5 {
         mac.update(data_4);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_4));
+        assertTrue(Arrays.equals(digest, digest_4), "Mac digest did not equal expected");
 
         mac.update(data_4);
         byte[] digest2 = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest2, digest_4));
+        assertTrue(Arrays.equals(digest2, digest_4), "Mac digest did not equal expected");
     }
 
     @Test
@@ -413,7 +413,7 @@ public class BaseTestHmacSHA256 extends BaseTestJunit5 {
         Mac mac = Mac.getInstance("HmacSHA256", getProviderName());
         int macLength = mac.getMacLength();
         boolean isExpectedValue = (macLength == 32);
-        assertTrue("Unexpected mac length", isExpectedValue);
+        assertTrue(isExpectedValue, "Unexpected mac length");
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA256Interop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA256Interop.java
@@ -13,7 +13,7 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHmacSHA256Interop extends BaseTestJunit5Interop {
     // test vectors from http://www.ietf.org/proceedings/02jul/I-D/draft-ietf-ipsec-ciph-sha-256-01.txt
@@ -372,7 +372,7 @@ public class BaseTestHmacSHA256Interop extends BaseTestJunit5Interop {
         mac2.update(data);
         byte[] digest2 = mac2.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest2));
+        assertTrue(Arrays.equals(digest, digest2), "Mac digest did not equal expected");
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA384.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA384.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHmacSHA384 extends BaseTestJunit5 {
     // test vectors from http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/HMAC_SHA384.pdf
@@ -76,7 +76,7 @@ public class BaseTestHmacSHA384 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -87,7 +87,7 @@ public class BaseTestHmacSHA384 extends BaseTestJunit5 {
         mac.update(data_2);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_2));
+        assertTrue(Arrays.equals(digest, digest_2), "Mac digest did not equal expected");
     }
 
     @Test
@@ -98,7 +98,7 @@ public class BaseTestHmacSHA384 extends BaseTestJunit5 {
         mac.update(data_3);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_3));
+        assertTrue(Arrays.equals(digest, digest_3), "Mac digest did not equal expected");
     }
 
     @Test
@@ -113,7 +113,7 @@ public class BaseTestHmacSHA384 extends BaseTestJunit5 {
         byte[] truncatedDigest = new byte[taglen];
         System.arraycopy(digest, 0, truncatedDigest, 0, taglen);
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(truncatedDigest, digest_4));
+        assertTrue(Arrays.equals(truncatedDigest, digest_4), "Mac digest did not equal expected");
     }
 
     @Test
@@ -126,7 +126,7 @@ public class BaseTestHmacSHA384 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -137,12 +137,12 @@ public class BaseTestHmacSHA384 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
 
         mac.update(data_1);
         byte[] digest2 = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest2, digest_1));
+        assertTrue(Arrays.equals(digest2, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -150,7 +150,7 @@ public class BaseTestHmacSHA384 extends BaseTestJunit5 {
         Mac mac = Mac.getInstance("HmacSHA384", getProviderName());
         int macLength = mac.getMacLength();
         boolean isExpectedValue = (macLength == 48);
-        assertTrue("Unexpected mac length", isExpectedValue);
+        assertTrue(isExpectedValue, "Unexpected mac length");
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA384Interop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA384Interop.java
@@ -13,7 +13,7 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHmacSHA384Interop extends BaseTestJunit5Interop {
     // test vectors from http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/HMAC_SHA384.pdf
@@ -135,7 +135,7 @@ public class BaseTestHmacSHA384Interop extends BaseTestJunit5Interop {
         mac2.update(data);
         byte[] digest2 = mac2.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest2));
+        assertTrue(Arrays.equals(digest, digest2), "Mac digest did not equal expected");
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA3_224.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA3_224.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHmacSHA3_224 extends BaseTestJunit5 {
 
@@ -77,7 +77,7 @@ public class BaseTestHmacSHA3_224 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -88,7 +88,7 @@ public class BaseTestHmacSHA3_224 extends BaseTestJunit5 {
         mac.update(data_2);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_2));
+        assertTrue(Arrays.equals(digest, digest_2), "Mac digest did not equal expected");
     }
 
     @Test
@@ -99,7 +99,7 @@ public class BaseTestHmacSHA3_224 extends BaseTestJunit5 {
         mac.update(data_3);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_3));
+        assertTrue(Arrays.equals(digest, digest_3), "Mac digest did not equal expected");
     }
 
     @Test
@@ -112,7 +112,7 @@ public class BaseTestHmacSHA3_224 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -123,12 +123,12 @@ public class BaseTestHmacSHA3_224 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
 
         mac.update(data_1);
         byte[] digest2 = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest2, digest_1));
+        assertTrue(Arrays.equals(digest2, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -136,7 +136,7 @@ public class BaseTestHmacSHA3_224 extends BaseTestJunit5 {
         Mac mac = Mac.getInstance("HmacSHA3-224", getProviderName());
         int macLength = mac.getMacLength();
         boolean isExpectedValue = (macLength == 28);
-        assertTrue("Unexpected mac length", isExpectedValue);
+        assertTrue(isExpectedValue, "Unexpected mac length");
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA3_256.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA3_256.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHmacSHA3_256 extends BaseTestJunit5 {
 
@@ -77,7 +77,7 @@ public class BaseTestHmacSHA3_256 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -88,7 +88,7 @@ public class BaseTestHmacSHA3_256 extends BaseTestJunit5 {
         mac.update(data_2);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_2));
+        assertTrue(Arrays.equals(digest, digest_2), "Mac digest did not equal expected");
     }
 
     @Test
@@ -99,7 +99,7 @@ public class BaseTestHmacSHA3_256 extends BaseTestJunit5 {
         mac.update(data_3);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_3));
+        assertTrue(Arrays.equals(digest, digest_3), "Mac digest did not equal expected");
     }
 
     @Test
@@ -112,7 +112,7 @@ public class BaseTestHmacSHA3_256 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -123,12 +123,12 @@ public class BaseTestHmacSHA3_256 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
 
         mac.update(data_1);
         byte[] digest2 = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest2, digest_1));
+        assertTrue(Arrays.equals(digest2, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -136,7 +136,7 @@ public class BaseTestHmacSHA3_256 extends BaseTestJunit5 {
         Mac mac = Mac.getInstance("HmacSHA3-256", getProviderName());
         int macLength = mac.getMacLength();
         boolean isExpectedValue = (macLength == 32);
-        assertTrue("Unexpected mac length", isExpectedValue);
+        assertTrue(isExpectedValue, "Unexpected mac length");
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA3_384.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA3_384.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHmacSHA3_384 extends BaseTestJunit5 {
 
@@ -77,7 +77,7 @@ public class BaseTestHmacSHA3_384 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -88,7 +88,7 @@ public class BaseTestHmacSHA3_384 extends BaseTestJunit5 {
         mac.update(data_2);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_2));
+        assertTrue(Arrays.equals(digest, digest_2), "Mac digest did not equal expected");
     }
 
     @Test
@@ -99,7 +99,7 @@ public class BaseTestHmacSHA3_384 extends BaseTestJunit5 {
         mac.update(data_3);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_3));
+        assertTrue(Arrays.equals(digest, digest_3), "Mac digest did not equal expected");
     }
 
     @Test
@@ -112,7 +112,7 @@ public class BaseTestHmacSHA3_384 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -123,12 +123,12 @@ public class BaseTestHmacSHA3_384 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
 
         mac.update(data_1);
         byte[] digest2 = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest2, digest_1));
+        assertTrue(Arrays.equals(digest2, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -136,7 +136,7 @@ public class BaseTestHmacSHA3_384 extends BaseTestJunit5 {
         Mac mac = Mac.getInstance("HmacSHA3-384", getProviderName());
         int macLength = mac.getMacLength();
         boolean isExpectedValue = (macLength == 48);
-        assertTrue("Unexpected mac length", isExpectedValue);
+        assertTrue(isExpectedValue, "Unexpected mac length");
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA3_512.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA3_512.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHmacSHA3_512 extends BaseTestJunit5 {
 
@@ -79,7 +79,7 @@ public class BaseTestHmacSHA3_512 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -90,7 +90,7 @@ public class BaseTestHmacSHA3_512 extends BaseTestJunit5 {
         mac.update(data_2);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_2));
+        assertTrue(Arrays.equals(digest, digest_2), "Mac digest did not equal expected");
     }
 
     @Test
@@ -101,7 +101,7 @@ public class BaseTestHmacSHA3_512 extends BaseTestJunit5 {
         mac.update(data_3);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_3));
+        assertTrue(Arrays.equals(digest, digest_3), "Mac digest did not equal expected");
     }
 
     @Test
@@ -114,7 +114,7 @@ public class BaseTestHmacSHA3_512 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -125,12 +125,12 @@ public class BaseTestHmacSHA3_512 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
 
         mac.update(data_1);
         byte[] digest2 = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest2, digest_1));
+        assertTrue(Arrays.equals(digest2, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -138,7 +138,7 @@ public class BaseTestHmacSHA3_512 extends BaseTestJunit5 {
         Mac mac = Mac.getInstance("HmacSHA3-512", getProviderName());
         int macLength = mac.getMacLength();
         boolean isExpectedValue = (macLength == 64);
-        assertTrue("Unexpected mac length", isExpectedValue);
+        assertTrue(isExpectedValue, "Unexpected mac length");
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA512.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA512.java
@@ -13,7 +13,7 @@ import java.util.Arrays;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHmacSHA512 extends BaseTestJunit5 {
     // test vectors from http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/HMAC_SHA512.pdf
@@ -77,7 +77,7 @@ public class BaseTestHmacSHA512 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -88,7 +88,7 @@ public class BaseTestHmacSHA512 extends BaseTestJunit5 {
         mac.update(data_2);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_2));
+        assertTrue(Arrays.equals(digest, digest_2), "Mac digest did not equal expected");
     }
 
     @Test
@@ -99,7 +99,7 @@ public class BaseTestHmacSHA512 extends BaseTestJunit5 {
         mac.update(data_3);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_3));
+        assertTrue(Arrays.equals(digest, digest_3), "Mac digest did not equal expected");
     }
 
     @Test
@@ -114,7 +114,7 @@ public class BaseTestHmacSHA512 extends BaseTestJunit5 {
         byte[] truncatedDigest = new byte[taglen];
         System.arraycopy(digest, 0, truncatedDigest, 0, taglen);
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(truncatedDigest, digest_4));
+        assertTrue(Arrays.equals(truncatedDigest, digest_4), "Mac digest did not equal expected");
     }
 
     @Test
@@ -127,7 +127,7 @@ public class BaseTestHmacSHA512 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -138,12 +138,12 @@ public class BaseTestHmacSHA512 extends BaseTestJunit5 {
         mac.update(data_1);
         byte[] digest = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+        assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
 
         mac.update(data_1);
         byte[] digest2 = mac.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest2, digest_1));
+        assertTrue(Arrays.equals(digest2, digest_1), "Mac digest did not equal expected");
     }
 
     @Test
@@ -151,7 +151,7 @@ public class BaseTestHmacSHA512 extends BaseTestJunit5 {
         Mac mac = Mac.getInstance("HmacSHA512", getProviderName());
         int macLength = mac.getMacLength();
         boolean isExpectedValue = (macLength == 64);
-        assertTrue("Unexpected mac length", isExpectedValue);
+        assertTrue(isExpectedValue, "Unexpected mac length");
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA512Interop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA512Interop.java
@@ -14,7 +14,7 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHmacSHA512Interop extends BaseTestJunit5Interop {
 
@@ -137,7 +137,7 @@ public class BaseTestHmacSHA512Interop extends BaseTestJunit5Interop {
         mac2.update(data);
         byte[] digest2 = mac2.doFinal();
 
-        assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest2));
+        assertTrue(Arrays.equals(digest, digest2), "Mac digest did not equal expected");
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestImplementationClassesExist.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestImplementationClassesExist.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.Vector;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestImplementationClassesExist extends BaseTestJunit5 {
 
@@ -47,7 +47,6 @@ public class BaseTestImplementationClassesExist extends BaseTestJunit5 {
             }
         }
 
-        assertTrue("Missing implementation classes for " + missingClassNames.toString(),
-                (missingClassNames.size() == 0));
+        assertTrue((missingClassNames.size() == 0), "Missing implementation classes for " + missingClassNames.toString());
     }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestImplementationClassesFinal.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestImplementationClassesFinal.java
@@ -16,7 +16,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.Vector;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestImplementationClassesFinal extends BaseTestJunit5 {
 
@@ -50,7 +50,6 @@ public class BaseTestImplementationClassesFinal extends BaseTestJunit5 {
             }
         }
 
-        assertTrue("Non-final implementation classes for " + nonFinalClassNames.toString(),
-                (nonFinalClassNames.size() == 0));
+        assertTrue((nonFinalClassNames.size() == 0), "Non-final implementation classes for " + nonFinalClassNames.toString());
     }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestInvalidArrayIndex.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestInvalidArrayIndex.java
@@ -16,7 +16,7 @@ import javax.crypto.spec.RC2ParameterSpec;
 import javax.crypto.spec.RC5ParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestInvalidArrayIndex extends BaseTestJunit5 {
 
@@ -55,11 +55,10 @@ public class BaseTestInvalidArrayIndex extends BaseTestJunit5 {
                     Integer.MAX_VALUE - 1, "");
             System.out
                     .println("Test Passed for IVParameterSpec, GCMParameterSpec and SecretKeySpec");
-            assertTrue("Spec Tests passed for IVParamerSpec, GCMParameterSpec and SecretKeySpec",
-                    true);
+            assertTrue(true, "Spec Tests passed for IVParamerSpec, GCMParameterSpec and SecretKeySpec");
         } catch (Exception ex) {
-            assertTrue("Spec Tests failed for IVParamerSpec, GCMParameterSpec and SecretKeySpec "
-                    + ex.getMessage(), false);
+            assertTrue(false, "Spec Tests failed for IVParamerSpec, GCMParameterSpec and SecretKeySpec "
+                    + ex.getMessage());
         }
     }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestJunit5Signature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestJunit5Signature.java
@@ -11,7 +11,7 @@ package ibm.jceplus.junit.base;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestJunit5Signature extends BaseTestJunit5 {
 
@@ -26,6 +26,6 @@ public class BaseTestJunit5Signature extends BaseTestJunit5 {
         verifying.initVerify(publicKey);
         verifying.update(message);
 
-        assertTrue("Signature verification failed", verifying.verify(signedBytes));
+        assertTrue(verifying.verify(signedBytes), "Signature verification failed");
     }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestMD5.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestMD5.java
@@ -11,7 +11,7 @@ package ibm.jceplus.junit.base;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestMD5 extends BaseTestMessageDigestClone {
 
@@ -126,7 +126,7 @@ public class BaseTestMD5 extends BaseTestMessageDigestClone {
         md.update(array3);
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(result, md5result));
+        assertTrue(Arrays.equals(result, md5result), "Digest did not match expected");
 
     }
 
@@ -136,7 +136,7 @@ public class BaseTestMD5 extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(result, md5_A));
+        assertTrue(Arrays.equals(result, md5_A), "Digest did not match expected");
 
     }
 
@@ -147,7 +147,7 @@ public class BaseTestMD5 extends BaseTestMessageDigestClone {
         md.update(md5_B_input);
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(result, md5_B));
+        assertTrue(Arrays.equals(result, md5_B), "Digest did not match expected");
 
     }
 
@@ -158,7 +158,7 @@ public class BaseTestMD5 extends BaseTestMessageDigestClone {
         md.update(md5_C_input);
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(result, md5_C));
+        assertTrue(Arrays.equals(result, md5_C), "Digest did not match expected");
 
     }
 
@@ -169,7 +169,7 @@ public class BaseTestMD5 extends BaseTestMessageDigestClone {
         md.update(md5_D_input);
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(result, md5_D));
+        assertTrue(Arrays.equals(result, md5_D), "Digest did not match expected");
 
     }
 
@@ -180,7 +180,7 @@ public class BaseTestMD5 extends BaseTestMessageDigestClone {
         md.update(md5_E_input);
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(result, md5_E));
+        assertTrue(Arrays.equals(result, md5_E), "Digest did not match expected");
 
     }
 
@@ -191,7 +191,7 @@ public class BaseTestMD5 extends BaseTestMessageDigestClone {
         md.update(md5_F_input);
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(result, md5_F));
+        assertTrue(Arrays.equals(result, md5_F), "Digest did not match expected");
 
     }
 
@@ -202,7 +202,7 @@ public class BaseTestMD5 extends BaseTestMessageDigestClone {
         md.update(md5_G_input);
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(result, md5_G));
+        assertTrue(Arrays.equals(result, md5_G), "Digest did not match expected");
 
     }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestMessageDigestClone.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestMessageDigestClone.java
@@ -11,8 +11,8 @@ package ibm.jceplus.junit.base;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 abstract public class BaseTestMessageDigestClone extends BaseTestJunit5 {
 
@@ -57,7 +57,7 @@ abstract public class BaseTestMessageDigestClone extends BaseTestJunit5 {
         byte[] digest1 = md.digest(input_2);
         byte[] digest2 = mdCopy.digest(input_3);
 
-        assertFalse("Digest of original matches clone's digest when it shouldn't", Arrays.equals(digest1, digest2));
+        assertFalse(Arrays.equals(digest1, digest2), "Digest of original matches clone's digest when it shouldn't");
     }
 
     @Test
@@ -81,6 +81,6 @@ abstract public class BaseTestMessageDigestClone extends BaseTestJunit5 {
         byte[] digest1 = md.digest(input_2);
         byte[] digest2 = mdCopy.digest(input_3);
 
-        assertFalse("Digest of original matches clone's digest when it shouldn't", Arrays.equals(digest1, digest2));
+        assertFalse(Arrays.equals(digest1, digest2), "Digest of original matches clone's digest when it shouldn't");
     }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestMiniRSAPSS2.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestMiniRSAPSS2.java
@@ -17,9 +17,11 @@ import java.security.Signature;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
 
@@ -247,14 +249,14 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
 
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                        Assert.assertTrue("signature is invalid!!", result);
+                        assertTrue(result, "signature is invalid!!");
 
 
                     } catch (Exception ex) {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                         ex.printStackTrace();
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -323,13 +325,13 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
 
                     System.out.println(
                             "testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (Exception ex) {
                     System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -396,13 +398,13 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
 
                     System.out.println(
                             "testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (Exception ex) {
                     System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -474,7 +476,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                     System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => An unexpected exception was thrown with message = "
                             + ex.getMessage());
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
 
@@ -549,7 +551,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                     System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => An unexpected exception was thrown with message = "
                             + ex.getMessage());
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
 
@@ -622,7 +624,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
 
                     System.out.println(
                             "testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -634,7 +636,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => An unexpected exception was thrown with message = "
                                 + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -702,7 +704,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
 
                     System.out.println(
                             "testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -714,7 +716,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => An unexpected exception was thrown with message = "
                                 + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -783,7 +785,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
 
                     System.out.println(
                             "testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -795,7 +797,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => An unexpected exception was thrown with message = "
                                 + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -864,7 +866,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
 
                     System.out.println(
                             "testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -876,7 +878,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => An unexpected exception was thrown with message = "
                                 + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -945,7 +947,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
 
                     System.out.println(
                             "testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -957,7 +959,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => An unexpected exception was thrown with message = "
                                 + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1034,7 +1036,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
 
                     System.out.println(
                             "testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1046,7 +1048,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => An unexpected exception was thrown with message = "
                                 + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1113,7 +1115,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
 
                     System.out.println(
                             "testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1125,7 +1127,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => An unexpected exception was thrown with message = "
                                 + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1193,7 +1195,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
 
                     System.out.println(
                             "testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1205,7 +1207,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => An unexpected exception was thrown with message = "
                                 + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1274,7 +1276,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
 
                     System.out.println(
                             "testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1286,7 +1288,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => An unexpected exception was thrown with message = "
                                 + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1354,7 +1356,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
 
                     System.out.println(
                             "testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1366,7 +1368,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => An unexpected exception was thrown with message = "
                                 + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1444,13 +1446,13 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
 
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                        Assert.assertTrue("signature is invalid!!", result);
+                        assertTrue(result, "signature is invalid!!");
 
                     } catch (Exception ex) {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                         ex.printStackTrace();
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1523,7 +1525,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                     System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => An unexpected exception was thrown with message = "
                             + ex.getMessage());
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
 
@@ -1596,7 +1598,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                     System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => An unexpected exception was thrown with message = "
                             + ex.getMessage());
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
 
@@ -1670,7 +1672,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                     System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => An unexpected exception was thrown with message = "
                             + ex.getMessage());
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -1744,7 +1746,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                             + " => An unexpected exception was thrown with message = "
                             + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -1819,15 +1821,15 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
 
                     System.out.println(
                             "testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (InvalidAlgorithmParameterException ex) {
-                    Assert.assertTrue(true);
+                    assertTrue(true);
                 } catch (Exception ex) {
                     System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -1895,15 +1897,15 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
 
                     System.out.println(
                             "testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (InvalidAlgorithmParameterException ex) {
-                    Assert.assertTrue(true);
+                    assertTrue(true);
                 } catch (Exception ex) {
                     System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -1971,15 +1973,15 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
 
                     System.out.println(
                             "testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (InvalidAlgorithmParameterException ex) {
-                    Assert.assertTrue(true);
+                    assertTrue(true);
                 } catch (Exception ex) {
                     System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -2050,12 +2052,12 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                             "testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " = " + result);
 
                 } catch (InvalidAlgorithmParameterException ex) {
-                    Assert.assertTrue(true);
+                    assertTrue(true);
                 } catch (InvalidKeyException ex) {
                     System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => An unexpected exception was thrown with message = "
                             + ex.getMessage());
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
 
@@ -2133,12 +2135,12 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     } catch (InvalidAlgorithmParameterException ex) {
-                        Assert.assertTrue(true);
+                        assertTrue(true);
                     } catch (InvalidKeyException ex) {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => An unexpected exception was thrown with message = "
                                 + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
 
                 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPublicMethodsToMakeNonPublic.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPublicMethodsToMakeNonPublic.java
@@ -20,7 +20,7 @@ import java.util.Vector;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 abstract public class BaseTestPublicMethodsToMakeNonPublic extends BaseTestJunit5 {
     private boolean debug = false;
@@ -74,8 +74,8 @@ abstract public class BaseTestPublicMethodsToMakeNonPublic extends BaseTestJunit
             }
         }
 
-        assertTrue("Public methods to make non-public: " + publicMethodNamesString,
-                (publicMethodNamesToCheck.size() == 0));
+        assertTrue((publicMethodNamesToCheck.size() == 0),
+            "Public methods to make non-public: " + publicMethodNamesString);
     }
 
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSA.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSA.java
@@ -41,7 +41,7 @@ import javax.crypto.spec.OAEPParameterSpec;
 import javax.crypto.spec.PSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestRSA extends BaseTestCipher {
@@ -375,7 +375,7 @@ public class BaseTestRSA extends BaseTestCipher {
         byte[] newPlainText = cp.doFinal();
 
         boolean success = decryptResultsMatch(cp.getAlgorithm(), plainText, newPlainText);
-        assertTrue("Decrypted text does not match expected", success);
+        assertTrue(success, "Decrypted text does not match expected");
 
     }
 
@@ -468,7 +468,7 @@ public class BaseTestRSA extends BaseTestCipher {
         Cipher cp = Cipher.getInstance(transformation, getProviderName());
         cp.init(Cipher.ENCRYPT_MODE, rsaPub);
         AlgorithmParameters algParams = cp.getParameters();
-        assertTrue("AlgorithmParameters not null", (algParams == null));
+        assertTrue((algParams == null), "AlgorithmParameters not null");
     }
 
 
@@ -480,7 +480,7 @@ public class BaseTestRSA extends BaseTestCipher {
         Cipher cp = Cipher.getInstance(transformation, getProviderName());
         cp.init(Cipher.ENCRYPT_MODE, rsaPub);
         AlgorithmParameters algParams = cp.getParameters();
-        assertTrue("AlgorithmParameters is null", (algParams != null));
+        assertTrue((algParams != null), "AlgorithmParameters is null");
     }
 
     @Test
@@ -493,7 +493,7 @@ public class BaseTestRSA extends BaseTestCipher {
         if (keySize == 0) {
             keySize = ((java.security.interfaces.RSAKey) rsaPub).getModulus().bitLength();
         }
-        assertTrue("Unexpected getOutputSize result", (outputSize == keySize / 8));
+        assertTrue((outputSize == keySize / 8), "Unexpected getOutputSize result");
     }
 
     @Test
@@ -555,7 +555,7 @@ public class BaseTestRSA extends BaseTestCipher {
         byte[] newPlainText = cp.doFinal(cipherText);
 
         boolean success = decryptResultsMatch(cp.getAlgorithm(), plainText, newPlainText);
-        assertTrue("Decrypted text does not match expected", success);
+        assertTrue(success, "Decrypted text does not match expected");
     }
 
     @Test
@@ -579,7 +579,7 @@ public class BaseTestRSA extends BaseTestCipher {
         byte[] newPlainText = cp.doFinal(cipherText);
 
         boolean success = decryptResultsMatch(cp.getAlgorithm(), plainText, newPlainText);
-        assertTrue("Decrypted text does not match expected", success);
+        assertTrue(success, "Decrypted text does not match expected");
     }
 
     @Test
@@ -593,7 +593,7 @@ public class BaseTestRSA extends BaseTestCipher {
         byte[] newPlainText = cp.doFinal(cipherText);
 
         boolean success = decryptResultsMatch(cp.getAlgorithm(), plainText, newPlainText);
-        assertTrue("Decrypted text does not match expected", success);
+        assertTrue(success, "Decrypted text does not match expected");
     }
 
     @Test
@@ -623,7 +623,7 @@ public class BaseTestRSA extends BaseTestCipher {
         byte[] newPlainText = cp.doFinal(cipherText);
 
         boolean success = decryptResultsMatch(cp.getAlgorithm(), plainText, newPlainText);
-        assertTrue("Decrypted text does not match expected", success);
+        assertTrue(success, "Decrypted text does not match expected");
     }
 
     @Test
@@ -721,7 +721,7 @@ public class BaseTestRSA extends BaseTestCipher {
         byte[] newPlainText = cp.doFinal(cipherText);
 
         boolean success = decryptResultsMatch(cp.getAlgorithm(), message, newPlainText);
-        assertTrue("Decrypted text does not match expected", success);
+        assertTrue(success, "Decrypted text does not match expected");
     }
 
     @Test
@@ -735,7 +735,7 @@ public class BaseTestRSA extends BaseTestCipher {
         byte[] newPlainText = cp.doFinal(cipherText);
 
         boolean success = decryptResultsMatch(cp.getAlgorithm(), plainText, newPlainText);
-        assertTrue("Decrypted text does not match expected", success);
+        assertTrue(success, "Decrypted text does not match expected");
     }
 
 
@@ -819,7 +819,7 @@ public class BaseTestRSA extends BaseTestCipher {
         byte[] newPlainText = cp.doFinal(cipherText);
 
         boolean success = decryptResultsMatch(cp.getAlgorithm(), message, newPlainText);
-        assertTrue("Decrypted text does not match expected", success);
+        assertTrue(success, "Decrypted text does not match expected");
     }
 
 
@@ -842,7 +842,7 @@ public class BaseTestRSA extends BaseTestCipher {
         byte[] newPlainText = cp.doFinal();
 
         boolean success = decryptResultsMatch(cp.getAlgorithm(), message, newPlainText);
-        assertTrue("Decrypted text does not match expected", success);
+        assertTrue(success, "Decrypted text does not match expected");
     }
 
 
@@ -873,7 +873,7 @@ public class BaseTestRSA extends BaseTestCipher {
         System.arraycopy(newPlainText2, 0, newPlainText, l, newPlainText2.length);
 
         boolean success = decryptResultsMatch(cp.getAlgorithm(), message, newPlainText);
-        assertTrue("Decrypted text does not match expected", success);
+        assertTrue(success, "Decrypted text does not match expected");
     }
 
     /*

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKey.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKey.java
@@ -23,7 +23,7 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestRSAKey extends BaseTestJunit5 {
@@ -218,7 +218,7 @@ public class BaseTestRSAKey extends BaseTestJunit5 {
                 /*fail("JCEPlus should require RSA private keys to be CRT (Chinese Remainder Theorem) key");*/
             } catch (InvalidKeySpecException ikse) {
                 //assertTrue("JCEPlus requires RSA private keys to be CRT (Chinese Remainder Theorem) keys", true);
-                assertTrue("JCEPlus InvalidKeySpeccException = " + ikse.getMessage(), false);
+                assertTrue(false, "JCEPlus InvalidKeySpeccException = " + ikse.getMessage());
             }
         } else {
             RSAPrivateKeySpec rsaPrivateSpec = rsaKeyFactory

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInterop.java
@@ -28,7 +28,7 @@ import java.util.Arrays;
 import javax.crypto.Cipher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestRSAKeyInterop extends BaseTestJunit5Interop {
@@ -297,7 +297,7 @@ public class BaseTestRSAKeyInterop extends BaseTestJunit5Interop {
             try {
                 rsaKeyFactoryJCE.generatePrivate(rsaPrivateSpecJCE);
             } catch (InvalidKeySpecException ikse) {
-                assertTrue("JCEPlus InvalidKeySpeccException = " + ikse.getMessage(), false);
+                assertTrue(false, "JCEPlus InvalidKeySpeccException = " + ikse.getMessage());
             }
         } else {
             RSAPrivateKeySpec rsaPrivateSpecJCE = rsaKeyFactoryJCE
@@ -340,8 +340,7 @@ public class BaseTestRSAKeyInterop extends BaseTestJunit5Interop {
 
                 rsaKeyFactoryPlus.generatePrivate(rsaPrivateSpecPlus);
             } catch (InvalidKeySpecException ikse) {
-
-                assertTrue("JCEPlus InvalidKeySpeccException = " + ikse.getMessage(), false);
+                assertTrue(false, "JCEPlus InvalidKeySpeccException = " + ikse.getMessage());
             }
         } else {
             RSAPrivateKeySpec rsaPrivateSpecPlus = rsaKeyFactoryPlus
@@ -381,10 +380,10 @@ public class BaseTestRSAKeyInterop extends BaseTestJunit5Interop {
             Signature verifyingPlus = Signature.getInstance("SHA256withRSA", getProviderName());
             verifyingPlus.initVerify(rsaPubPlus);
             verifyingPlus.update(origMsg);
-            assertTrue("Signature verification failed", verifyingPlus.verify(signedBytesJCE));
+            assertTrue(verifyingPlus.verify(signedBytesJCE), "Signature verification failed");
         } catch (Exception ex) {
             ex.printStackTrace();
-            assertTrue("signJCEAndVerifyPlus failed", false);
+            assertTrue(false, "signJCEAndVerifyPlus failed");
         }
     }
 
@@ -414,10 +413,10 @@ public class BaseTestRSAKeyInterop extends BaseTestJunit5Interop {
             Signature verifyingPlus = Signature.getInstance("SHA256withRSA", getProviderName());
             verifyingPlus.initVerify(rsaPubPlus);
             verifyingPlus.update(origMsg);
-            assertTrue("Signature verification failed", verifyingPlus.verify(signedBytesJCE));
+            assertTrue(verifyingPlus.verify(signedBytesJCE), "Signature verification failed");
         } catch (Exception ex) {
             ex.printStackTrace();
-            assertTrue("signJCEAndVerifyPlus failed", false);
+            assertTrue(false, "signJCEAndVerifyPlus failed");
         }
     }
 
@@ -446,12 +445,12 @@ public class BaseTestRSAKeyInterop extends BaseTestJunit5Interop {
             Signature verifyingJCE = Signature.getInstance("SHA256withRSA", getInteropProviderName());
             verifyingJCE.initVerify(rsaPubJCE);
             verifyingJCE.update(origMsg);
-            assertTrue("Signature verification", verifyingJCE.verify(signedBytesPlus));
+            assertTrue(verifyingJCE.verify(signedBytesPlus), "Signature verification");
         }
 
         catch (Exception ex) {
             ex.printStackTrace();
-            assertTrue("SignAndVerify failed", false);
+            assertTrue(false, "SignAndVerify failed");
         }
 
 
@@ -482,10 +481,10 @@ public class BaseTestRSAKeyInterop extends BaseTestJunit5Interop {
             Signature verifyingJCE = Signature.getInstance("SHA256withRSA", getProviderName());
             verifyingJCE.initVerify(rsaPubJCE);
             verifyingJCE.update(origMsg);
-            assertTrue("Signature verification failed", verifyingJCE.verify(signedBytesPlus));
+            assertTrue(verifyingJCE.verify(signedBytesPlus), "Signature verification failed");
         } catch (Exception ex) {
             ex.printStackTrace();
-            assertTrue("signPlusAndVerifyJCE failed", false);
+            assertTrue( false, "signPlusAndVerifyJCE failed");
         }
     }
 
@@ -525,7 +524,7 @@ public class BaseTestRSAKeyInterop extends BaseTestJunit5Interop {
             assertTrue(Arrays.equals(msgBytes, decryptedBytes));
         } catch (Exception ex) {
             ex.printStackTrace();
-            assertTrue("testEncryptPlusDecryptJCE", false);
+            assertTrue(false, "testEncryptPlusDecryptJCE");
         }
     }
 
@@ -563,7 +562,7 @@ public class BaseTestRSAKeyInterop extends BaseTestJunit5Interop {
             assertTrue(Arrays.equals(msgBytes, decryptedBytes));
         } catch (Exception ex) {
             ex.printStackTrace();
-            assertTrue(" testEncryptJCEDecryptPlus", false);
+            assertTrue(false, " testEncryptJCEDecryptPlus");
         }
     }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInteropBC.java
@@ -28,7 +28,7 @@ import java.util.Arrays;
 import javax.crypto.Cipher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestRSAKeyInteropBC extends BaseTestJunit5Interop {
@@ -305,7 +305,7 @@ public class BaseTestRSAKeyInteropBC extends BaseTestJunit5Interop {
             try {
                 rsaKeyFactoryBC.generatePrivate(rsaPrivateSpecBC);
             } catch (InvalidKeySpecException ikse) {
-                assertTrue("BCPlus InvalidKeySpeccException = " + ikse.getMessage(), false);
+                assertTrue(false, "BCPlus InvalidKeySpeccException = " + ikse.getMessage());
             }
         } else {
             RSAPrivateKeySpec rsaPrivateSpecBC = rsaKeyFactoryBC
@@ -348,7 +348,7 @@ public class BaseTestRSAKeyInteropBC extends BaseTestJunit5Interop {
                 rsaKeyFactoryPlus.generatePrivate(rsaPrivateSpecPlus);
             } catch (InvalidKeySpecException ikse) {
 
-                assertTrue("BCPlus InvalidKeySpeccException = " + ikse.getMessage(), false);
+                assertTrue(false, "BCPlus InvalidKeySpeccException = " + ikse.getMessage());
             }
         } else {
             RSAPrivateKeySpec rsaPrivateSpecPlus = rsaKeyFactoryPlus
@@ -392,10 +392,10 @@ public class BaseTestRSAKeyInteropBC extends BaseTestJunit5Interop {
             Signature verifyingPlus = Signature.getInstance("SHA256withRSA", getProviderName());
             verifyingPlus.initVerify(rsaPubPlus);
             verifyingPlus.update(origMsg);
-            assertTrue("Signature verification failed", verifyingPlus.verify(signedBytesBC));
+            assertTrue(verifyingPlus.verify(signedBytesBC), "Signature verification failed");
         } catch (Exception ex) {
             ex.printStackTrace();
-            assertTrue("signBCAndVerifyPlus failed", false);
+            assertTrue(false, "signBCAndVerifyPlus failed");
         }
     }
 
@@ -429,10 +429,10 @@ public class BaseTestRSAKeyInteropBC extends BaseTestJunit5Interop {
             Signature verifyingPlus = Signature.getInstance("SHA256withRSA", getProviderName());
             verifyingPlus.initVerify(rsaPubPlus);
             verifyingPlus.update(origMsg);
-            assertTrue("Signature verification failed", verifyingPlus.verify(signedBytesBC));
+            assertTrue(verifyingPlus.verify(signedBytesBC), "Signature verification failed");
         } catch (Exception ex) {
             ex.printStackTrace();
-            assertTrue("signBCAndVerifyPlus failed", false);
+            assertTrue(false, "signBCAndVerifyPlus failed");
         }
     }
 
@@ -465,12 +465,12 @@ public class BaseTestRSAKeyInteropBC extends BaseTestJunit5Interop {
             Signature verifyingBC = Signature.getInstance("SHA256withRSA", getInteropProviderName());
             verifyingBC.initVerify(rsaPubBC);
             verifyingBC.update(origMsg);
-            assertTrue("Signature verification", verifyingBC.verify(signedBytesPlus));
+            assertTrue(verifyingBC.verify(signedBytesPlus), "Signature verification");
         }
 
         catch (Exception ex) {
             ex.printStackTrace();
-            assertTrue("SignAndVerify failed", false);
+            assertTrue(false, "SignAndVerify failed");
         }
 
 
@@ -505,10 +505,10 @@ public class BaseTestRSAKeyInteropBC extends BaseTestJunit5Interop {
             Signature verifyingBC = Signature.getInstance("SHA256withRSA", getProviderName());
             verifyingBC.initVerify(rsaPubBC);
             verifyingBC.update(origMsg);
-            assertTrue("Signature verification failed", verifyingBC.verify(signedBytesPlus));
+            assertTrue(verifyingBC.verify(signedBytesPlus), "Signature verification failed");
         } catch (Exception ex) {
             ex.printStackTrace();
-            assertTrue("signPlusAndVerifyBC failed", false);
+            assertTrue(false, "signPlusAndVerifyBC failed");
         }
     }
 
@@ -552,7 +552,7 @@ public class BaseTestRSAKeyInteropBC extends BaseTestJunit5Interop {
             assertTrue(Arrays.equals(msgBytes, decryptedBytes));
         } catch (Exception ex) {
             ex.printStackTrace();
-            assertTrue("testEncryptPlusDecryptBC", false);
+            assertTrue(false, "testEncryptPlusDecryptBC");
         }
     }
 
@@ -594,7 +594,7 @@ public class BaseTestRSAKeyInteropBC extends BaseTestJunit5Interop {
             assertTrue(Arrays.equals(msgBytes, decryptedBytes));
         } catch (Exception ex) {
             ex.printStackTrace();
-            assertTrue(" testEncryptBCDecryptPlus", false);
+            assertTrue(false, " testEncryptBCDecryptPlus");
         }
     }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSS.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSS.java
@@ -24,7 +24,7 @@ import java.security.spec.RSAPrivateKeySpec;
 import java.security.spec.RSAPublicKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestRSAPSS extends BaseTestJunit5 {
 
@@ -152,7 +152,7 @@ public class BaseTestRSAPSS extends BaseTestJunit5 {
 
         boolean signatureVerified = sig.verify(sigBytes);
 
-        assertTrue("signature is invalid!!", signatureVerified);
+        assertTrue(signatureVerified, "signature is invalid!!");
     }
 
     @Test
@@ -366,7 +366,7 @@ public class BaseTestRSAPSS extends BaseTestJunit5 {
         // verifySig.update(content);
         boolean signatureVerified = sig.verify(sigBytes);
 
-        assertTrue("signature is invalid!!", signatureVerified);
+        assertTrue(signatureVerified, "signature is invalid!!");
     }
 
     /**
@@ -407,7 +407,7 @@ public class BaseTestRSAPSS extends BaseTestJunit5 {
         // verifySig.update(content);
         boolean signatureVerified = sig.verify(sigBytes);
 
-        assertTrue("signature is invalid!!", signatureVerified);
+        assertTrue(signatureVerified, "signature is invalid!!");
     }
 
     /**
@@ -448,7 +448,7 @@ public class BaseTestRSAPSS extends BaseTestJunit5 {
 
         boolean signatureVerified = sig.verify(sigBytes);
 
-        assertTrue("signature is invalid!!", signatureVerified);
+        assertTrue(signatureVerified, "signature is invalid!!");
     }
 
     /**
@@ -486,7 +486,7 @@ public class BaseTestRSAPSS extends BaseTestJunit5 {
 
         boolean signatureVerified = sig.verify(sigBytes);
 
-        assertTrue("signature is invalid!!", signatureVerified);
+        assertTrue(signatureVerified, "signature is invalid!!");
     }
 
     /*
@@ -527,11 +527,9 @@ public class BaseTestRSAPSS extends BaseTestJunit5 {
             X509EncodedKeySpec x509KeySpec2 = new X509EncodedKeySpec(encodedKey);
             KeyFactory.getInstance("RSASSA-PSS", getProviderName());
             RSAPublicKey publicKey2 = (RSAPublicKey) kf.generatePublic(x509KeySpec2);
-            assertTrue("Algorithm name different",
-                    publicKey.getAlgorithm().equalsIgnoreCase(publicKey2.getAlgorithm()));
-            assertTrue("Modulus different", publicKey.getModulus().equals(publicKey2.getModulus()));
-            assertTrue("Exponentdifferent",
-                    publicKey.getPublicExponent().equals(publicKey2.getPublicExponent()));
+            assertTrue(publicKey.getAlgorithm().equalsIgnoreCase(publicKey2.getAlgorithm()), "Algorithm name different");
+            assertTrue(publicKey.getModulus().equals(publicKey2.getModulus()), "Modulus different");
+            assertTrue(publicKey.getPublicExponent().equals(publicKey2.getPublicExponent()), "Exponent different");
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSS2.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSS2.java
@@ -19,9 +19,11 @@ import java.security.Signature;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestRSAPSS2 extends BaseTestJunit5 {
 
@@ -445,7 +447,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " = " + result);
-                        Assert.assertTrue("signature is invalid!!", result);
+                        assertTrue(result, "signature is invalid!!");
 
 
                     } catch (Exception ex) {
@@ -453,7 +455,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => Exception thrown with message = " + ex.getMessage());
                         ex.printStackTrace();
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -572,14 +574,14 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (Exception ex) {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -697,14 +699,14 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (Exception ex) {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -825,7 +827,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 0) //If key size <= 512
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -843,7 +845,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 512
                     {
@@ -851,7 +853,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -974,7 +976,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 0) //If key size <= 512
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -992,7 +994,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 512
                     {
@@ -1000,7 +1002,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1124,7 +1126,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1138,7 +1140,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1257,7 +1259,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1271,7 +1273,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1390,7 +1392,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1404,7 +1406,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1523,7 +1525,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1537,7 +1539,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1656,7 +1658,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1670,7 +1672,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1798,7 +1800,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1812,7 +1814,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1930,7 +1932,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1944,7 +1946,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2063,7 +2065,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -2077,7 +2079,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2197,7 +2199,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -2211,7 +2213,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2330,7 +2332,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -2344,7 +2346,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2457,14 +2459,14 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " = " + result);
-                        Assert.assertTrue("signature is invalid!!", result);
+                        assertTrue(result, "signature is invalid!!");
 
                     } catch (Exception ex) {
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => Exception thrown with message = " + ex.getMessage());
                         ex.printStackTrace();
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2586,7 +2588,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 0) //If key size <= 512
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -2604,7 +2606,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 512
                     {
@@ -2612,7 +2614,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2735,7 +2737,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 0) //If key size <= 512
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -2753,7 +2755,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 512
                     {
@@ -2761,7 +2763,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2884,7 +2886,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 1) //If key size <= 1024
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -2902,7 +2904,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 1024
                     {
@@ -2910,7 +2912,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -3032,7 +3034,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 2) //If key size <= 2048
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -3050,7 +3052,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 2048
                     {
@@ -3058,7 +3060,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -3184,16 +3186,16 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (InvalidAlgorithmParameterException apex) {
-                    Assert.assertTrue("expected exception", true);
+                    assertTrue(true, "expected exception");
                 } catch (Exception ex) {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -3301,16 +3303,16 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " = " + result);
-                        Assert.assertTrue("signature is invalid!!", result);
+                        assertTrue(result, "signature is invalid!!");
 
                     } catch (InvalidAlgorithmParameterException apex) {
-                        Assert.assertTrue("expected exception", true);
+                        assertTrue(true, "expected exception");
                     } catch (Exception ex) {
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => Exception thrown with message = " + ex.getMessage());
                         ex.printStackTrace();
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -3429,16 +3431,16 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue("Did not get InvalidAlgorithmParameterException ", false);
+                    assertTrue(false, "Did not get InvalidAlgorithmParameterException ");
 
                 } catch (InvalidAlgorithmParameterException apex) {
-                    Assert.assertTrue("expected exception", true);
+                    assertTrue(true, "expected exception");
                 } catch (Exception ex) {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -3558,17 +3560,17 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException apex) {
-                    Assert.assertTrue("expected exception", true);
+                    assertTrue(true, "expected exception");
                 } catch (InvalidKeyException ex) {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => An unexpected exception was thrown with message = "
                                 + ex.getMessage());
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
 
@@ -3690,17 +3692,17 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException apex) {
-                    Assert.assertTrue("expected exception", true);
+                    assertTrue(true, "expected exception");
                 } catch (InvalidKeyException ex) {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => An unexpected exception was thrown with message = "
                                 + ex.getMessage());
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
 
@@ -3775,7 +3777,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                 if (printJunitTrace)
                     System.out.println(
                             "BaseTestRSAPSS2.java:  testRSAPSS_SameObjectTest():  The signature did not verify -FAILED ");
-                Assert.fail();
+                Assertions.fail();
             }
 
             //=======================================================
@@ -3788,19 +3790,19 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                 if (printJunitTrace)
                     System.out.println(
                             "BaseTestRSAPSS2.java:  testRSAPSS_SameObjectTest():  The signature did verify and should not have - FAILED ");
-                Assert.fail();
+                Assertions.fail();
             }
 
             if (printJunitTrace)
                 System.out
                         .println("BaseTestRSAPSS2.java:  testRSAPSS_SameObjectTest():  Successful");
-            Assert.assertTrue("Test SUCCESSFUL", true);
+            assertTrue(true, "Test SUCCESSFUL");
         } catch (Exception ex) {
             if (printJunitTrace)
                 System.out.println(
                         "BaseTestRSAPSS2.java:  testRSAPSS_SameObjectTest():  The following exception was thrown: ");
             ex.printStackTrace();
-            Assert.fail();
+            Assertions.fail();
         }
     } // end testRSAPSS_SameObjectTest()( )
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop.java
@@ -22,7 +22,7 @@ import java.security.spec.InvalidParameterSpecException;
 import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestRSAPSSInterop extends BaseTestJunit5Interop {
 
@@ -496,7 +496,7 @@ public class BaseTestRSAPSSInterop extends BaseTestJunit5Interop {
 
         boolean signatureVerified = sig1.verify(sigBytes);
 
-        assertTrue("signature is invalid!!", signatureVerified);
+        assertTrue(signatureVerified, "signature is invalid!!");
     }
 
     //    
@@ -549,7 +549,7 @@ public class BaseTestRSAPSSInterop extends BaseTestJunit5Interop {
         // verifySig.update(content);
         boolean signatureVerified = sigB.verify(sigBytes);
 
-        assertTrue("signature is invalid!!", signatureVerified);
+        assertTrue(signatureVerified, "signature is invalid!!");
     }
 
     /** 
@@ -649,7 +649,7 @@ public class BaseTestRSAPSSInterop extends BaseTestJunit5Interop {
         boolean signatureVerified = sigB.verify(sigBytes);
         /*System.out.println("Inter-op test " + signatureVerified);*/
 
-        assertTrue("signature is invalid!!", signatureVerified);
+        assertTrue(signatureVerified, "signature is invalid!!");
     }
 
     /**

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop2.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop2.java
@@ -18,9 +18,11 @@ import java.security.Signature;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
 
@@ -447,7 +449,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
 
                 } catch (Exception ex) {
@@ -455,7 +457,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -559,14 +561,14 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (Exception ex) {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -670,14 +672,14 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (Exception ex) {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -784,7 +786,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 0) //if key size <= 512
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -802,7 +804,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 512
                     {
@@ -810,7 +812,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -919,7 +921,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 0) //if key size <= 512
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -937,7 +939,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 512
                     {
@@ -945,7 +947,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1056,7 +1058,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1070,7 +1072,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1175,7 +1177,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1189,7 +1191,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1295,7 +1297,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1309,7 +1311,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1415,7 +1417,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1429,7 +1431,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1534,7 +1536,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1548,7 +1550,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1662,7 +1664,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1676,7 +1678,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1780,7 +1782,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1794,7 +1796,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1899,7 +1901,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1913,7 +1915,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2019,7 +2021,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -2033,7 +2035,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2138,11 +2140,11 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue(true);
-                    //Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
+                    assertTrue(true);
+                    //fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
-                    Assert.fail("Sha1 should not have failed");
+                    fail("Sha1 should not have failed");
                     if (ex.getMessage().indexOf(
                             "The message digest within the PSSParameterSpec does not match the MGF message digest.") != -1) {
                         if (printJunitTrace)
@@ -2153,7 +2155,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2262,14 +2264,14 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (Exception ex) {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -2376,7 +2378,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 0) //if key size <= 512
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -2394,7 +2396,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 512
                     {
@@ -2402,7 +2404,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2511,7 +2513,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 0) //if key size <= 512
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -2529,7 +2531,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 512
                     {
@@ -2537,7 +2539,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2646,7 +2648,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 1) //if key size <= 1024
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -2664,7 +2666,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 1024
                     {
@@ -2672,7 +2674,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2780,7 +2782,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 2) //if key size <= 2048
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -2798,7 +2800,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 2048
                     {
@@ -2806,7 +2808,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2918,14 +2920,14 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (Exception ex) {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -3029,14 +3031,14 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (Exception ex) {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -3140,14 +3142,14 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (Exception ex) {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -3255,7 +3257,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 0) //if key size <= 512
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -3273,7 +3275,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 512
                     {
@@ -3281,7 +3283,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -3391,7 +3393,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 0) //if key size <= 512
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -3409,7 +3411,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 512
                     {
@@ -3417,7 +3419,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop3.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop3.java
@@ -17,9 +17,11 @@ import java.security.Signature;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
 
@@ -432,7 +434,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
 
                 } catch (Exception ex) {
@@ -440,7 +442,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -544,14 +546,14 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (Exception ex) {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -655,14 +657,14 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (Exception ex) {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -769,7 +771,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 0) //If key size <= 512
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -787,7 +789,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 512
                     {
@@ -795,7 +797,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -904,7 +906,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 0) //If key size <= 512
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -922,7 +924,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 512
                     {
@@ -930,7 +932,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1040,7 +1042,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1054,7 +1056,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1159,7 +1161,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1173,7 +1175,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1278,7 +1280,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1292,7 +1294,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1397,7 +1399,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1411,7 +1413,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1516,7 +1518,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1530,7 +1532,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1644,7 +1646,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1658,7 +1660,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1762,7 +1764,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1776,7 +1778,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -1881,7 +1883,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -1895,7 +1897,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2001,7 +2003,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                    fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                             + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
@@ -2015,7 +2017,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2120,11 +2122,11 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue(true);
-                    //Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
+                    assertTrue(true);
+                    //fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1) + " => Instead, this test should have produced an InvalidAlgorithmParameterException");
 
                 } catch (InvalidAlgorithmParameterException ex) {
-                    Assert.fail("SHA1 should not have failed.");
+                    fail("SHA1 should not have failed.");
                     if (ex.getMessage().indexOf(
                             "The message digest within the PSSParameterSpec does not match the MGF message digest.") != -1) {
                         if (printJunitTrace)
@@ -2136,7 +2138,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2245,14 +2247,14 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (Exception ex) {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -2359,7 +2361,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 0) //If key size <= 512
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -2377,7 +2379,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 512
                     {
@@ -2385,7 +2387,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2494,7 +2496,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 0) //If key size <= 512
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -2512,7 +2514,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 512
                     {
@@ -2520,7 +2522,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2629,7 +2631,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 1) //If key size <= 1024
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -2647,7 +2649,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 1024
                     {
@@ -2655,7 +2657,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2763,7 +2765,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 2) //If key size <= 2048
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -2781,7 +2783,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 2048
                     {
@@ -2789,7 +2791,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -2901,14 +2903,14 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (Exception ex) {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -3012,14 +3014,14 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (Exception ex) {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -3123,14 +3125,14 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
-                    Assert.assertTrue("signature is invalid!!", result);
+                    assertTrue(result, "signature is invalid!!");
 
                 } catch (Exception ex) {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Exception thrown with message = " + ex.getMessage());
                     ex.printStackTrace();
-                    Assert.fail();
+                    Assertions.fail();
                 }
 
                 //======================================================================================================
@@ -3238,7 +3240,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 0) //If key size <= 512
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -3256,7 +3258,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 512
                     {
@@ -3264,7 +3266,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 
@@ -3374,7 +3376,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                     // For all key sizes and data lengths
                     if (ii <= 0) //If key size <= 512
                     {
-                        Assert.fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
+                        fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
@@ -3392,7 +3394,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                                         + (testCaseNumber - 1)
                                         + " => An unexpected exception was thrown with message = "
                                         + ex.getMessage());
-                            Assert.fail();
+                            Assertions.fail();
                         }
                     } else // else key size > 512
                     {
@@ -3400,7 +3402,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
-                        Assert.fail();
+                        Assertions.fail();
                     }
                 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSSignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSSignature.java
@@ -53,7 +53,7 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import sun.security.x509.X500Name;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestRSAPSSSignature extends BaseTestJunit5Signature {
 
@@ -541,7 +541,7 @@ public class BaseTestRSAPSSSignature extends BaseTestJunit5Signature {
         // verifySig.update(content);
         boolean signatureVerified = sig.verify(sigBytes);
 
-        assertTrue("signature is invalid!!", signatureVerified);
+        assertTrue(signatureVerified, "signature is invalid!!");
     }
 
     /**
@@ -581,7 +581,7 @@ public class BaseTestRSAPSSSignature extends BaseTestJunit5Signature {
         // verifySig.update(content);
         boolean signatureVerified = sig.verify(sigBytes);
 
-        assertTrue("signature is invalid!!", signatureVerified);
+        assertTrue(signatureVerified, "signature is invalid!!");
     }
 
     /** 
@@ -650,7 +650,7 @@ public class BaseTestRSAPSSSignature extends BaseTestJunit5Signature {
         if (printJunitTrace)
             System.out.println("Inter-op test " + signatureVerified);
 
-        assertTrue("signature is invalid!!", signatureVerified);
+        assertTrue(signatureVerified, "signature is invalid!!");
     }
 
     /**
@@ -747,7 +747,7 @@ public class BaseTestRSAPSSSignature extends BaseTestJunit5Signature {
         if (printJunitTrace)
             System.out.println("Inter-op test " + signatureVerified);
 
-        assertTrue("signature is invalid!!", signatureVerified);
+        assertTrue(signatureVerified, "signature is invalid!!");
     }
 
     /** 
@@ -784,7 +784,7 @@ public class BaseTestRSAPSSSignature extends BaseTestJunit5Signature {
 
         boolean signatureVerified = sig.verify(sigBytes);
 
-        assertTrue("signature is invalid!!", signatureVerified);
+        assertTrue(signatureVerified, "signature is invalid!!");
     }
 
     /**
@@ -822,7 +822,7 @@ public class BaseTestRSAPSSSignature extends BaseTestJunit5Signature {
 
         boolean signatureVerified = sig.verify(sigBytes);
 
-        assertTrue("signature is invalid!!", signatureVerified);
+        assertTrue(signatureVerified, "signature is invalid!!");
     }
 
     /**
@@ -1623,11 +1623,9 @@ public class BaseTestRSAPSSSignature extends BaseTestJunit5Signature {
             X509EncodedKeySpec x509KeySpec2 = new X509EncodedKeySpec(encodedKey);
             KeyFactory.getInstance("RSASSA-PSS", providerNameKF);
             RSAPublicKey publicKey2 = (RSAPublicKey) kf.generatePublic(x509KeySpec2);
-            assertTrue("Algorithm name different",
-                    publicKey.getAlgorithm().equalsIgnoreCase(publicKey2.getAlgorithm()));
-            assertTrue("Modulus different", publicKey.getModulus().equals(publicKey2.getModulus()));
-            assertTrue("Exponentdifferent",
-                    publicKey.getPublicExponent().equals(publicKey2.getPublicExponent()));
+            assertTrue(publicKey.getAlgorithm().equalsIgnoreCase(publicKey2.getAlgorithm()), "Algorithm name different");
+            assertTrue(publicKey.getModulus().equals(publicKey2.getModulus()), "Modulus different");
+            assertTrue(publicKey.getPublicExponent().equals(publicKey2.getPublicExponent()), "Exponent different");
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSASignature.java
@@ -26,7 +26,7 @@ import java.security.spec.RSAPublicKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestRSASignature extends BaseTestJunit5Signature {
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSASignatureChunkUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSASignatureChunkUpdate.java
@@ -14,8 +14,8 @@ import java.security.Signature;
 import java.security.SignatureException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestRSASignatureChunkUpdate extends BaseTestJunit5Signature {
     static final String KEY_ALGO = "RSA";

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSATypeCheckEnabled.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSATypeCheckEnabled.java
@@ -15,7 +15,7 @@ import java.security.interfaces.RSAPublicKey;
 import javax.crypto.Cipher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestRSATypeCheckEnabled extends BaseTestJunit5 {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA1.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA1.java
@@ -11,7 +11,7 @@ import java.security.MessageDigest;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestSHA1 extends BaseTestMessageDigestClone {
 
@@ -86,7 +86,7 @@ public class BaseTestSHA1 extends BaseTestMessageDigestClone {
 
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(result, sharesult));
+        assertTrue(Arrays.equals(result, sharesult), "Digest did not match expected");
 
     }
 
@@ -97,7 +97,7 @@ public class BaseTestSHA1 extends BaseTestMessageDigestClone {
         md.update(sha_A_input);
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(result, sha_A));
+        assertTrue(Arrays.equals(result, sha_A), "Digest did not match expected");
 
     }
 
@@ -108,7 +108,7 @@ public class BaseTestSHA1 extends BaseTestMessageDigestClone {
         md.update(sha_B_input);
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(result, sha_B));
+        assertTrue(Arrays.equals(result, sha_B), "Digest did not match expected");
 
     }
 
@@ -122,7 +122,7 @@ public class BaseTestSHA1 extends BaseTestMessageDigestClone {
 
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(result, sha_C));
+        assertTrue(Arrays.equals(result, sha_C), "Digest did not match expected");
 
     }
 
@@ -135,7 +135,7 @@ public class BaseTestSHA1 extends BaseTestMessageDigestClone {
         md.update(sha_B_input);
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(result, sha_B));
+        assertTrue(Arrays.equals(result, sha_B), "Digest did not match expected");
 
     }
 
@@ -144,7 +144,7 @@ public class BaseTestSHA1 extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         int digestLength = md.getDigestLength();
         boolean isExpectedValue = (digestLength == 20);
-        assertTrue("Unexpected digest length", isExpectedValue);
+        assertTrue(isExpectedValue, "Unexpected digest length");
     }
 
     @Test
@@ -153,9 +153,9 @@ public class BaseTestSHA1 extends BaseTestMessageDigestClone {
         byte[] bytes = new byte[] {1, 1, 1, 1, 1};
         try {
             md.update(bytes, -1, 1);
-            assertTrue("No expected IndexOutOfBoundsException", false);
+            assertTrue(false, "No expected IndexOutOfBoundsException");
         } catch (IndexOutOfBoundsException e) {
-            assertTrue("Expected IndexOutOfBoundsException", true);
+            assertTrue(true, "Expected IndexOutOfBoundsException");
         }
 
     }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA224.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA224.java
@@ -12,7 +12,7 @@ import java.security.MessageDigest;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestSHA224 extends BaseTestMessageDigestClone {
     static final byte[] input_1 = {(byte) 0x61, (byte) 0x62, (byte) 0x63};
@@ -38,14 +38,14 @@ public class BaseTestSHA224 extends BaseTestMessageDigestClone {
     @Test
     public void testSHA224_1() throws Exception {
         boolean result = checkDigest(input_1, digest_1);
-        assertTrue("Digest did not match expected, testSHA224_1:", result);
+        assertTrue(result, "Digest did not match expected, testSHA224_1:");
 
     }
 
     @Test
     public void testSHA224_2() throws Exception {
         boolean result = checkDigest(input_2, digest_2);
-        assertTrue("Digest did not match expected, testSHA224_2", result);
+        assertTrue(result, "Digest did not match expected, testSHA224_2");
     }
 
     @Test
@@ -56,7 +56,7 @@ public class BaseTestSHA224 extends BaseTestMessageDigestClone {
         md.update(input_2);
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(result, digest_2));
+        assertTrue(Arrays.equals(result, digest_2), "Digest did not match expected");
     }
 
     @Test
@@ -64,7 +64,7 @@ public class BaseTestSHA224 extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         int digestLength = md.getDigestLength();
         boolean isExpectedValue = (digestLength == 28);
-        assertTrue("Unexpected digest length", isExpectedValue);
+        assertTrue(isExpectedValue, "Unexpected digest length");
     }
 
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA256.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA256.java
@@ -12,7 +12,7 @@ import java.security.MessageDigest;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestSHA256 extends BaseTestMessageDigestClone {
 
@@ -68,7 +68,7 @@ public class BaseTestSHA256 extends BaseTestMessageDigestClone {
             md.update(input_1);
         byte[] digest = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(digest, result_1));
+        assertTrue(Arrays.equals(digest, result_1), "Digest did not match expected");
     }
 
     @Test
@@ -76,7 +76,7 @@ public class BaseTestSHA256 extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         byte[] digest = md.digest(input_2);
 
-        assertTrue("Digest did not match expected", Arrays.equals(digest, result_2));
+        assertTrue(Arrays.equals(digest, result_2), "Digest did not match expected");
     }
 
     @Test
@@ -87,7 +87,7 @@ public class BaseTestSHA256 extends BaseTestMessageDigestClone {
         md.update(input_2);
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(result, result_2));
+        assertTrue(Arrays.equals(result, result_2), "Digest did not match expected");
     }
 
     @Test
@@ -95,7 +95,7 @@ public class BaseTestSHA256 extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         byte[] digest = md.digest(input_3);
 
-        assertTrue("Digest did not match expected", Arrays.equals(digest, result_3));
+        assertTrue(Arrays.equals(digest, result_3), "Digest did not match expected");
     }
 
     @Test
@@ -103,6 +103,6 @@ public class BaseTestSHA256 extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         int digestLength = md.getDigestLength();
         boolean isExpectedValue = (digestLength == 32);
-        assertTrue("Unexpected digest length", isExpectedValue);
+        assertTrue(isExpectedValue, "Unexpected digest length");
     }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA384.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA384.java
@@ -12,7 +12,7 @@ import java.security.MessageDigest;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestSHA384 extends BaseTestMessageDigestClone {
 
@@ -85,7 +85,7 @@ public class BaseTestSHA384 extends BaseTestMessageDigestClone {
             md.update(input_1);
         byte[] digest = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(digest, result_1));
+        assertTrue(Arrays.equals(digest, result_1), "Digest did not match expected");
 
     }
 
@@ -95,7 +95,7 @@ public class BaseTestSHA384 extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         byte[] digest = md.digest(input_2);
 
-        assertTrue("Digest did not match expected", Arrays.equals(digest, result_2));
+        assertTrue(Arrays.equals(digest, result_2), "Digest did not match expected");
 
     }
 
@@ -108,7 +108,7 @@ public class BaseTestSHA384 extends BaseTestMessageDigestClone {
         md.update(input_2);
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(result, result_2));
+        assertTrue(Arrays.equals(result, result_2), "Digest did not match expected");
 
     }
 
@@ -119,7 +119,7 @@ public class BaseTestSHA384 extends BaseTestMessageDigestClone {
 
         byte[] digest = md.digest(input_3);
 
-        assertTrue("Digest did not match expected", Arrays.equals(digest, result_3));
+        assertTrue(Arrays.equals(digest, result_3), "Digest did not match expected");
 
     }
 
@@ -128,6 +128,6 @@ public class BaseTestSHA384 extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         int digestLength = md.getDigestLength();
         boolean isExpectedValue = (digestLength == 48);
-        assertTrue("Unexpected digest length", isExpectedValue);
+        assertTrue(isExpectedValue, "Unexpected digest length");
     }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_224KAT.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_224KAT.java
@@ -11,7 +11,7 @@ import java.security.MessageDigest;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestSHA3_224KAT extends BaseTestMessageDigestClone {
 
@@ -506,8 +506,7 @@ public class BaseTestSHA3_224KAT extends BaseTestMessageDigestClone {
             md.update(BaseUtils.hexStringToByteArray(tests[x][0]));
             byte[] digest = md.digest();
 
-            assertTrue("Digest did not match expected = " + x,
-                    Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[x][1])));
+            assertTrue(Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[x][1])), "Digest did not match expected = " + x);
         }
     }
 
@@ -516,8 +515,7 @@ public class BaseTestSHA3_224KAT extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         byte[] digest = md.digest(BaseUtils.hexStringToByteArray(tests[0][0]));
 
-        assertTrue("Digest did not match expected",
-                Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[0][1])));
+        assertTrue(Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[0][1])), "Digest did not match expected");
     }
 
     @Test
@@ -528,8 +526,7 @@ public class BaseTestSHA3_224KAT extends BaseTestMessageDigestClone {
         md.update(BaseUtils.hexStringToByteArray(tests[1][0]));
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected",
-                Arrays.equals(result, BaseUtils.hexStringToByteArray(tests[1][1])));
+        assertTrue(Arrays.equals(result, BaseUtils.hexStringToByteArray(tests[1][1])), "Digest did not match expected");
     }
 
     @Test
@@ -537,8 +534,7 @@ public class BaseTestSHA3_224KAT extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         byte[] digest = md.digest(BaseUtils.hexStringToByteArray(tests[1][0]));
 
-        assertTrue("Digest did not match expected",
-                Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[1][1])));
+        assertTrue(Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[1][1])), "Digest did not match expected");
     }
 
     @Test
@@ -546,6 +542,6 @@ public class BaseTestSHA3_224KAT extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         int digestLength = md.getDigestLength();
         boolean isExpectedValue = (digestLength == 28);
-        assertTrue("Unexpected digest length", isExpectedValue);
+        assertTrue(isExpectedValue, "Unexpected digest length");
     }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_256KAT.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_256KAT.java
@@ -11,7 +11,7 @@ import java.security.MessageDigest;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestSHA3_256KAT extends BaseTestMessageDigestClone {
 
@@ -495,8 +495,7 @@ public class BaseTestSHA3_256KAT extends BaseTestMessageDigestClone {
             md.update(BaseUtils.hexStringToByteArray(tests[x][0]));
             byte[] digest = md.digest();
 
-            assertTrue("Digest did not match expected = " + x,
-                    Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[x][1])));
+            assertTrue(Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[x][1])), "Digest did not match expected = " + x);
         }
     }
 
@@ -505,8 +504,7 @@ public class BaseTestSHA3_256KAT extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         byte[] digest = md.digest(BaseUtils.hexStringToByteArray(tests[0][0]));
 
-        assertTrue("Digest did not match expected",
-                Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[0][1])));
+        assertTrue(Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[0][1])), "Digest did not match expected");
     }
 
     @Test
@@ -517,8 +515,7 @@ public class BaseTestSHA3_256KAT extends BaseTestMessageDigestClone {
         md.update(BaseUtils.hexStringToByteArray(tests[1][0]));
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected",
-                Arrays.equals(result, BaseUtils.hexStringToByteArray(tests[1][1])));
+        assertTrue(Arrays.equals(result, BaseUtils.hexStringToByteArray(tests[1][1])), "Digest did not match expected");
     }
 
     @Test
@@ -526,8 +523,7 @@ public class BaseTestSHA3_256KAT extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         byte[] digest = md.digest(BaseUtils.hexStringToByteArray(tests[1][0]));
 
-        assertTrue("Digest did not match expected",
-                Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[1][1])));
+        assertTrue(Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[1][1])), "Digest did not match expected");
     }
 
     @Test
@@ -535,6 +531,6 @@ public class BaseTestSHA3_256KAT extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         int digestLength = md.getDigestLength();
         boolean isExpectedValue = (digestLength == 32);
-        assertTrue("Unexpected digest length", isExpectedValue);
+        assertTrue(isExpectedValue, "Unexpected digest length");
     }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_384KAT.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_384KAT.java
@@ -11,7 +11,7 @@ import java.security.MessageDigest;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestSHA3_384KAT extends BaseTestMessageDigestClone {
 
@@ -436,8 +436,7 @@ public class BaseTestSHA3_384KAT extends BaseTestMessageDigestClone {
             md.update(BaseUtils.hexStringToByteArray(tests[x][0]));
             byte[] digest = md.digest();
 
-            assertTrue("Digest did not match expected = " + x,
-                    Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[x][1])));
+            assertTrue(Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[x][1])), "Digest did not match expected = " + x);
         }
     }
 
@@ -446,8 +445,7 @@ public class BaseTestSHA3_384KAT extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         byte[] digest = md.digest(BaseUtils.hexStringToByteArray(tests[0][0]));
 
-        assertTrue("Digest did not match expected",
-                Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[0][1])));
+        assertTrue(Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[0][1])), "Digest did not match expected");
     }
 
     @Test
@@ -458,8 +456,7 @@ public class BaseTestSHA3_384KAT extends BaseTestMessageDigestClone {
         md.update(BaseUtils.hexStringToByteArray(tests[1][0]));
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected",
-                Arrays.equals(result, BaseUtils.hexStringToByteArray(tests[1][1])));
+        assertTrue(Arrays.equals(result, BaseUtils.hexStringToByteArray(tests[1][1])), "Digest did not match expected");
     }
 
     @Test
@@ -467,8 +464,7 @@ public class BaseTestSHA3_384KAT extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         byte[] digest = md.digest(BaseUtils.hexStringToByteArray(tests[1][0]));
 
-        assertTrue("Digest did not match expected",
-                Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[1][1])));
+        assertTrue(Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[1][1])), "Digest did not match expected");
     }
 
     @Test
@@ -476,7 +472,7 @@ public class BaseTestSHA3_384KAT extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         int digestLength = md.getDigestLength();
         boolean isExpectedValue = (digestLength == 48);
-        assertTrue("Unexpected digest length", isExpectedValue);
+        assertTrue(isExpectedValue, "Unexpected digest length");
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_512KAT.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_512KAT.java
@@ -11,7 +11,7 @@ import java.security.MessageDigest;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestSHA3_512KAT extends BaseTestMessageDigestClone {
 
@@ -372,8 +372,7 @@ public class BaseTestSHA3_512KAT extends BaseTestMessageDigestClone {
             md.update(BaseUtils.hexStringToByteArray(tests[x][0]));
             byte[] digest = md.digest();
 
-            assertTrue("Digest did not match expected = " + x,
-                    Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[x][1])));
+            assertTrue(Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[x][1])), "Digest did not match expected = " + x);
         }
     }
 
@@ -382,8 +381,7 @@ public class BaseTestSHA3_512KAT extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         byte[] digest = md.digest(BaseUtils.hexStringToByteArray(tests[0][0]));
 
-        assertTrue("Digest did not match expected",
-                Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[0][1])));
+        assertTrue(Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[0][1])), "Digest did not match expected");
     }
 
     @Test
@@ -394,8 +392,7 @@ public class BaseTestSHA3_512KAT extends BaseTestMessageDigestClone {
         md.update(BaseUtils.hexStringToByteArray(tests[1][0]));
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected",
-                Arrays.equals(result, BaseUtils.hexStringToByteArray(tests[1][1])));
+        assertTrue(Arrays.equals(result, BaseUtils.hexStringToByteArray(tests[1][1])), "Digest did not match expected");
     }
 
     @Test
@@ -403,8 +400,7 @@ public class BaseTestSHA3_512KAT extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         byte[] digest = md.digest(BaseUtils.hexStringToByteArray(tests[1][0]));
 
-        assertTrue("Digest did not match expected",
-                Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[1][1])));
+        assertTrue(Arrays.equals(digest, BaseUtils.hexStringToByteArray(tests[1][1])), "Digest did not match expected");
     }
 
     @Test
@@ -412,6 +408,6 @@ public class BaseTestSHA3_512KAT extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         int digestLength = md.getDigestLength();
         boolean isExpectedValue = (digestLength == 64);
-        assertTrue("Unexpected digest length", isExpectedValue);
+        assertTrue(isExpectedValue, "Unexpected digest length");
     }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA512.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA512.java
@@ -12,7 +12,7 @@ import java.security.MessageDigest;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestSHA512 extends BaseTestMessageDigestClone {
 
@@ -89,7 +89,7 @@ public class BaseTestSHA512 extends BaseTestMessageDigestClone {
             md.update(input_1);
         byte[] digest = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(digest, result_1));
+        assertTrue(Arrays.equals(digest, result_1), "Digest did not match expected");
 
     }
 
@@ -101,7 +101,7 @@ public class BaseTestSHA512 extends BaseTestMessageDigestClone {
         md.update(input_2);
         byte[] result = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(result, result_2));
+        assertTrue(Arrays.equals(result, result_2), "Digest did not match expected");
 
     }
 
@@ -110,7 +110,7 @@ public class BaseTestSHA512 extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         byte[] digest = md.digest(input_2);
 
-        assertTrue("Digest did not match expected", Arrays.equals(digest, result_2));
+        assertTrue(Arrays.equals(digest, result_2), "Digest did not match expected");
 
     }
 
@@ -119,7 +119,7 @@ public class BaseTestSHA512 extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         byte[] digest = md.digest(input_3);
 
-        assertTrue("Digest did not match expected", Arrays.equals(digest, result_3));
+        assertTrue(Arrays.equals(digest, result_3), "Digest did not match expected");
 
     }
 
@@ -128,6 +128,6 @@ public class BaseTestSHA512 extends BaseTestMessageDigestClone {
         MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
         int digestLength = md.getDigestLength();
         boolean isExpectedValue = (digestLength == 64);
-        assertTrue("Unexpected digest length", isExpectedValue);
+        assertTrue(isExpectedValue, "Unexpected digest length");
     }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA512_224.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA512_224.java
@@ -12,7 +12,7 @@ import java.security.MessageDigest;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestSHA512_224 extends BaseTestMessageDigestClone {
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA512_256.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA512_256.java
@@ -12,7 +12,7 @@ import java.security.MessageDigest;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestSHA512_256 extends BaseTestMessageDigestClone {
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSignatureInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSignatureInterop.java
@@ -11,7 +11,7 @@ package ibm.jceplus.junit.base;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestSignatureInterop extends BaseTestJunit5Interop {
 
@@ -33,7 +33,7 @@ public class BaseTestSignatureInterop extends BaseTestJunit5Interop {
         verifying.initVerify(publicKey);
         verifying.update(message);
 
-        assertTrue("Signature verification failed", verifying.verify(signedBytes));
+        assertTrue(verifying.verify(signedBytes), "Signature verification failed");
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestTruncatedDigest.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestTruncatedDigest.java
@@ -14,7 +14,7 @@ import java.security.Signature;
 import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestTruncatedDigest extends BaseTestJunit5Signature {
 
@@ -168,7 +168,7 @@ public class BaseTestTruncatedDigest extends BaseTestJunit5Signature {
         // verifySig.update(content);
         boolean signatureVerified = sig.verify(sigBytes);
 
-        assertTrue("signature is invalid!!", signatureVerified);
+        assertTrue(signatureVerified, "signature is invalid!!");
     }
 
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyImport.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyImport.java
@@ -24,7 +24,7 @@ import java.security.spec.XECPublicKeySpec;
 import java.util.Arrays;
 import java.util.Base64;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestXDHKeyImport extends BaseTestJunit5 {
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDHMultiParty.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDHMultiParty.java
@@ -20,7 +20,7 @@ import java.security.spec.NamedParameterSpec;
 import java.util.Arrays;
 import javax.crypto.KeyAgreement;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestXDHMultiParty extends BaseTestJunit5 {
 

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressAES.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressAES.java
@@ -18,7 +18,7 @@ import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestMemStressAES extends BaseTestCipher {
 

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressAESGCM.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressAESGCM.java
@@ -17,7 +17,7 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestMemStressAESGCM extends BaseTestJunit5 {
 
@@ -134,10 +134,9 @@ public class BaseTestMemStressAESGCM extends BaseTestJunit5 {
             params = cp.getParameters();
 
             if (requireLengthMultipleBlockSize) {
-                assertTrue(
+                assertTrue(((blockSize > 0) && (message.length % blockSize) == 0),
                         "Did not get expected IllegalBlockSizeException, blockSize=" + blockSize
-                                + ", msglen=" + message.length,
-                        ((blockSize > 0) && (message.length % blockSize) == 0));
+                                + ", msglen=" + message.length);
             }
 
             // Verify the text
@@ -152,10 +151,9 @@ public class BaseTestMemStressAESGCM extends BaseTestJunit5 {
             assertTrue(java.util.Arrays.equals(newPlainText, newPlainText2));
 
         } catch (IllegalBlockSizeException e) {
-            assertTrue(
+            assertTrue((!requireLengthMultipleBlockSize || (message.length % blockSize) != 0),
                     "Unexpected IllegalBlockSizeException, blockSize=" + blockSize + ", msglen="
-                            + message.length,
-                    (!requireLengthMultipleBlockSize || (message.length % blockSize) != 0));
+                            + message.length);
         }
     }
 

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressChaCha20Poly1305.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressChaCha20Poly1305.java
@@ -17,7 +17,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestMemStressChaCha20Poly1305 extends BaseTestCipher implements ChaCha20Constants {

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDH.java
@@ -23,7 +23,7 @@ import javax.crypto.KeyAgreement;
 import javax.crypto.spec.DHParameterSpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestMemStressDH extends BaseTestJunit5 {
 

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressHKDF.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressHKDF.java
@@ -29,7 +29,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestMemStressHKDF extends BaseTestJunit5 {
 

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressHmacSHA.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressHmacSHA.java
@@ -13,7 +13,7 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestMemStressHmacSHA extends BaseTestJunit5 {
     /* This test by default tests HmacSHAWith256 */
@@ -73,7 +73,7 @@ public class BaseTestMemStressHmacSHA extends BaseTestJunit5 {
             mac.update(data_1);
             byte[] digest = mac.doFinal();
 
-            assertTrue("Mac digest did not equal expected", Arrays.equals(digest, digest_1));
+            assertTrue(Arrays.equals(digest, digest_1), "Mac digest did not equal expected");
             currentTotalMemory = rt.totalMemory();
             currentFreeMemory = rt.freeMemory();
             currentUsedMemory = currentTotalMemory - currentFreeMemory;

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressRSAPSS2.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressRSAPSS2.java
@@ -16,7 +16,7 @@ import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestMemStressRSAPSS2 extends BaseTestJunit5 {
 
@@ -147,6 +147,6 @@ public class BaseTestMemStressRSAPSS2 extends BaseTestJunit5 {
         // verifySig.update(content);
         boolean signatureVerified = sig.verify(sigBytes);
 
-        assertTrue("signature is invalid!!", signatureVerified);
+        assertTrue(signatureVerified, "signature is invalid!!");
     }
 }

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressSHA.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressSHA.java
@@ -13,7 +13,7 @@ import java.security.MessageDigest;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestMemStressSHA extends BaseTestJunit5 {
 
@@ -66,7 +66,7 @@ public class BaseTestMemStressSHA extends BaseTestJunit5 {
             md.update(input_1);
         byte[] digest = md.digest();
 
-        assertTrue("Digest did not match expected", Arrays.equals(digest, result_1));
+        assertTrue(Arrays.equals(digest, result_1), "Digest did not match expected");
     }
 
     @Test
@@ -83,7 +83,7 @@ public class BaseTestMemStressSHA extends BaseTestJunit5 {
             MessageDigest md = MessageDigest.getInstance(digestAlg, getProviderName());
             byte[] digest = md.digest(input_2);
 
-            assertTrue("Digest did not match expected", Arrays.equals(digest, result_2));
+            assertTrue(Arrays.equals(digest, result_2), "Digest did not match expected");
             currentTotalMemory = rt.totalMemory();
             currentFreeMemory = rt.freeMemory();
             currentUsedMemory = currentTotalMemory - currentFreeMemory;

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressXDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressXDH.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import javax.crypto.KeyAgreement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestMemStressXDH extends BaseTestJunit5 {
     /* This class by default tests "X25519" */

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSASignatureWithSpecificSize.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSASignatureWithSpecificSize.java
@@ -18,8 +18,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class TestRSASignatureWithSpecificSize extends BaseTestJunit5 { 
@@ -81,9 +81,9 @@ public class TestRSASignatureWithSpecificSize extends BaseTestJunit5 {
         }
         verify.update(message);
         if (signedBytes != null) {
-            assertTrue("Signature verification failed", verify.verify(signedBytes));
+            assertTrue(verify.verify(signedBytes), "Signature verification failed");
         } else {
-            assertFalse("Signature verification failed", verify.verify(signedBytes));
+            assertFalse(verify.verify(signedBytes), "Signature verification failed");
         }
     }
 


### PR DESCRIPTION
The older junit dependency is still configured in the pom.xml mvn file as a dependency. This update removes this dependency and migrates all codes to junit jupiter framework. In particular the following changes were made.

1. The `pom.xml` file was updated to remove the junit dependency. It was replaced by just the hamcrest portion of the features that are used in the project.

1. All imports are now being done from the `org.junit.jupiter.api` package instead of `org.junit`.

1. Various assertions required the message string to be last argument to the method instead of first.

Back-ported from: #410

Signed-off-by: Jason Katonica <katonica@us.ibm.com>