### PR TITLE
Remove the use of the SecurityManager

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
@@ -11,7 +11,6 @@ package com.ibm.crypto.plus.provider;
 import com.ibm.crypto.plus.provider.ock.OCKContext;
 import com.ibm.crypto.plus.provider.ock.OCKException;
 import java.lang.reflect.Constructor;
-import java.security.AccessController;
 import java.security.InvalidParameterException;
 import java.security.Key;
 import java.security.NoSuchAlgorithmException;
@@ -25,7 +24,6 @@ import java.util.Map;
 import javax.crypto.SecretKey;
 import sun.security.util.Debug;
 
-@SuppressWarnings({"removal", "deprecation"})
 public final class OpenJCEPlus extends OpenJCEPlusProvider {
 
     private static final long serialVersionUID = -1610967128950682479L;
@@ -70,7 +68,6 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
     private static OCKContext ockContext;
     private static Map<String, String> attrs;
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     public OpenJCEPlus() {
         super("OpenJCEPlus", info);
 
@@ -80,27 +77,19 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
 
         final OpenJCEPlusProvider jce = this;
 
-        AccessController.doPrivileged(new java.security.PrivilegedAction() {
-            public Object run() {
-
-                // Do java OCK initialization which includes loading native code
-                // Don't do this in the static initializer because it might
-                // be necessary for an applet running in a browser to grant
-                // access rights beforehand.
-                if (!ockInitialized) {
-                    initializeContext();
-                }
-
-                registerAlgorithms(jce);
-
-                return null;
-            }
-        });
+        // Do java OCK initialization which includes loading native code
+        // Don't do this in the static initializer because it might
+        // be necessary for an applet running in a browser to grant
+        // access rights beforehand.
+        if (!ockInitialized) {
+            initializeContext();
+        }
+        registerAlgorithms(jce);
 
         if (instance == null) {
             instance = this;
         }
-    
+
         if (debug != null) {
             debug.println("OpenJCEPlus Build-Level: " + getDebugDate(this.getClass().getName()));
             debug.println("OpenJCEPlus library build date: " + OCKContext.getLibraryBuildDate());

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -11,7 +11,6 @@ package com.ibm.crypto.plus.provider;
 import com.ibm.crypto.plus.provider.ock.OCKContext;
 import com.ibm.crypto.plus.provider.ock.OCKException;
 import java.lang.reflect.Constructor;
-import java.security.AccessController;
 import java.security.InvalidParameterException;
 import java.security.Key;
 import java.security.NoSuchAlgorithmException;
@@ -26,7 +25,6 @@ import java.util.Map;
 import javax.crypto.SecretKey;
 import sun.security.util.Debug;
 
-@SuppressWarnings({"removal", "deprecation"})
 public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
 
     // Field serialVersionUID per tag [SERIALIZATION] in DesignNotes.txt
@@ -99,7 +97,6 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
         isPlatformSupported = isOsSupported && isArchSupported;
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     public OpenJCEPlusFIPS() {
         super("OpenJCEPlusFIPS", info);
         if (debug != null) {
@@ -113,22 +110,14 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
 
         final OpenJCEPlusProvider jce = this;
 
-        AccessController.doPrivileged(new java.security.PrivilegedAction() {
-            public Object run() {
-
-                // Do java OCK initialization which includes loading native code
-                // Don't do this in the static initializer because it might
-                // be necessary for an applet running in a browser to grant
-                // access rights beforehand.
-                if (!ockInitialized) {
-                    initializeContext();
-                }
-
-                registerAlgorithms(jce);
-
-                return null;
-            }
-        });
+        // Do java OCK initialization which includes loading native code
+        // Don't do this in the static initializer because it might
+        // be necessary for an applet running in a browser to grant
+        // access rights beforehand.
+        if (!ockInitialized) {
+            initializeContext();
+        }
+        registerAlgorithms(jce);
 
         if (instance == null) {
             instance = this;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/Digest.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/Digest.java
@@ -8,13 +8,10 @@
 
 package com.ibm.crypto.plus.provider.ock;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@SuppressWarnings({"removal", "deprecation"})
 public final class Digest implements Cloneable {
 
     /* ===========================================================================
@@ -56,22 +53,18 @@ public final class Digest implements Cloneable {
 
     static {
         // Configurable number of cached contexts
-        numContexts = AccessController.doPrivileged(new PrivilegedAction<Integer>() {
-            public Integer run() {
-                int numContexts;
-                if (isWindows) {
-                    return 0;
-                } else {
-                    try {
-                        numContexts = Integer
-                                .parseInt(System.getProperty(DIGEST_CONTEXT_CACHE_SIZE, "2048"));
-                    } catch (NumberFormatException e) {
-                        numContexts = 0;
-                    }
-                    return numContexts;
-                }
+        int tmpNumContext = 0;
+        if (isWindows) {
+            tmpNumContext = 0;
+        } else {
+            try {
+                tmpNumContext = Integer
+                        .parseInt(System.getProperty(DIGEST_CONTEXT_CACHE_SIZE, "2048"));
+            } catch (NumberFormatException e) {
+                tmpNumContext = 0;
             }
-        });
+        }
+        numContexts = tmpNumContext;
     }
 
     void getContext() throws OCKException {

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/GCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/GCMCipher.java
@@ -9,8 +9,6 @@
 package com.ibm.crypto.plus.provider.ock;
 
 import java.nio.ByteBuffer;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -19,11 +17,10 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.ShortBufferException;
 
-@SuppressWarnings({"removal", "deprecation"})
 public final class GCMCipher {
 
-    private static final boolean disableGCMAcceleration;
     private static final String DISABLE_GCM_ACCELERATION = "com.ibm.crypto.provider.DisableGCMAcceleration";
+    private static final boolean disableGCMAcceleration = Boolean.parseBoolean(System.getProperty(DISABLE_GCM_ACCELERATION));
     private static final String debPrefix = "GCMCipher";
     private static long GCMHardwareFunctionPtr = 0;
 
@@ -38,14 +35,6 @@ public final class GCMCipher {
     static final int GCM_MODE_DECRYPT = 128;
     static final int GCM_AUGMENTED_MODE = 768;
 
-    static {
-        disableGCMAcceleration = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-            public Boolean run() {
-                return ("true"
-                        .equalsIgnoreCase(System.getProperty(DISABLE_GCM_ACCELERATION, "false")));
-            }
-        });
-    }
     // Buffer to pass GCM input to native
     private static final ThreadLocal<FastJNIBuffer> inputBuffer = new ThreadLocal<FastJNIBuffer>() {
         @Override

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
@@ -12,12 +12,9 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.nio.ByteBuffer;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.security.ProviderException;
 import sun.security.util.Debug;
 
-@SuppressWarnings({"removal", "deprecation"})
 final class NativeInterface {
 
     // User enabled debugging
@@ -43,22 +40,16 @@ final class NativeInterface {
     private static String JVMFIPSmode = null;
 
     static {
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            public Void run() {
-                if (ockDynamicallyLoaded) {
-                    // Preload OCK library. We want to pre-load OCK to help
-                    // ensure we are picking up the expected version within
-                    // the JRE.
-                    //
-                    preloadOCK();
-                }
-
-                // Load native code for java-gskit
-                //
-                preloadJGskit();
-                return null;
-            }
-        });
+        if (ockDynamicallyLoaded) {
+            // Preload OCK library. We want to pre-load OCK to help
+            // ensure we are picking up the expected version within
+            // the JRE.
+            //
+            preloadOCK();
+        }
+        // Load native code for java-gskit
+        //
+        preloadJGskit();
     }
 
     public static String getOsName() {

--- a/src/test/java/ibm/jceplus/junit/base/certificateutils/Debug.java
+++ b/src/test/java/ibm/jceplus/junit/base/certificateutils/Debug.java
@@ -21,7 +21,6 @@ import sun.util.logging.PlatformLogger;
  * A utility class for debuging.
  *
  */
-@SuppressWarnings({"removal", "deprecation"})
 public class Debug {
 
     private String prefix;
@@ -29,18 +28,8 @@ public class Debug {
     private static SimpleConsoleLogger tl = null;
 
     static {
-        args = java.security.AccessController
-                .doPrivileged(new java.security.PrivilegedAction<String>() {
-                    public String run() {
-                        return System.getProperty("java.security.debug");
-                    }
-                });
-        String args2 = java.security.AccessController
-                .doPrivileged(new java.security.PrivilegedAction<String>() {
-                    public String run() {
-                        return System.getProperty("java.security.auth.debug");
-                    }
-                });
+        args = System.getProperty("java.security.debug");
+        String args2 = System.getProperty("java.security.auth.debug");
         if (args == null) {
             args = args2;
         } else {


### PR DESCRIPTION
As described in [JEP 486](https://openjdk.org/jeps/486) the SecurityManager is being disabled in Java 24. This update removes all use of the SecurityManager class and privileged actions.

Back-ported from: #448

Signed-off-by: Jason Katonica <katonica@us.ibm.com>