### PR TITLE
Migrate to GPLv2 license

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -2,10 +2,9 @@
 #
 # Copyright IBM Corp. 2023
 #
-# Licensed under the Apache License 2.0 (the "License").  You may not use
-# this file except in compliance with the License.  You can obtain a copy
-# in the file LICENSE in the source distribution.
-#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms provided by IBM in the LICENSE file that accompanied
+# this code, including the "Classpath" Exception described therein.
 ###############################################################################
 
 name: GitHub Actions OpenJCEPlus

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,9 @@
 #
 # Copyright IBM Corp. 2023
 #
-# Licensed under the Apache License 2.0 (the "License").  You may not use
-# this file except in compliance with the License.  You can obtain a copy
-# in the file LICENSE in the source distribution.
-#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms provided by IBM in the LICENSE file that accompanied
+# this code, including the "Classpath" Exception described therein.
 ###############################################################################
 
 # Compiled class file

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024, 2025
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 import groovy.json.JsonOutput;

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,342 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+The GNU General Public License (GPL)
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Version 2, June 1991
 
-   1. Definitions.
+Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+Everyone is permitted to copy and distribute verbatim copies of this license
+document, but changing it is not allowed.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+Preamble
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+The licenses for most software are designed to take away your freedom to share
+and change it.  By contrast, the GNU General Public License is intended to
+guarantee your freedom to share and change free software--to make sure the
+software is free for all its users.  This General Public License applies to
+most of the Free Software Foundation's software and to any other program whose
+authors commit to using it.  (Some other Free Software Foundation software is
+covered by the GNU Library General Public License instead.) You can apply it to
+your programs, too.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+When we speak of free software, we are referring to freedom, not price.  Our
+General Public Licenses are designed to make sure that you have the freedom to
+distribute copies of free software (and charge for this service if you wish),
+that you receive source code or can get it if you want it, that you can change
+the software or use pieces of it in new free programs; and that you know you
+can do these things.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+To protect your rights, we need to make restrictions that forbid anyone to deny
+you these rights or to ask you to surrender the rights.  These restrictions
+translate to certain responsibilities for you if you distribute copies of the
+software, or if you modify it.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+For example, if you distribute copies of such a program, whether gratis or for
+a fee, you must give the recipients all the rights that you have.  You must
+make sure that they, too, receive or can get the source code.  And you must
+show them these terms so they know their rights.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+We protect your rights with two steps: (1) copyright the software, and (2)
+offer you this license which gives you legal permission to copy, distribute
+and/or modify the software.
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+Also, for each author's protection and ours, we want to make certain that
+everyone understands that there is no warranty for this free software.  If the
+software is modified by someone else and passed on, we want its recipients to
+know that what they have is not the original, so that any problems introduced
+by others will not reflect on the original authors' reputations.
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+Finally, any free program is threatened constantly by software patents.  We
+wish to avoid the danger that redistributors of a free program will
+individually obtain patent licenses, in effect making the program proprietary.
+To prevent this, we have made it clear that any patent must be licensed for
+everyone's free use or not licensed at all.
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+The precise terms and conditions for copying, distribution and modification
+follow.
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+0. This License applies to any program or other work which contains a notice
+placed by the copyright holder saying it may be distributed under the terms of
+this General Public License.  The "Program", below, refers to any such program
+or work, and a "work based on the Program" means either the Program or any
+derivative work under copyright law: that is to say, a work containing the
+Program or a portion of it, either verbatim or with modifications and/or
+translated into another language.  (Hereinafter, translation is included
+without limitation in the term "modification".) Each licensee is addressed as
+"you".
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+Activities other than copying, distribution and modification are not covered by
+this License; they are outside its scope.  The act of running the Program is
+not restricted, and the output from the Program is covered only if its contents
+constitute a work based on the Program (independent of having been made by
+running the Program).  Whether that is true depends on what the Program does.
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+1. You may copy and distribute verbatim copies of the Program's source code as
+you receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice and
+disclaimer of warranty; keep intact all the notices that refer to this License
+and to the absence of any warranty; and give any other recipients of the
+Program a copy of this License along with the Program.
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+You may charge a fee for the physical act of transferring a copy, and you may
+at your option offer warranty protection in exchange for a fee.
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+2. You may modify your copy or copies of the Program or any portion of it, thus
+forming a work based on the Program, and copy and distribute such modifications
+or work under the terms of Section 1 above, provided that you also meet all of
+these conditions:
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+    a) You must cause the modified files to carry prominent notices stating
+    that you changed the files and the date of any change.
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+    b) You must cause any work that you distribute or publish, that in whole or
+    in part contains or is derived from the Program or any part thereof, to be
+    licensed as a whole at no charge to all third parties under the terms of
+    this License.
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+    c) If the modified program normally reads commands interactively when run,
+    you must cause it, when started running for such interactive use in the
+    most ordinary way, to print or display an announcement including an
+    appropriate copyright notice and a notice that there is no warranty (or
+    else, saying that you provide a warranty) and that users may redistribute
+    the program under these conditions, and telling the user how to view a copy
+    of this License.  (Exception: if the Program itself is interactive but does
+    not normally print such an announcement, your work based on the Program is
+    not required to print an announcement.)
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+These requirements apply to the modified work as a whole.  If identifiable
+sections of that work are not derived from the Program, and can be reasonably
+considered independent and separate works in themselves, then this License, and
+its terms, do not apply to those sections when you distribute them as separate
+works.  But when you distribute the same sections as part of a whole which is a
+work based on the Program, the distribution of the whole must be on the terms
+of this License, whose permissions for other licensees extend to the entire
+whole, and thus to each and every part regardless of who wrote it.
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+Thus, it is not the intent of this section to claim rights or contest your
+rights to work written entirely by you; rather, the intent is to exercise the
+right to control the distribution of derivative or collective works based on
+the Program.
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+In addition, mere aggregation of another work not based on the Program with the
+Program (or with a work based on the Program) on a volume of a storage or
+distribution medium does not bring the other work under the scope of this
+License.
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
+3. You may copy and distribute the Program (or a work based on it, under
+Section 2) in object code or executable form under the terms of Sections 1 and
+2 above provided that you also do one of the following:
 
-   END OF TERMS AND CONDITIONS
+    a) Accompany it with the complete corresponding machine-readable source
+    code, which must be distributed under the terms of Sections 1 and 2 above
+    on a medium customarily used for software interchange; or,
 
-   APPENDIX: How to apply the Apache License to your work.
+    b) Accompany it with a written offer, valid for at least three years, to
+    give any third party, for a charge no more than your cost of physically
+    performing source distribution, a complete machine-readable copy of the
+    corresponding source code, to be distributed under the terms of Sections 1
+    and 2 above on a medium customarily used for software interchange; or,
 
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
+    c) Accompany it with the information you received as to the offer to
+    distribute corresponding source code.  (This alternative is allowed only
+    for noncommercial distribution and only if you received the program in
+    object code or executable form with such an offer, in accord with
+    Subsection b above.)
 
-   Copyright 2023 IBM Corp.
+The source code for a work means the preferred form of the work for making
+modifications to it.  For an executable work, complete source code means all
+the source code for all modules it contains, plus any associated interface
+definition files, plus the scripts used to control compilation and installation
+of the executable.  However, as a special exception, the source code
+distributed need not include anything that is normally distributed (in either
+source or binary form) with the major components (compiler, kernel, and so on)
+of the operating system on which the executable runs, unless that component
+itself accompanies the executable.
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+If distribution of executable or object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the source
+code from the same place counts as distribution of the source code, even though
+third parties are not compelled to copy the source along with the object code.
 
-       http://www.apache.org/licenses/LICENSE-2.0
+4. You may not copy, modify, sublicense, or distribute the Program except as
+expressly provided under this License.  Any attempt otherwise to copy, modify,
+sublicense or distribute the Program is void, and will automatically terminate
+your rights under this License.  However, parties who have received copies, or
+rights, from you under this License will not have their licenses terminated so
+long as such parties remain in full compliance.
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+5. You are not required to accept this License, since you have not signed it.
+However, nothing else grants you permission to modify or distribute the Program
+or its derivative works.  These actions are prohibited by law if you do not
+accept this License.  Therefore, by modifying or distributing the Program (or
+any work based on the Program), you indicate your acceptance of this License to
+do so, and all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the Program),
+the recipient automatically receives a license from the original licensor to
+copy, distribute or modify the Program subject to these terms and conditions.
+You may not impose any further restrictions on the recipients' exercise of the
+rights granted herein.  You are not responsible for enforcing compliance by
+third parties to this License.
+
+7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues), conditions
+are imposed on you (whether by court order, agreement or otherwise) that
+contradict the conditions of this License, they do not excuse you from the
+conditions of this License.  If you cannot distribute so as to satisfy
+simultaneously your obligations under this License and any other pertinent
+obligations, then as a consequence you may not distribute the Program at all.
+For example, if a patent license would not permit royalty-free redistribution
+of the Program by all those who receive copies directly or indirectly through
+you, then the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply and
+the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or
+other property right claims or to contest validity of any such claims; this
+section has the sole purpose of protecting the integrity of the free software
+distribution system, which is implemented by public license practices.  Many
+people have made generous contributions to the wide range of software
+distributed through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing to
+distribute software through any other system and a licensee cannot impose that
+choice.
+
+This section is intended to make thoroughly clear what is believed to be a
+consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in certain
+countries either by patents or by copyrighted interfaces, the original
+copyright holder who places the Program under this License may add an explicit
+geographical distribution limitation excluding those countries, so that
+distribution is permitted only in or among countries not thus excluded.  In
+such case, this License incorporates the limitation as if written in the body
+of this License.
+
+9. The Free Software Foundation may publish revised and/or new versions of the
+General Public License from time to time.  Such new versions will be similar in
+spirit to the present version, but may differ in detail to address new problems
+or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any later
+version", you have the option of following the terms and conditions either of
+that version or of any later version published by the Free Software Foundation.
+If the Program does not specify a version number of this License, you may
+choose any version ever published by the Free Software Foundation.
+
+10. If you wish to incorporate parts of the Program into other free programs
+whose distribution conditions are different, write to the author to ask for
+permission.  For software which is copyrighted by the Free Software Foundation,
+write to the Free Software Foundation; we sometimes make exceptions for this.
+Our decision will be guided by the two goals of preserving the free status of
+all derivatives of our free software and of promoting the sharing and reuse of
+software generally.
+
+NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR
+THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN OTHERWISE
+STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE
+PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND
+PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE,
+YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL
+ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE
+PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR
+INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA
+BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER
+OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible
+use to the public, the best way to achieve this is to make it free software
+which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program.  It is safest to attach
+them to the start of each source file to most effectively convey the exclusion
+of warranty; and each file should have at least the "copyright" line and a
+pointer to where the full notice is found.
+
+    One line to give the program's name and a brief idea of what it does.
+
+    Copyright (C) <year> <name of author>
+
+    This program is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the Free
+    Software Foundation; either version 2 of the License, or (at your option)
+    any later version.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+    more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this when it
+starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author Gnomovision comes
+    with ABSOLUTELY NO WARRANTY; for details type 'show w'.  This is free
+    software, and you are welcome to redistribute it under certain conditions;
+    type 'show c' for details.
+
+The hypothetical commands 'show w' and 'show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may be
+called something other than 'show w' and 'show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.  Here
+is a sample; alter the names:
+
+    Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+    'Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+    signature of Ty Coon, 1 April 1989
+
+    Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General Public
+License instead of this License.
+
+"CLASSPATH" EXCEPTION TO THE GPL
+
+This Program is subject to the following clarification and special exception to the GPL:
+
+    Linking this library statically or dynamically with other modules is making
+    a combined work based on this library.  Thus, the terms and conditions of
+    the GNU General Public License cover the whole combination.
+
+    As a special exception, the copyright holders of this library give you
+    permission to link this library with independent modules to produce an
+    executable, regardless of the license terms of these independent modules,
+    and to copy and distribute the resulting executable under terms of your
+    choice, provided that you also meet, for each linked independent module,
+    the terms and conditions of the license of that module.  An independent
+    module is a module which is not derived from or based on this library.  If
+    you modify this library, you may extend this exception to your version of
+    the library, but you are not obligated to do so.  If you do not wish to do
+    so, delete this exception statement from your version.

--- a/NOTICES.md
+++ b/NOTICES.md
@@ -1,0 +1,13 @@
+# Notices for OpenJCEPlus
+
+* Project home: https://github.com/IBM/OpenJCEPlus
+
+## Trademarks
+
+Java and all Java-based trademarks are trademarks of Oracle Corporation in the United States, other countries, or both.
+
+## Applicable Licenses
+
+The GNU General Public License (GPL) Version 2 with "Classpath" exceptions. See this projects included LICENCE file located at https://github.com/IBM/OpenJCEPlus/blob/main/LICENSE for more details.
+
+Portions of OpenJCEPlus may be based on code made available by Oracle in OpenJDK files designated as subject to the Oracle ClassPath Exception described at https://openjdk.org/legal/gplv2+ce.html. Such code is copyright Oracle America, Inc. or its affiliates.

--- a/README.md
+++ b/README.md
@@ -359,6 +359,10 @@ Signature                   | SHA512withRSA              |X                |X   
 
 The following contribution guidelines should be followed:
 
+1. View this projects [LICENSE](LICENSE) file. Be sure terms and conditions are acceptable.
+
+1. View this projects [NOTICES.md](NOTICES.md) file. Be sure terms and conditions are acceptable.
+
 1. Java code should be styled according to the included [style.xml](style.xml) eclipse rules.
 
 1. C code should be styled using the clang-format tool using the included [.clang-format](.clang-format) rules.

--- a/assembly.xml
+++ b/assembly.xml
@@ -3,10 +3,9 @@
 #
 # Copyright IBM Corp. 2024
 #
-# Licensed under the Apache License 2.0 (the "License").  You may not use
-# this file except in compliance with the License.  You can obtain a copy
-# in the file LICENSE in the source distribution.
-#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms provided by IBM in the LICENSE file that accompanied
+# this code, including the "Classpath" Exception described therein.
 ###############################################################################
 -->
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/buildNative.sh
+++ b/buildNative.sh
@@ -4,10 +4,9 @@
 #
 # Copyright IBM Corp. 2023
 #
-# Licensed under the Apache License 2.0 (the "License").  You may not use
-# this file except in compliance with the License.  You can obtain a copy
-# in the file LICENSE in the source distribution.
-#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms provided by IBM in the LICENSE file that accompanied
+# this code, including the "Classpath" Exception described therein.
 ###############################################################################
 
 PLATFORMS=(arm-linux64 ppc-aix64 ppcle-linux64 s390-linux64 s390-zos64 x86-linux64)

--- a/buildNativeMac.sh
+++ b/buildNativeMac.sh
@@ -4,10 +4,9 @@
 #
 # Copyright IBM Corp. 2023
 #
-# Licensed under the Apache License 2.0 (the "License").  You may not use
-# this file except in compliance with the License.  You can obtain a copy
-# in the file LICENSE in the source distribution.
-#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms provided by IBM in the LICENSE file that accompanied
+# this code, including the "Classpath" Exception described therein.
 ###############################################################################
 
 if [ -z "$JAVA_HOME" ]; 

--- a/buildNativeWin64.bat
+++ b/buildNativeWin64.bat
@@ -2,10 +2,9 @@
 ::#
 ::# Copyright IBM Corp. 2023
 ::#
-::# Licensed under the Apache License 2.0 (the "License").  You may not use
-::# this file except in compliance with the License.  You can obtain a copy
-::# in the file LICENSE in the source distribution.
-::#
+::# This code is free software; you can redistribute it and/or modify it
+::# under the terms provided by IBM in the LICENSE file that accompanied
+::# this code, including the "Classpath" Exception described therein.
 ::#############################################################################
 
 @echo off

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -4,10 +4,9 @@
 #
 # Copyright IBM Corp. 2023
 #
-# Licensed under the Apache License 2.0 (the "License").  You may not use
-# this file except in compliance with the License.  You can obtain a copy
-# in the file LICENSE in the source distribution.
-#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms provided by IBM in the LICENSE file that accompanied
+# this code, including the "Classpath" Exception described therein.
 ###############################################################################
 -->
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
@@ -31,7 +30,7 @@
     <module name="NewlineAtEndOfFile"/>
     <module name="RegexpHeader">
         <property name="fileExtensions" value="java"/>
-        <property name="header" value="^\W.*\n^.*Copyright IBM Corp\. \d\d\d\d\n^\W.*\n^\W.*. Licensed under the Apache License 2.0 \(the &quot;License&quot;\).  You may not use\n^\W.* this file except in compliance with the License.  You can obtain a copy\n^\W.* in the file LICENSE in the source distribution.\n^\W"/>
+        <property name="header" value="^\W.*\n^.*Copyright IBM Corp\. \d\d\d\d\n^\W.*\n^\W.*. This code is free software; you can redistribute it and/or modify it\n^\W.*. under the terms provided by IBM in the LICENSE file that accompanied\n^\W.*. this code, including the &quot;Classpath&quot; Exception described therein."/>
     </module>
     <module name="FileTabCharacter"/>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -3,10 +3,9 @@
 #
 # Copyright IBM Corp. 2023, 2024
 #
-# Licensed under the Apache License 2.0 (the "License").  You may not use
-# this file except in compliance with the License.  You can obtain a copy
-# in the file LICENSE in the source distribution.
-#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms provided by IBM in the LICENSE file that accompanied
+# this code, including the "Classpath" Exception described therein.
 ###############################################################################
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/main/java/com/ibm/crypto/plus/provider/AESCCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESCCMCipher.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/AESCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESCipher.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/AESConstants.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESConstants.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/AESGCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESGCMCipher.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/AESKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/AESKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/AESKeyGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKeyGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/AESParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESParameters.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/AESUtils.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESUtils.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/CCMConstants.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/CCMConstants.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/CCMParameterGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/CCMParameterGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/CCMParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/CCMParameters.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Cipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Cipher.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Constants.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Constants.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Key.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Key.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Parameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Parameters.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Poly1305Cipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Poly1305Cipher.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Poly1305Parameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Poly1305Parameters.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ConstructKeys.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ConstructKeys.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/CurveDB.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/CurveDB.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/CurveUtil.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/CurveUtil.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DESConstants.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESConstants.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeCipher.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeKeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeKeyGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeKeyGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeParameters.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHKeyAgreement.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DHKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHKeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DHKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHKeyPairGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DHParameterGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHParameterGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DHParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHParameters.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DHPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHPublicKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DHUtils.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHUtils.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2025
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAKeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAKeyPairGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAParameterGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAParameterGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAParameters.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAPrivateKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAPublicKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DSASignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DSASignatureNONE.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSASignatureNONE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/DatawithECDSA.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DatawithECDSA.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ECDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECDHKeyAgreement.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ECDSASignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECDSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ECKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECKeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ECKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECKeyPairGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ECNamedCurve.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECNamedCurve.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ECParameterGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECParameterGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ECParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECParameters.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ECPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECPublicKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ECUtils.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECUtils.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAKeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAKeyPairGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAPrivateKeyImpl.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAPublicKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAPublicKeyImpl.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSASignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/GCMConstants.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/GCMConstants.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/GCMParameterGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/GCMParameterGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/GCMParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/GCMParameters.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/HASHDRBG.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/HASHDRBG.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/HKDFGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/HKDFGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/HmacCore.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/HmacCore.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/HmacKeyGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/HmacKeyGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/MessageDigest.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/MessageDigest.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/NamedCurve.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/NamedCurve.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/OAEPParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OAEPParameters.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2025
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2025
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/PBKDF2Core.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PBKDF2Core.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2025
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/PBKDF2KeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PBKDF2KeyImpl.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2025
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/PSSParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PSSParameters.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/Poly1305Constants.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/Poly1305Constants.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ProviderContext.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ProviderContext.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/RSA.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSA.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAKeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAKeyPairGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPSSSignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPSSSignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateCrtKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateCrtKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPublicKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/RSASignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/RSASignatureNONE.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSASignatureNONE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 //----------------------------------------------------------------------------

--- a/src/main/java/com/ibm/crypto/plus/provider/RSASignatureSSL.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSASignatureSSL.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 //----------------------------------------------------------------------------

--- a/src/main/java/com/ibm/crypto/plus/provider/RSASignatureSSL_I2.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSASignatureSSL_I2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 //----------------------------------------------------------------------------

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAUtil.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAUtil.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/TlsKeyMaterialGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/TlsKeyMaterialGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/TlsMasterSecretGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/TlsMasterSecretGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/TlsPrfGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/TlsPrfGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/TlsRsaPremasterSecretGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/TlsRsaPremasterSecretGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyPairGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/AsymmetricKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/AsymmetricKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/BasicRandom.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/BasicRandom.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/ByteArrayOutputDelay.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/ByteArrayOutputDelay.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package com.ibm.crypto.plus.provider.ock;
 

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/CCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/CCMCipher.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/DHKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/DHKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/DSAKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/DSAKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/Digest.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/Digest.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/ECKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/ECKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/ExtendedRandom.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/ExtendedRandom.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/FastJNIBuffer.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/FastJNIBuffer.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/GCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/GCMCipher.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/HKDF.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/HKDF.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/HMAC.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/HMAC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/IOScheme.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/IOScheme.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2025
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/OCKContext.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/OCKContext.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/OCKDebug.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/OCKDebug.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/OCKException.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/OCKException.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/PBKDF.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/PBKDF.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2025
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/Padding.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/Padding.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/Poly1305Cipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/Poly1305Cipher.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/RSACipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/RSACipher.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/RSAKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/RSAKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/RSAPadding.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/RSAPadding.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/Signature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/Signature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/SignatureDSANONE.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/SignatureDSANONE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/SignatureEdDSA.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/SignatureEdDSA.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/SignatureRSAPSS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/SignatureRSAPSS.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/SignatureRSASSL.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/SignatureRSASSL.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/SymmetricCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/SymmetricCipher.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/XECKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/XECKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package com.ibm.crypto.plus.provider.ock;

--- a/src/main/java/ibm/security/internal/spec/CCMParameterSpec.java
+++ b/src/main/java/ibm/security/internal/spec/CCMParameterSpec.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.security.internal.spec;

--- a/src/main/java/ibm/security/internal/spec/HKDFExpandParameterSpec.java
+++ b/src/main/java/ibm/security/internal/spec/HKDFExpandParameterSpec.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.security.internal.spec;

--- a/src/main/java/ibm/security/internal/spec/HKDFExtractParameterSpec.java
+++ b/src/main/java/ibm/security/internal/spec/HKDFExtractParameterSpec.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.security.internal.spec;

--- a/src/main/java/ibm/security/internal/spec/HKDFParameterSpec.java
+++ b/src/main/java/ibm/security/internal/spec/HKDFParameterSpec.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.security.internal.spec;

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 module openjceplus {

--- a/src/main/native/BasicRandom.c
+++ b/src/main/native/BasicRandom.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/BuildDate.c
+++ b/src/main/native/BuildDate.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/CCM.c
+++ b/src/main/native/CCM.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 #include <jni.h>
 #include <stdio.h>

--- a/src/main/native/Context.h
+++ b/src/main/native/Context.h
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #ifndef _CONTEXT_H

--- a/src/main/native/DHKey.c
+++ b/src/main/native/DHKey.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/DSAKey.c
+++ b/src/main/native/DSAKey.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/Digest.c
+++ b/src/main/native/Digest.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/Digest.h
+++ b/src/main/native/Digest.h
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #ifndef _DIGEST_H

--- a/src/main/native/ECKey.c
+++ b/src/main/native/ECKey.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/ExceptionCodes.h
+++ b/src/main/native/ExceptionCodes.h
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #ifndef _EXCEPTION_CODES_H

--- a/src/main/native/ExtendedRandom.c
+++ b/src/main/native/ExtendedRandom.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/GCM.c
+++ b/src/main/native/GCM.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 #include <jni.h>
 #include <stdio.h>

--- a/src/main/native/HKDF.c
+++ b/src/main/native/HKDF.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/HMAC.c
+++ b/src/main/native/HMAC.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/PBKDF.c
+++ b/src/main/native/PBKDF.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2025
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/PKey.c
+++ b/src/main/native/PKey.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/Padding.h
+++ b/src/main/native/Padding.h
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #ifndef _PADDING_H

--- a/src/main/native/Poly1305Cipher.c
+++ b/src/main/native/Poly1305Cipher.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/RSA.c
+++ b/src/main/native/RSA.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/RSAKey.c
+++ b/src/main/native/RSAKey.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/RSAPadding.h
+++ b/src/main/native/RSAPadding.h
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #ifndef _RSAPADDING_H

--- a/src/main/native/RsaPss.c
+++ b/src/main/native/RsaPss.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/RsaPss.h
+++ b/src/main/native/RsaPss.h
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #ifndef _RsaPss_H

--- a/src/main/native/Signature.c
+++ b/src/main/native/Signature.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/SignatureDSANONE.c
+++ b/src/main/native/SignatureDSANONE.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/SignatureEdDSA.c
+++ b/src/main/native/SignatureEdDSA.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/SignatureRSASSL.c
+++ b/src/main/native/SignatureRSASSL.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/StaticStub.c
+++ b/src/main/native/StaticStub.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/SymmetricCipher.c
+++ b/src/main/native/SymmetricCipher.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/Utils.c
+++ b/src/main/native/Utils.c
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <jni.h>

--- a/src/main/native/Utils.h
+++ b/src/main/native/Utils.h
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #ifndef _UTILS_H

--- a/src/main/native/jgskit.mac.mak
+++ b/src/main/native/jgskit.mac.mak
@@ -2,10 +2,9 @@
 #
 # Copyright IBM Corp. 2023, 2025
 #
-# Licensed under the Apache License 2.0 (the "License").  You may not use
-# this file except in compliance with the License.  You can obtain a copy
-# in the file LICENSE in the source distribution.
-#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms provided by IBM in the LICENSE file that accompanied
+# this code, including the "Classpath" Exception described therein.
 ###############################################################################
 
 TOPDIR=../../..

--- a/src/main/native/jgskit.mak
+++ b/src/main/native/jgskit.mak
@@ -2,10 +2,9 @@
 #
 # Copyright IBM Corp. 2023, 2025
 #
-# Licensed under the Apache License 2.0 (the "License").  You may not use
-# this file except in compliance with the License.  You can obtain a copy
-# in the file LICENSE in the source distribution.
-#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms provided by IBM in the LICENSE file that accompanied
+# this code, including the "Classpath" Exception described therein.
 ###############################################################################
 
 TOPDIR=../../..

--- a/src/main/native/jgskit.win64.cygwin.mak
+++ b/src/main/native/jgskit.win64.cygwin.mak
@@ -2,10 +2,9 @@
 #
 # Copyright IBM Corp. 2023, 2025
 #
-# Licensed under the Apache License 2.0 (the "License").  You may not use
-# this file except in compliance with the License.  You can obtain a copy
-# in the file LICENSE in the source distribution.
-#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms provided by IBM in the LICENSE file that accompanied
+# this code, including the "Classpath" Exception described therein.
 ###############################################################################
 
 TOPDIR = $(MAKEDIR)\..\..\..

--- a/src/main/native/jgskit.win64.mak
+++ b/src/main/native/jgskit.win64.mak
@@ -2,10 +2,9 @@
 #
 # Copyright IBM Corp. 2023, 2025
 #
-# Licensed under the Apache License 2.0 (the "License").  You may not use
-# this file except in compliance with the License.  You can obtain a copy
-# in the file LICENSE in the source distribution.
-#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms provided by IBM in the LICENSE file that accompanied
+# this code, including the "Classpath" Exception described therein.
 ###############################################################################
 
 TOPDIR = $(MAKEDIR)../../..

--- a/src/main/native/jgskit_resource.rc
+++ b/src/main/native/jgskit_resource.rc
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 #include <winver.h>
@@ -30,7 +30,7 @@ BEGIN
             VALUE "FileVersion", "23\0"
 	        VALUE "Build Increment", "0\0"
             VALUE "InternalName", "jgskit.dll\0"
-            VALUE "LegalCopyright", "(C) Copyright IBM Corp. 2023, 2024. Licensed under the Apache License 2.0.\0"
+            VALUE "LegalCopyright", "(C) Copyright IBM Corp. 2023, 2024. Licensed under the GLP v2 plus classpath exception. See LICENSE file associated with source.\0"
             VALUE "OriginalFilename", "jgskit.dll\0"
             VALUE "ProductName", "OpenJCEPlus Crypto Provider for Windows, 23.0\0"
             VALUE "ProductVersion", "23.0\0"

--- a/src/main/native/zHardwareFunctions.h
+++ b/src/main/native/zHardwareFunctions.h
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 typedef size_t UDATA;

--- a/src/test/java/ibm/jceplus/junit/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/TestAll.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit;

--- a/src/test/java/ibm/jceplus/junit/TestIntegration.java
+++ b/src/test/java/ibm/jceplus/junit/TestIntegration.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit;
 

--- a/src/test/java/ibm/jceplus/junit/TestMemStressAll.java
+++ b/src/test/java/ibm/jceplus/junit/TestMemStressAll.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit;

--- a/src/test/java/ibm/jceplus/junit/TestMultithread.java
+++ b/src/test/java/ibm/jceplus/junit/TestMultithread.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit;

--- a/src/test/java/ibm/jceplus/junit/TestMultithreadFIPS.java
+++ b/src/test/java/ibm/jceplus/junit/TestMultithreadFIPS.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseByteArrayOutputDelayTest.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseByteArrayOutputDelayTest.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAES.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAES.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCM.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCM.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCM2.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCM2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCMInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCMInteropBC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCMParameters.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCMParameters.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESCipherInputStreamExceptions.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESCipherInputStreamExceptions.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESCopySafe.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESCopySafe.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMBufferIV.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMBufferIV.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMCICOWithGCM.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMCICOWithGCM.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMCICOWithGCMAndAAD.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMCICOWithGCMAndAAD.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMLong.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMLong.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMNonExpanding.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMNonExpanding.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMSameBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMSameBuffer.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMUpdate.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMUpdateInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMUpdateInteropBC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMWithByteBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMWithByteBuffer.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMWithKeyAndIvCheck.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMWithKeyAndIvCheck.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM_ExtIV.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM_ExtIV.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM_IntIV.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM_IntIV.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 /*

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20KAT.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20KAT.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20NoReuse.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20NoReuse.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20Poly1305.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20Poly1305.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20Poly1305ByteBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20Poly1305ByteBuffer.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20Poly1305ChunkUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20Poly1305ChunkUpdate.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestCipher.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestCipher.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDESede.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDESede.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDH.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDHInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDHInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDHKeyFactory.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDHKeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDHKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDHKeyPairGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDHMultiParty.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDHMultiParty.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDSAKey.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDSAKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDSASignatureInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDSASignatureInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDSASignatureInterop2.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDSASignatureInterop2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDH.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDHInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDHInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDHKeyAgreementParamValidation.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDHKeyAgreementParamValidation.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDHMultiParty.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDHMultiParty.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDSASignatureInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDSASignatureInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDSASignatureInterop2.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDSASignatureInterop2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyImport.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyImport.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyImportInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyImportInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyPairGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestEdDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestEdDSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestEdDSASignatureInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestEdDSASignatureInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHKDF.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHKDF.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHKDFInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHKDFInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacMD5.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacMD5.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacMD5Interop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacMD5Interop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA1.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA1.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA1Interop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA1Interop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA224.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA224.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA224Interop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA224Interop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA256.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA256Interop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA256Interop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA384.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA384.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA384Interop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA384Interop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA3_224.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA3_224.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA3_256.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA3_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA3_384.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA3_384.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA3_512.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA3_512.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA512.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA512.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA512Interop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA512Interop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestImplementationClassesExist.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestImplementationClassesExist.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestImplementationClassesFinal.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestImplementationClassesFinal.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestInvalidArrayIndex.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestInvalidArrayIndex.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestIsAssignableFromOrder.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestIsAssignableFromOrder.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestJunit5.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestJunit5.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 abstract public class BaseTestJunit5 {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestJunit5Interop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestJunit5Interop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestJunit5Signature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestJunit5Signature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestMD5.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestMD5.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestMessageDigestClone.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestMessageDigestClone.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestMiniRSAPSS2.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestMiniRSAPSS2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPBKDF2.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPBKDF2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2025
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPBKDF2Interop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPBKDF2Interop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2025
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPublicMethodsToMakeNonPublic.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPublicMethodsToMakeNonPublic.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSA.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSA.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKey.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInteropBC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSS.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSS.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 // A test program to test all DSA classes

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSS2.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSS2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 // A test program to test all DSA classes

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop2.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop3.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop3.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSSignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSSignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSASignatureChunkUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSASignatureChunkUpdate.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSASignatureInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSASignatureInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSATypeCheckDisabled.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSATypeCheckDisabled.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSATypeCheckEnabled.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSATypeCheckEnabled.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestResetByteBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestResetByteBuffer.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA1.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA1.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA224.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA224.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA256.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA256Clone_SharedMD.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA256Clone_SharedMD.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA384.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA384.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_224KAT.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_224KAT.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_256KAT.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_256KAT.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_384KAT.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_384KAT.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_512KAT.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_512KAT.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA512.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA512.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA512_224.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA512_224.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA512_256.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA512_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSignatureInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSignatureInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestTruncatedDigest.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestTruncatedDigest.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDHInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDHInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyImport.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyImport.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyPairGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDHMultiParty.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDHMultiParty.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/BaseUtils.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseUtils.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/Record.java
+++ b/src/test/java/ibm/jceplus/junit/base/Record.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base;

--- a/src/test/java/ibm/jceplus/junit/base/certificateutils/CertAndKeyGen.java
+++ b/src/test/java/ibm/jceplus/junit/base/certificateutils/CertAndKeyGen.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.certificateutils;

--- a/src/test/java/ibm/jceplus/junit/base/certificateutils/CertificationRequest.java
+++ b/src/test/java/ibm/jceplus/junit/base/certificateutils/CertificationRequest.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.certificateutils;

--- a/src/test/java/ibm/jceplus/junit/base/certificateutils/CertificationRequestInfo.java
+++ b/src/test/java/ibm/jceplus/junit/base/certificateutils/CertificationRequestInfo.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.certificateutils;

--- a/src/test/java/ibm/jceplus/junit/base/certificateutils/Debug.java
+++ b/src/test/java/ibm/jceplus/junit/base/certificateutils/Debug.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.certificateutils;

--- a/src/test/java/ibm/jceplus/junit/base/certificateutils/PKCSDerObject.java
+++ b/src/test/java/ibm/jceplus/junit/base/certificateutils/PKCSDerObject.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.certificateutils;

--- a/src/test/java/ibm/jceplus/junit/base/certificateutils/PKCSException.java
+++ b/src/test/java/ibm/jceplus/junit/base/certificateutils/PKCSException.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.certificateutils;

--- a/src/test/java/ibm/jceplus/junit/base/certificateutils/X500Signer.java
+++ b/src/test/java/ibm/jceplus/junit/base/certificateutils/X500Signer.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.certificateutils;

--- a/src/test/java/ibm/jceplus/junit/base/integration/BaseTestTLS.java
+++ b/src/test/java/ibm/jceplus/junit/base/integration/BaseTestTLS.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base.integration;
 

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressAES.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressAES.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base.memstress;
 

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressAESGCM.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressAESGCM.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.memstress;

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressChaCha20Poly1305.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressChaCha20Poly1305.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.memstress;

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDH.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.memstress;

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDHKeyFactory.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDHKeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base.memstress;
 

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDHKeyPair.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDHKeyPair.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base.memstress;
 

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDSAKeyFactory.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDSAKeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.memstress;

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDSAKeyPair.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDSAKeyPair.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base.memstress;
 

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.memstress;

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDigest.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDigest.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.memstress;

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressECDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressECDSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base.memstress;
 

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressECKeyFactory.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressECKeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base.memstress;
 

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressECKeyPair.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressECKeyPair.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.memstress;

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressHKDF.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressHKDF.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.memstress;

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressHmacSHA.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressHmacSHA.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base.memstress;
 

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressRSAKeyFactory.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressRSAKeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.base.memstress;
 

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressRSAKeyPair.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressRSAKeyPair.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.memstress;

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressRSAPSS2.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressRSAPSS2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.memstress;

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressRSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressRSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.memstress;

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressSHA.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressSHA.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.memstress;

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressSHAClone.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressSHAClone.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.memstress;

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressXDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressXDH.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.base.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAES.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAES.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.openjceplus;
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAES256Interop.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAES256Interop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESCCM.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESCCM.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESCCM2.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESCCM2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESCCMInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESCCMInteropBC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESCCMParameters.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESCCMParameters.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESCipherInputStreamExceptions.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESCipherInputStreamExceptions.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESCopySafe.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESCopySafe.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCM.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCM.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMBufferIV.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMBufferIV.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMCICOWithGCM.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMCICOWithGCM.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMCICOWithGCMAndAAD.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMCICOWithGCMAndAAD.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMLong.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMLong.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMNonExpanding.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMNonExpanding.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMSameBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMSameBuffer.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMUpdate.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMUpdateInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMUpdateInteropBC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMWithByteBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMWithByteBuffer.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMWithKeyAndIvCheck.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCMWithKeyAndIvCheck.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCM_128.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCM_128.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCM_192.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCM_192.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCM_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCM_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCM_ExtIV.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCM_ExtIV.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCM_IntIV.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESGCM_IntIV.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAES_128.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAES_128.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.openjceplus;
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAES_192.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAES_192.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.openjceplus;
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAES_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAES_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.openjceplus;
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAliases.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAliases.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAll.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2025
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestByteArrayOutputDelay.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestByteArrayOutputDelay.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestChaCha20.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestChaCha20.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestChaCha20KAT.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestChaCha20KAT.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestChaCha20NoReuse.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestChaCha20NoReuse.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestChaCha20Poly1305.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestChaCha20Poly1305.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestChaCha20Poly1305ByteBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestChaCha20Poly1305ByteBuffer.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestChaCha20Poly1305ChunkUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestChaCha20Poly1305ChunkUpdate.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestDESede.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestDESede.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestDH.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestDH.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestDHInteropSunJCE.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestDHInteropSunJCE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestDHKeyFactory.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestDHKeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestDHKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestDHKeyPairGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestDHMultiParty.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestDHMultiParty.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestDSAKey.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestDSAKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestDSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestDSASignatureInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestDSASignatureInteropBC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestDSASignatureInteropSUN.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestDSASignatureInteropSUN.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestECDH.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestECDH.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestECDHInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestECDHInteropBC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestECDHInteropSunEC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestECDHInteropSunEC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestECDHKeyAgreementParamValidation.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestECDHKeyAgreementParamValidation.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.openjceplus;
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestECDHMultiParty.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestECDHMultiParty.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestECDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestECDSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestECDSASignatureInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestECDSASignatureInteropBC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestECDSASignatureInteropSunEC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestECDSASignatureInteropSunEC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestECKeyImport.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestECKeyImport.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestECKeyImportInteropSunEC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestECKeyImportInteropSunEC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestECKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestECKeyPairGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestEdDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestEdDSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestEdDSASignatureInterop.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestEdDSASignatureInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestHKDF.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestHKDF.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestHKDFInterop.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestHKDFInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacMD5.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacMD5.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacMD5InteropSunJCE.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacMD5InteropSunJCE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA1.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA1.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA1InteropSunJCE.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA1InteropSunJCE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA224.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA224.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA224InteropSunJCE.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA224InteropSunJCE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA256InteropSunJCE.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA256InteropSunJCE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA384.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA384.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA384InteropSunJCE.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA384InteropSunJCE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA3_224.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA3_224.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA3_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA3_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA3_384.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA3_384.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA3_512.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA3_512.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA512.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA512.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA512InteropSunJCE.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestHmacSHA512InteropSunJCE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestImplementationClassesExist.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestImplementationClassesExist.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestImplementationClassesFinal.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestImplementationClassesFinal.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestInvalidArrayIndex.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestInvalidArrayIndex.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestIsAssignableFromOrder.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestIsAssignableFromOrder.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestMD5.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestMD5.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestMiniRSAPSS2.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestMiniRSAPSS2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestPBKDF2.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestPBKDF2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2025
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestPBKDF2Interop.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestPBKDF2Interop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2025
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestPublicMethodsToMakeNonPublic.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestPublicMethodsToMakeNonPublic.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSA.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSA.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAKey.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAKeyInterop.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAKeyInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAKeyInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAKeyInteropBC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAPSS.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAPSS.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAPSS2.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAPSS2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAPSSInterop.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAPSSInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAPSSInterop2.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAPSSInterop2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAPSSInterop3.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAPSSInterop3.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAPSSSignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSAPSSSignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSASignatureChunkUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSASignatureChunkUpdate.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSASignatureInteropSunRsaSign.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSASignatureInteropSunRsaSign.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSATypeCheckDefault.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSATypeCheckDefault.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSATypeCheckDisabled.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSATypeCheckDisabled.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSATypeCheckEnabled.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSATypeCheckEnabled.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSA_1024.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSA_1024.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSA_2048.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSA_2048.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSA_4096.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSA_4096.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestRSA_512.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestRSA_512.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestResetByteBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestResetByteBuffer.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA1.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA1.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA224.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA224.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA384.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA384.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA3_224.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA3_224.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.openjceplus;
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA3_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA3_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA3_384.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA3_384.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA3_512.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA3_512.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA512.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA512.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA512_224.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA512_224.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA512_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestSHA512_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestTruncatedDigest.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestTruncatedDigest.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestXDH.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestXDH.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestXDHInterop.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestXDHInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestXDHInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestXDHInteropBC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestXDHKeyImport.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestXDHKeyImport.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestXDHKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestXDHKeyPairGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestXDHMultiParty.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestXDHMultiParty.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/Utils.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/Utils.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/integration/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/integration/TestAll.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.openjceplus.integration;
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/integration/TestTLS.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/integration/TestTLS.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.openjceplus.integration;
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressAES256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressAES256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressAESGCM.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressAESGCM.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressAll.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressChaChaPoly1305.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressChaChaPoly1305.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressDH.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressDH.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressDHKeyFactory.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressDHKeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressDHKeyPair.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressDHKeyPair.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressDSAKeyFactory.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressDSAKeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressDSAKeyPair.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressDSAKeyPair.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressDSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressECDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressECDSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.openjceplus.memstress;
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressECKeyFactory.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressECKeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressECKeyPair.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressECKeyPair.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressHKDF.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressHKDF.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressHmacSHA256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressHmacSHA256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressMD5.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressMD5.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressRSAKeyFactory.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressRSAKeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressRSAKeyPair.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressRSAKeyPair.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressRSAPSS2.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressRSAPSS2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressRSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressRSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressSHA256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressSHA256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressXDH_X25519.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressXDH_X25519.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressXDH_X448.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/memstress/TestMemStressXDH_X448.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.memstress;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESCipherInputStreamExceptions.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESCipherInputStreamExceptions.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESCopySafe.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESCopySafe.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCMCICOWithGCM.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCMCICOWithGCM.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCMCICOWithGCMAndAAD.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCMCICOWithGCMAndAAD.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCMLong.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCMLong.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCMNonExpanding.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCMNonExpanding.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCMSameBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCMSameBuffer.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCMUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCMUpdate.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCMWithByteBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCMWithByteBuffer.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCMWithKeyAndIvCheck.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCMWithKeyAndIvCheck.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCM_128.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCM_128.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCM_192.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCM_192.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCM_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAESGCM_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAES_128.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAES_128.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAES_192.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAES_192.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAES_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAES_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAliases.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestAliases.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestDESede.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestDESede.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestDH.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestDH.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestDSAKey.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestDSAKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestDSASignatureInteropSUN.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestDSASignatureInteropSUN.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestECDH.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestECDH.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestECDHInteropSunEC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestECDHInteropSunEC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestECDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestECDSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestEdDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestEdDSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestHKDF.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestHKDF.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestHmacMD5.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestHmacMD5.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestHmacMD5InteropSunJCE.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestHmacMD5InteropSunJCE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestHmacSHA256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestHmacSHA256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestHmacSHA256InteropSunJCE.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestHmacSHA256InteropSunJCE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestHmacSHA3_224.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestHmacSHA3_224.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestHmacSHA3_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestHmacSHA3_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestHmacSHA3_384.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestHmacSHA3_384.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestHmacSHA3_512.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestHmacSHA3_512.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestMiniRSAPSS2.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestMiniRSAPSS2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestRSAKey.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestRSAKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestRSAPSS.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestRSAPSS.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestRSAPSS2.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestRSAPSS2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestRSAPSSInterop2.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestRSAPSSInterop2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestRSAPSSInterop3.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestRSAPSSInterop3.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestRSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestRSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestRSASignatureInteropSunRsaSign.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestRSASignatureInteropSunRsaSign.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestRSA_2048.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestRSA_2048.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestSHA256Clone_SharedMD.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestSHA256Clone_SharedMD.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestSHA3_224.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestSHA3_224.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestSHA3_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestSHA3_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestSHA3_384.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestSHA3_384.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestSHA3_512.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestSHA3_512.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestSHA512.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestSHA512.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestSHA512_224.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestSHA512_224.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestSHA512_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestSHA512_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestXDH.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestXDH.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestXDHKeyImport.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestXDHKeyImport.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestXDHKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestXDHKeyPairGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestXDHMultiParty.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestXDHMultiParty.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplus.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAES.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAES.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.openjceplusfips;
 

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAES256Interop.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAES256Interop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESCCM.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESCCM.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESCCM2.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESCCM2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESCCMInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESCCMInteropBC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESCCMParameters.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESCCMParameters.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESCipherInputStreamExceptions.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESCipherInputStreamExceptions.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESCopySafe.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESCopySafe.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCM.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCM.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCMBufferIV.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCMBufferIV.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCMCICOWithGCM.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCMCICOWithGCM.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCMCICOWithGCMAndAAD.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCMCICOWithGCMAndAAD.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCMLong.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCMLong.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCMNonExpanding.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCMNonExpanding.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCMSameBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCMSameBuffer.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCMUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCMUpdate.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCMWithByteBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCMWithByteBuffer.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCMWithKeyAndIvCheck.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCMWithKeyAndIvCheck.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCM_128.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCM_128.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCM_192.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCM_192.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCM_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCM_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCM_ExtIV.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCM_ExtIV.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCM_IntIV.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESGCM_IntIV.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAES_128.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAES_128.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.openjceplusfips;
 

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAES_192.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAES_192.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.openjceplusfips;
 

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAES_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAES_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.openjceplusfips;
 

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAliases.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAliases.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAll.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2025
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestChaCha20.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestChaCha20.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestChaCha20Poly1305ChunkUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestChaCha20Poly1305ChunkUpdate.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDESede.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDESede.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDH.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDH.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDHInteropSunJCE.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDHInteropSunJCE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDHKeyFactory.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDHKeyFactory.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDHKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDHKeyPairGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDHMultiParty.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDHMultiParty.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDSAKey.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDSAKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDSASignatureInteropSUN.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestDSASignatureInteropSUN.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECDH.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECDH.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECDHInteropSunEC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECDHInteropSunEC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECDHKeyAgreementParamValidation.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECDHKeyAgreementParamValidation.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.openjceplusfips;
 

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECDHMultiParty.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECDHMultiParty.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECDSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECDSASignatureInteropSunEC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECDSASignatureInteropSunEC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECKeyImport.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECKeyImport.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECKeyImportInteropSunEC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECKeyImportInteropSunEC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestECKeyPairGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestFIPSVerifyOnlyTest.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestFIPSVerifyOnlyTest.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHKDF.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHKDF.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHKDFInterop.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHKDFInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacMD5.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacMD5.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacMD5InteropSunJCE.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacMD5InteropSunJCE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA1.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA1.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA1InteropSunJCE.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA1InteropSunJCE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA224.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA224.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA224InteropSunJCE.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA224InteropSunJCE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA256InteropSunJCE.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA256InteropSunJCE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA384.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA384.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA384InteropSunJCE.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA384InteropSunJCE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA3_224.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA3_224.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA3_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA3_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA3_384.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA3_384.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA3_512.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA3_512.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA512.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA512.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA512InteropSunJCE.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestHmacSHA512InteropSunJCE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestImplementationClassesExist.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestImplementationClassesExist.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestImplementationClassesFinal.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestImplementationClassesFinal.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestInvalidArrayIndex.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestInvalidArrayIndex.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestMD5.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestMD5.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestMiniRSAPSS2.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestMiniRSAPSS2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestPBKDF2.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestPBKDF2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2025
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestPBKDF2Interop.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestPBKDF2Interop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2025
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestPublicMethodsToMakeNonPublic.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestPublicMethodsToMakeNonPublic.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSA.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSA.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSAKey.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSAKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSAKeyInterop.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSAKeyInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSAKeyInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSAKeyInteropBC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSAPSS.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSAPSS.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSAPSS2.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSAPSS2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSAPSSInterop.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSAPSSInterop.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSAPSSInterop2.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSAPSSInterop2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSAPSSInterop3.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSAPSSInterop3.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSASignatureChunkUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSASignatureChunkUpdate.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSASignatureInteropSunRsaSign.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSASignatureInteropSunRsaSign.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSASignatureWithSpecificSize.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSASignatureWithSpecificSize.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.openjceplusfips;
 

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSATypeCheckDefault.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSATypeCheckDefault.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSATypeCheckDisabled.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSATypeCheckDisabled.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSATypeCheckEnabled.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSATypeCheckEnabled.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSA_1024.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSA_1024.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSA_2048.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSA_2048.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSA_4096.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestRSA_4096.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestResetByteBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestResetByteBuffer.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA1.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA1.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA224.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA224.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA384.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA384.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA3_224.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA3_224.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.openjceplusfips;
 

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA3_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA3_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA3_384.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA3_384.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA3_512.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA3_512.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA512.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestSHA512.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/Utils.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/Utils.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/integration/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/integration/TestAll.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.openjceplusfips.integration;
 

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/integration/TestTLS.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/integration/TestTLS.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 package ibm.jceplus.junit.openjceplusfips.integration;
 

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESCipherInputStreamExceptions.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESCipherInputStreamExceptions.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESCopySafe.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESCopySafe.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCMCICOWithGCM.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCMCICOWithGCM.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCMCICOWithGCMAndAAD.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCMCICOWithGCMAndAAD.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCMLong.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCMLong.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCMNonExpanding.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCMNonExpanding.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCMSameBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCMSameBuffer.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCMUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCMUpdate.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCMWithByteBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCMWithByteBuffer.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCMWithKeyAndIvCheck.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCMWithKeyAndIvCheck.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCM_128.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCM_128.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCM_192.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCM_192.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCM_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAESGCM_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAES_128.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAES_128.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAES_192.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAES_192.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAES_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAES_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAliases.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestAliases.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestDESede.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestDESede.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestDH.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestDH.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestDSAKey.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestDSAKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestDSASignatureInteropSUN.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestDSASignatureInteropSUN.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestECDH.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestECDH.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestECDHInteropSunEC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestECDHInteropSunEC.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestECDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestECDSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHKDF.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHKDF.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacMD5.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacMD5.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacMD5InteropSunJCE.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacMD5InteropSunJCE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA256InteropSunJCE.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA256InteropSunJCE.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA3_224.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA3_224.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA3_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA3_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA3_384.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA3_384.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA3_512.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestHmacSHA3_512.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestMiniRSAPSS2.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestMiniRSAPSS2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSAKey.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSAKey.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSAPSS.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSAPSS.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSAPSS2.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSAPSS2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSAPSSInterop2.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSAPSSInterop2.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSAPSSInterop3.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSAPSSInterop3.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSASignature.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSASignatureInteropSunRsaSign.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSASignatureInteropSunRsaSign.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSA_2048.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestRSA_2048.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA256Clone_SharedMD.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA256Clone_SharedMD.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA3_224.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA3_224.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA3_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA3_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA3_384.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA3_384.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA3_512.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA3_512.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA512.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA512.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA512_224.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA512_224.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA512_256.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestSHA512_256.java
@@ -1,9 +1,9 @@
 /*
  * Copyright IBM Corp. 2023, 2024
  *
- * Licensed under the Apache License 2.0 (the "License").  You may not use
- * this file except in compliance with the License.  You can obtain a copy
- * in the file LICENSE in the source distribution.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
  */
 
 package ibm.jceplus.junit.openjceplusfips.multithread;


### PR DESCRIPTION
This set of updates migrates the OpenJCEPlus project to the GPLv2 license with classpath exception.

Back-ported from: #475

Signed-off-by: Jason Katonica <katonica@us.ibm.com>