### PR TITLE
Update to use latest maven dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
                 <build.platform.value>win</build.platform.value>
                 <build.target.jgskitlib.dir>${project.basedir}\target\buildwin\host64\</build.target.jgskitlib.dir>
             </properties>
-          </profile>       
+          </profile>
           <profile>
             <id>Profile for AIX ppc64</id>
             <activation>
@@ -323,7 +323,7 @@
                     <excludes>**/module-info.java</excludes>
                     <sourceDirectories>
                         <sourceDirectory>src</sourceDirectory>
-                        <sourceDirectory>src/native</sourceDirectory> 
+                        <sourceDirectory>src/native</sourceDirectory>
                     </sourceDirectories>
                 </configuration>
                 <executions>
@@ -335,7 +335,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>                
+            </plugin>
             <plugin>
               <groupId>org.codehaus.mojo</groupId>
               <artifactId>exec-maven-plugin</artifactId>
@@ -361,7 +361,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
-                    <source>${jdk.build.target}</source>   
+                    <source>${jdk.build.target}</source>
                     <target>${jdk.build.target}</target>
                     <compilerArgs>
                         <arg>-XDignore.symbol.file</arg>
@@ -528,7 +528,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.3.1-jre</version>
+            <version>33.4.0-jre</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.reporting</groupId>
@@ -538,7 +538,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>4.0.0-beta-5</version>
+            <version>4.0.0-rc-2</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.mojo</groupId>
@@ -564,31 +564,31 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-suite</artifactId>
-            <version>1.11.3</version>
+            <version>1.12.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.11.3</version>
+            <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.11.3</version>
+            <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.11.3</version>
+            <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>4.0.0-beta-1</version>
+            <version>4.0.0-beta-2</version>
             <type>maven-plugin</type>
             <exclusions>
                 <exclusion>
@@ -600,7 +600,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.17.0</version>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
@@ -642,17 +642,17 @@
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-clean-plugin</artifactId>
-            <version>4.0.0-beta-1</version>
+            <version>4.0.0-beta-2</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.79</version>
+            <version>1.80</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>1.79</version>
+            <version>1.80</version>
         </dependency>
         <dependency>
           <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
This update strips trailing whitespace from a few lines of the pom.xml file. This update also updates all maven dependencies versions to the latest available.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/486

Signed-off-by: Jason Katonica <katonica@us.ibm.com>