### PR TITLE
Upgrade Maven from 3.9.6 to 3.9.9

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -232,8 +232,8 @@ def getJava(hardware, software) {
  * Get the Maven tool and extract it.
  */
 def getMaven() {
-    sh "curl -kLO https://dlcdn.apache.org/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz"
-    untar file: "apache-maven-3.9.6-bin.tar.gz"
+    sh "curl -kLO https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz"
+    untar file: "apache-maven-3.9.9-bin.tar.gz"
 }
 
 /*
@@ -309,14 +309,14 @@ def runOpenJCEPlus(command, software) {
 
         def java_home = "export JAVA_HOME=$WORKSPACE/java/jdk;"
         def gskit_home = "export GSKIT_HOME=$WORKSPACE/openjceplus/OCK/jgsk_sdk;"
-        def environment = "export PATH=$WORKSPACE/apache-maven-3.9.6/bin:\$PATH;"
+        def environment = "export PATH=$WORKSPACE/apache-maven-3.9.9/bin:\$PATH;"
         def ock_path = "$WORKSPACE/openjceplus/OCK/"
         if (software == "windows") {
             def workspace_unix_style = sh (
                 script: "cygpath -u '$WORKSPACE'",
                 returnStdout: true
             ).trim()
-            environment = """export PATH=${workspace_unix_style}/apache-maven-3.9.6/bin:/cygdrive/c/Program\\ Files\\ \\(x86\\)/Windows\\ Kits/10/bin/10.0.19041.0/x64/:/cygdrive/c/Program\\ Files/Microsoft\\ Visual\\ Studio/2022/Professional/VC/Tools/MSVC/14.31.31103/bin/Hostx64/x64/:\$PATH;\\
+            environment = """export PATH=${workspace_unix_style}/apache-maven-3.9.9/bin:/cygdrive/c/Program\\ Files\\ \\(x86\\)/Windows\\ Kits/10/bin/10.0.19041.0/x64/:/cygdrive/c/Program\\ Files/Microsoft\\ Visual\\ Studio/2022/Professional/VC/Tools/MSVC/14.31.31103/bin/Hostx64/x64/:\$PATH;\\
                             |export INCLUDE="C:/Program Files (x86)/Windows Kits/10/include/10.0.19041.0/um/;C:/Program Files (x86)/Windows Kits/10/include/10.0.19041.0/shared/;C:/Program Files/Microsoft Visual Studio/2022/Professional/VC/Tools/MSVC/14.31.31103/include/;C:/Program Files (x86)/Windows Kits/10/include/10.0.19041.0/ucrt/";\\
                             |export LIB="C:/Program Files/Microsoft Visual Studio/2022/Professional/VC/Tools/MSVC/14.31.31103/lib/x64;C:/Program Files (x86)/Windows Kits/10/lib/10.0.19041.0/ucrt/x64;C:/Program Files (x86)/Windows Kits/10/lib/10.0.19041.0/um/x64";\\
                             |""".stripMargin()


### PR DESCRIPTION
This update changes the Jenkins pipeline to use maven version 3.9.9.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/484

Signed-off-by: Jason Katonica <katonica@us.ibm.com>