### PR TITLE
Enhancements to AES-GCM Tests and Cipher Initialization

### DIFF
--- a/src/main/native/GCM.c
+++ b/src/main/native/GCM.c
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -1680,26 +1680,22 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_create_1GCM_1context(
     static const char* functionName = "NativeInterface.create_GCM_context";
     ICC_CTX*           ockCtx       = (ICC_CTX*)((intptr_t)ockContextId);
     ICC_AES_GCM_CTX*   gcmCtx       = NULL;
-    int                rc           = 0;
 
     if (debug) {
         gslogFunctionEntry(functionName);
     }
-    if (debug) {
-        gslogFunctionExit(functionName);
-    }
     gcmCtx = ICC_AES_GCM_CTX_new(ockCtx);
-    rc = ICC_AES_GCM_CTX_ctrl(ockCtx, gcmCtx, ICC_AES_GCM_CTRL_TLS13, 0, NULL);
-    if (rc != ICC_OSSL_SUCCESS) {
+    if (gcmCtx == NULL) {
 #ifdef DEBUG_GCM_DETAIL
         if (debug) {
-            gslogMessage("ICC_AES_GCM_CTX_ctrl failed rc = %d\n", rc);
+            gslogMessage("ICC_AES_GCM_CTX_new failed to create a new context.");
         }
 #endif
-        if (gcmCtx != NULL) {
-            ICC_AES_GCM_CTX_free(ockCtx, gcmCtx);
-        }
-        gcmCtx = NULL;
+        throwOCKException(env, 0,
+                          "ICC_AES_GCM_CTX_new failed to create a new context.");
+    }
+    if (debug) {
+        gslogFunctionExit(functionName);
     }
     return (jlong)gcmCtx;
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -17,6 +17,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.AlgorithmParameters;
@@ -82,7 +83,7 @@ public class BaseTestAESGCMUpdate extends BaseTestJunit5 {
         key = aesKeyGen.generateKey();
     }
 
-    static String[] plainTextStrArray = {"a", "ab", "abc", "abcd", "abcde", "abcdef", "abcdefg",
+    String[] plainTextStrArray = {"a", "ab", "abc", "abcd", "abcde", "abcdef", "abcdefg",
             "abcdefgh", "abcdefghi", "abcdefghi", "abcdefghij", "abcdefghijk", "abcdefghijkl",
             "abcdefghijklm", "abcdefghijklmn", "abcdefghijklmno", "abcdefghijklmnop",
             "abcdefghijklmnopq", "abcdefghijklmnopqr", "abcdefghijklmnopqrs",
@@ -93,7 +94,7 @@ public class BaseTestAESGCMUpdate extends BaseTestJunit5 {
             "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyza",
             "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0123456789"};
 
-    static String[] plainTextStrArray1 = {
+    String[] plainTextStrArray1 = {
             //"abcdefghijklmnopqrstuvwxyz0123456789012345678901234",
             "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyza01234",
             "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa012345678901234"};
@@ -182,15 +183,16 @@ public class BaseTestAESGCMUpdate extends BaseTestJunit5 {
         byte[] myAAD = "aaaaaaaaa".getBytes();
 
         GCMParameterSpec ivSpec = new GCMParameterSpec(GCM_TAG_LENGTH * Byte.SIZE, iv);
+
         for (int keysizeloop = 1; keysizeloop < 3; keysizeloop++) {
-            String myStr = "";
+            StringBuilder myStr = new StringBuilder();
+            SecretKey key16 = new SecretKeySpec(new byte[16 * keysizeloop], "AES"); // key is 16 zero bytes
+
             for (int i = 0; i < 118999;) {
-                myStr = myStr + "a";
+                myStr.append("a");
 
-                byte[] plainTextBytes = myStr.getBytes("UTF-8");
+                byte[] plainTextBytes = myStr.toString().getBytes(StandardCharsets.UTF_8);
 
-
-                SecretKey key16 = new SecretKeySpec(new byte[16 * keysizeloop], "AES"); // key is 16 zero bytes
                 byte[] encryptedText = dotestWithString(Cipher.ENCRYPT_MODE, key16, myAAD,
                         plainTextBytes, ivSpec);
                 byte[] decryptedText = dotestWithString(Cipher.DECRYPT_MODE, key16, myAAD,
@@ -767,14 +769,14 @@ public class BaseTestAESGCMUpdate extends BaseTestJunit5 {
 
         GCMParameterSpec ivSpec = new GCMParameterSpec(GCM_TAG_LENGTH * Byte.SIZE, iv);
         for (int keysizeloop = 1; keysizeloop < 3; keysizeloop++) {
-            String myStr = "";
+            StringBuilder myStr = new StringBuilder();
             for (int i = 0; i < 250; i++) {
-                myStr = myStr + "a";
+                myStr.append("a");
             }
             for (int i = 250; i < 118999;) {
-                myStr = myStr + "a";
+                myStr.append("a");
                 int numTimes = 7;
-                byte[] plainTextBytes = myStr.getBytes("UTF-8");
+                byte[] plainTextBytes = myStr.toString().getBytes(StandardCharsets.UTF_8);
                 SecretKey key = new SecretKeySpec(new byte[16 * keysizeloop], "AES"); // key is 16 zero bytes
                 byte[] encryptedText = doTestWithMultipleDataUpdate(Cipher.ENCRYPT_MODE, key, myAAD,
                         plainTextBytes, ivSpec, numTimes);

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMUpdateInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMUpdateInteropBC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -37,7 +37,7 @@ public class BaseTestAESGCMUpdateInteropBC extends BaseTestJunit5Interop {
     //protected Method methodGCMParameterSpecSetAAD = null;
     protected int specifiedKeySize = 0;
 
-    static String[] plainTextStrArray = {"a", "ab", "abc", "abcd", "abcde", "abcdef", "abcdefg",
+    String[] plainTextStrArray = {"a", "ab", "abc", "abcd", "abcde", "abcdef", "abcdefg",
             "abcdefgh", "abcdefghi", "abcdefghi", "abcdefghij", "abcdefghijk", "abcdefghijkl",
             "abcdefghijklm", "abcdefghijklmn", "abcdefghijklmno", "abcdefghijklmnop",
             "abcdefghijklmnopq", "abcdefghijklmnopqr", "abcdefghijklmnopqrs",
@@ -48,7 +48,7 @@ public class BaseTestAESGCMUpdateInteropBC extends BaseTestJunit5Interop {
             "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyza",
             "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0123456789"};
 
-    static String[] plainTextStrArray1 = {
+    String[] plainTextStrArray1 = {
             //"abcdefghijklmnopqrstuvwxyz0123456789012345678901234",
             "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyza01234",
             "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa012345678901234"};


### PR DESCRIPTION
This is a back port PR from PR https://github.com/IBM/OpenJCEPlus/pull/473

This update addresses multiple issues related to the AES-GCM cipher.

AES context creation is now validated to prevent returning a NULL context. Using a NULL context in subsequent API calls was previously causing crashes.

The ICC_AES_GCM_CTX_ctrl API has been removed, as it was deprecated and no longer needed.

AES-GCM test cases were updated to eliminate unintended use of static variables in multi-threaded scenarios. This issue could lead to unpredictable behavior due to concurrent reads and writes to shared fields.

BaseTestAESGCMUpdate now uses StringBuilder instead of string concatenation, reducing memory pressure and improving efficiency.