### PR TITLE
Potential multithreading issues related to static variables

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/AESGCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESGCMCipher.java
@@ -780,7 +780,11 @@ public final class AESGCMCipher extends CipherSpi implements AESConstants, GCMCo
         if (firstIV) {
             // SecureRandom random = null;
             if (random == null) {
-                random = provider.getSecureRandom(null);
+                synchronized (AESGCMCipher.class) {
+                    if (random == null) {
+                        random = provider.getSecureRandom(null);
+                    }
+                }
             }
             generatedIVDevField = new byte[GENERATED_IV_DEVICE_FIELD_LENGTH];
             random.nextBytes(generatedIVDevField);

--- a/src/main/java/com/ibm/crypto/plus/provider/CurveUtil.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/CurveUtil.java
@@ -21,9 +21,9 @@ class CurveUtil {
         X25519, X448, FFDHE2048, FFDHE3072, FFDHE4096, FFDHE6144, FFDHE8192
     }
 
-    private static Map<CURVE, Integer> curveSizes = new HashMap<CURVE, Integer>(); // key sizes of curves in bytes
-    private static Map<CURVE, Integer> DEREncodingSizes = new HashMap<CURVE, Integer>(); // key sizes of der encoded private key values.
-    private static Map<Integer, CURVE> sizesToCurves = new HashMap<Integer, CURVE>(); // maps the total key size (I think?)
+    private static final Map<CURVE, Integer> curveSizes = new HashMap<CURVE, Integer>(); // key sizes of curves in bytes
+    private static final Map<CURVE, Integer> DEREncodingSizes = new HashMap<CURVE, Integer>(); // key sizes of der encoded private key values.
+    private static final Map<Integer, CURVE> sizesToCurves = new HashMap<Integer, CURVE>(); // maps the total key size (I think?)
                                                                                           // to algorithm (used in constructor)
     static {
 

--- a/src/main/java/com/ibm/crypto/plus/provider/ECNamedCurve.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECNamedCurve.java
@@ -172,7 +172,7 @@ final class ECNamedCurve extends ECGenParameterSpec implements AlgorithmParamete
     // private static final Map<Integer, ECParameterSpec> lengthMap = new
     // HashMap<Integer, ECParameterSpec>();
 
-    private static Pattern SPLIT_PATTERN = Pattern.compile(",|\\[|\\]");
+    private static final Pattern SPLIT_PATTERN = Pattern.compile(",|\\[|\\]");
 
     private static BigInteger bi(String s) {
         return new BigInteger(s, 16);
@@ -445,7 +445,6 @@ final class ECNamedCurve extends ECGenParameterSpec implements AlgorithmParamete
                 "7DDE385D566332ECC0EABFA9CF7822FDF209F70024A57B1AA000C55B881F8111B2DCDE494A5F485E5BCA4BD88A2763AED1CA2B2FA8F0540678CD1E0F3AD80892",
                 "AADD9DB8DBE9C48B3FD4E6AE33C9FC07CB308DB3B3C9D20ED6639CCA70330870553E5C414CA92619418661197FAC10471DB1D381085DDADDB58796829CA90069",
                 1, false);
-        SPLIT_PATTERN = null;
     }
 
     public String getName() {

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
@@ -27,7 +27,7 @@ public abstract class OpenJCEPlusProvider extends java.security.Provider {
     static final String DEBUG_VALUE = "jceplus";
 
     //    private static boolean verifiedSelfIntegrity = false;
-    private static boolean verifiedSelfIntegrity = true;
+    private static final boolean verifiedSelfIntegrity = true;
 
     OpenJCEPlusProvider(String name, String info) {
         super(name, PROVIDER_VER, info);

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAKeyPairGenerator.java
@@ -26,8 +26,8 @@ abstract class RSAKeyPairGenerator extends KeyPairGeneratorSpi {
     private OpenJCEPlusProvider provider = null;
     private int keysize = 2048;
     private BigInteger publicExponent = RSAKeyGenParameterSpec.F4;
-    static int DEF_RSA_KEY_SIZE = 2048;
-    static int DEF_RSASSA_PSS_KEY_SIZE = 2048;
+    static final int DEF_RSA_KEY_SIZE = 2048;
+    static final int DEF_RSASSA_PSS_KEY_SIZE = 2048;
     private KeyType type = RSAUtil.KeyType.RSA;
     private AlgorithmId rsaId;
 

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/ByteArrayOutputDelay.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/ByteArrayOutputDelay.java
@@ -22,8 +22,8 @@ import java.util.Arrays;
 public final class ByteArrayOutputDelay {
     public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
 
-    private static int DEFAULT_BYTE_DELAY = 16;
-    public static int MAX_BYTE_DELAY = 65536; //Only used to protect against "unreasonable" memory usage
+    private static final int DEFAULT_BYTE_DELAY = 16;
+    public static final int MAX_BYTE_DELAY = 65536; //Only used to protect against "unreasonable" memory usage
 
     private int byteDelay = 0;
     private ByteArrayOutputStream byteArrayOutputStream = null;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/SymmetricCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/SymmetricCipher.java
@@ -12,7 +12,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.ShortBufferException;
@@ -35,15 +35,15 @@ public final class SymmetricCipher {
     // CBC Upgrade variables
     private int mode; // Mode used by z_kmc
     private FastJNIBuffer parameters; // Fast way to pass all parameters in z_kmc call
-    private final static int PARAM_CAP = 1024 * 6; // Capacity of the FastJNIBUffer
+    private static final int PARAM_CAP = 1024 * 6; // Capacity of the FastJNIBUffer
     private long inputPointer; // Pointer to memory that has the input to be encrypted by z_kmc
     private long outputPointer; // Pointer to memory that has the output to the encrypted text by z_kmc
     private long outputOffset; // Offset, in the buffer, to where the output is stored, used to retrieve output after z_kmc call
     private long paramPointer; // Pointer to memory that has the parameters/state keeping used by z_kmc
     private static long hardwareFunctionPtr = 0;
     private boolean use_z_fast_command = false;
-    private static HashMap<OCKContext, Boolean> hardwareEnabled = new HashMap<OCKContext, Boolean>(); // Caching for hardwareFunctionPtr
-    private final static String badIdMsg = "Cipher Identifier is not valid";
+    private static final ConcurrentHashMap<OCKContext, Boolean> hardwareEnabled = new ConcurrentHashMap<>(); // Caching for hardwareFunctionPtr
+    private static final String badIdMsg = "Cipher Identifier is not valid";
     /* private final static String debPrefix = "SymCipher"; Adding Debug causes test cases to fail */
     int paramOffset;
     FastJNIBuffer parametersBuffer = null;


### PR DESCRIPTION
This is a back port PR from PR https://github.com/IBM/OpenJCEPlus/pull/485

This commit checks all static variables across Java files to investigate potential multithreading issues and implements the following changes:

AESGCMCipher.java: Update getSecureRandom with a synchronized block to ensure thread safety.

CurveUtil.java, ECNamedCurve.java, OpenJCEPlusProvider.java, RSAKeyPairGenerator.java, and ByteArrayOutputDelay.java: Update some static variables to static final since they remain unchanged after initialization.

SymmetricCipher.java: Update static variables to static final as they do not change after initialization. Additionally, use ConcurrentHashMap to enforce thread safety.

In addition to the changes made in this commit, there are other static variables, as outlined below:

CurveUtil.java: This class contains three static Map variables, which are initialized in a static block. After initialization, these maps are only read, not written or modified. So, they are thread-safe.

NativeInterface.java: The variables osName and osArch are defined as private static String. Regardless of potential race conditions or multiple threads trying to initialize these variables, the values of these static variables remain consistent across the JVM. So, they should be thread-safe.

Digest.java: This class contains two static arrays, which are initialized within a synchronized block. As a result, the initialization is thread-safe, ensuring that the arrays are correctly set up for concurrent access.

AESCCMCipher.java: The static variable private static SecureRandom random = null; is declared but not used in this class.

AESCipher.java: The static variable private static int isHardwareSupport = 0; is declared but not used in this class.

OpenJCEPlus.java and OpenJCEPlusFIPS.java: The static variables ockInitialized and ockContext are initialized within a synchronized method, so they should be fine. The static variable private static Map<String, String> attrs; is declared but not used in this class.

OAEPParameters.java: The static variables OID_MGF1 and OID_PSpecified are initialized in a static block, so they should be fine.

OCKContext.java: The static variable private static String libraryBuildDate = unobtainedValue; is initialized within a synchronized method, so it should be fine.

CurveDB.java: This class contains static maps, but since we removed CurveDB in another PR, no changes are needed for those maps.

CCMCipher.java, GCMCipher.java, and SymmetricCipher.java: The hardware check variables are defined as static. However, on open platforms, hardware support is not checked at all. So, this static variable has no actual impact.