### PR TITLE
Initialize FastJNIBuffer only when use_z_fast_command is set to true

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/ock/SymmetricCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/SymmetricCipher.java
@@ -46,7 +46,7 @@ public final class SymmetricCipher {
     private final static String badIdMsg = "Cipher Identifier is not valid";
     /* private final static String debPrefix = "SymCipher"; Adding Debug causes test cases to fail */
     int paramOffset;
-    FastJNIBuffer parametersBuffer = FastJNIBuffer.create(PARAM_CAP);
+    FastJNIBuffer parametersBuffer = null;
     // GSKit code adds 16 to the input buffer length for every Update  and provide a 
     // 16  byte buffer for the Final which has no input data.
     private final int OCK_ENCRYPTION_RESIDUE = 16;
@@ -185,6 +185,9 @@ public final class SymmetricCipher {
 
 
         if (use_z_fast_command) {
+            if (parametersBuffer == null) {
+                parametersBuffer = FastJNIBuffer.create(PARAM_CAP);
+            }
             // Calculating pointers/offsets
             // parameters = SymmetricCipher.parametersBuffer.get();
             inputPointer = parametersBuffer.pointer();


### PR DESCRIPTION
This is a back port PR from PR https://github.com/IBM/OpenJCEPlus/pull/450

FastJNIBuffer is initialized every time a SymmetricCipher instance is created, regardless of whether it is used or not. Move the initialization of FastJNIBuffer to occur only when use_z_fast_command is set to true.