### PR TITLE
Tolerate empty message EdDSA verify

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSASignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -183,11 +183,9 @@ abstract class EdDSASignature extends SignatureSpi {
         if (!publicKeyInit) {
             throw new SignatureException("Missing public key");
         }
-        if (message == null) {
-            return false;
-        }
 
         try {
+            ensureMessageInit();
             byte[] messageBytes = message.toByteArray();
             message = null;
             return this.signature.verify(sigBytes, messageBytes);

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestEdDSASignatureInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestEdDSASignatureInterop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -8,107 +8,87 @@
 
 package ibm.jceplus.junit.base;
 
-import java.io.IOException;
-import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.security.SecureRandom;
 import java.security.Signature;
-import java.security.spec.EdECPoint;
-import java.security.spec.EdECPublicKeySpec;
 import java.security.spec.NamedParameterSpec;
-import org.bouncycastle.crypto.Signer;
-import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
-import org.bouncycastle.crypto.params.Ed448PublicKeyParameters;
-import org.bouncycastle.crypto.signers.Ed25519Signer;
-import org.bouncycastle.crypto.signers.Ed448Signer;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BaseTestEdDSASignatureInterop extends BaseTestJunit5Signature {
+public class BaseTestEdDSASignatureInterop extends BaseTestJunit5Interop {
 
     static final byte[] origMsg = "this is the original message to be signed".getBytes();
+    static final String EDDSA_ALG_NAME = "EdDSA";
 
-    private static final SecureRandom RANDOM = new SecureRandom();
-
-    @Test
-    public void testEd25519withEdDSA() throws Exception {
-        KeyPair keyPair = generateKeyPair("Ed25519");
-        byte[] signedMsg = doSign("Ed25519", origMsg, keyPair.getPrivate());
-        doVerifyEd25519(origMsg, signedMsg, keyPair.getPublic());
+    @ParameterizedTest
+    @MethodSource("testEdDSAArguments")
+    public void testEdDSA(String KeyPairAlg, byte[] message, String provider1, String provider2)
+            throws Exception {
+        KeyPair keyPair = generateKeyPair(KeyPairAlg, provider1);
+        byte[] signedMsg = doSign(message, keyPair.getPrivate(), provider1);
+        doVerify(message, signedMsg, keyPair.getPublic(), provider2);
     }
 
-    @Test
-    public void testEd448withEdDSA() throws Exception {
-        KeyPair keyPair = generateKeyPair("Ed448");
-        byte[] signedMsg = doSign("Ed448", origMsg, keyPair.getPrivate());
-        doVerifyEd448(origMsg, signedMsg, keyPair.getPublic());
+    private Stream<Arguments> testEdDSAArguments() {
+        return Stream.of(
+                Arguments.of("Ed25519", origMsg, getProviderName(), getInteropProviderName()),
+                Arguments.of("Ed25519", origMsg, getInteropProviderName(), getProviderName()),
+                Arguments.of("Ed448", origMsg, getProviderName(), getInteropProviderName()),
+                Arguments.of("Ed448", origMsg, getInteropProviderName(), getProviderName()),
+                Arguments.of("Ed448", null, getProviderName(), getInteropProviderName()),
+                Arguments.of("Ed448", null, getInteropProviderName(), getProviderName()),
+                Arguments.of("Ed25519", null, getProviderName(), getInteropProviderName()),
+                Arguments.of("Ed25519", null, getInteropProviderName(), getProviderName()));
     }
 
-    private KeyPair generateKeyPair(String alg) throws Exception {
-        KeyPairGenerator xecKeyPairGen = KeyPairGenerator.getInstance(alg, getProviderName());
+    private KeyPair generateKeyPair(String alg, String providerName) throws Exception {
+        KeyPairGenerator xecKeyPairGen = KeyPairGenerator.getInstance(alg, providerName);
         xecKeyPairGen.initialize(new NamedParameterSpec(alg));
         return xecKeyPairGen.generateKeyPair();
     }
 
-
-    //Sign the message with OpenJCEPlus provided EdDSA
-    private byte[] doSign(String sigAlgo, byte[] message, PrivateKey privateKey) throws Exception {
-        Signature signing = Signature.getInstance(sigAlgo, getProviderName());
+    /**
+     * Sign a message.
+     *
+     * @param message The message to sign. This can be null in which no message will be used.
+     * @param privateKey The private key to sign the message with.
+     * @param providerName The name of the provider to instantiate the message `sigAlgo` with.
+     * @return A byte array that contains the resulting signature.
+     * @throws Exception
+     */
+    private byte[] doSign(byte[] message, PrivateKey privateKey, String providerName)
+            throws Exception {
+        Signature signing = Signature.getInstance(EDDSA_ALG_NAME, providerName);
         signing.initSign(privateKey);
-        signing.update(message);
+        if (message != null) {
+            signing.update(message);
+        }
         byte[] signedBytes = signing.sign();
         return signedBytes;
     }
 
+    /**
+     * Verify a signature.
+     *
+     * @param message The message to verify. This can be null in which no message will be used.
+     * @param signedBytes The signature bytes.
+     * @param publicKey The public key used to verify the message.
+     * @param providerName he name of the provider to instantiate the message `sigAlgo` with.
+     * @throws Exception
+     */
+    protected void doVerify(byte[] message, byte[] signedBytes, PublicKey publicKey,
+            String providerName) throws Exception {
 
-    //Verify the message with BouncyCastle provided Ed25519
-    protected void doVerifyEd25519(byte[] message, byte[] signedBytes, PublicKey publicKey)
-            throws Exception {
-        KeyFactory keyFactory = KeyFactory.getInstance("EdDSA", getProviderName());
-        EdECPublicKeySpec keySpec = keyFactory.getKeySpec(publicKey, EdECPublicKeySpec.class);
-        EdECPoint point = keySpec.getPoint();
-        byte[] encodedPoint = point.getY().toByteArray();
-        reverseByteArray(encodedPoint);
-        byte setMSB = point.isXOdd() ? (byte)0x80 : (byte)0x00;
-        encodedPoint[encodedPoint.length - 1] |= setMSB;
-
-        Ed25519PublicKeyParameters publicKeyBC = new Ed25519PublicKeyParameters(encodedPoint);
-        Signer signer = new Ed25519Signer();
-        signer.init(false, publicKeyBC);
-        signer.update(message, 0, message.length);
-        assertTrue(signer.verifySignature(signedBytes), "Signature verification failed ");
-    }
-
-
-    //Verify the message with BouncyCastle provided Ed448
-    protected void doVerifyEd448(byte[] message, byte[] signedBytes, PublicKey publicKey)
-            throws Exception {
-        KeyFactory keyFactory = KeyFactory.getInstance("EdDSA", getProviderName());
-        EdECPublicKeySpec keySpec = keyFactory.getKeySpec(publicKey, EdECPublicKeySpec.class);
-        EdECPoint point = keySpec.getPoint();
-        byte[] originalEncodedPoint = point.getY().toByteArray();
-        reverseByteArray(originalEncodedPoint);
-        byte[] encodedPoint = java.util.Arrays.copyOf(originalEncodedPoint, 57);
-        byte setMSB = point.isXOdd() ? (byte)0x80 : (byte)0x00;
-        encodedPoint[encodedPoint.length - 1] = setMSB;
-
-        Ed448PublicKeyParameters publicKeyBC = new Ed448PublicKeyParameters(encodedPoint);
-        Signer signer = new Ed448Signer(new byte[0]);
-        signer.init(false, publicKeyBC);
-        signer.update(message, 0, message.length);
-        assertTrue(signer.verifySignature(signedBytes), "Signature verification failed ");
-    }
-
-    private static void reverseByteArray(byte[] arr) throws IOException {
-        for (int i = 0; i < arr.length / 2; i++) {
-            byte temp = arr[i];
-            arr[i] = arr[arr.length - 1 - i];
-            arr[arr.length - 1 - i] = temp;
+        Signature verify = Signature.getInstance(EDDSA_ALG_NAME, providerName);
+        verify.initVerify(publicKey);
+        if (message != null) {
+            verify.update(message, 0, message.length);
         }
+        assertTrue(verify.verify(signedBytes), "Signature verification failed.");
     }
-
 }
-

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestEdDSASignatureInterop.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestEdDSASignatureInterop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -17,8 +17,10 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 public class TestEdDSASignatureInterop extends BaseTestEdDSASignatureInterop {
 
     @BeforeAll
-    public void beforeAll() {
+    public void beforeAll() throws Exception {
         Utils.loadProviderTestSuite();
+        Utils.loadProviderBC();
         setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
+        setInteropProviderName(Utils.PROVIDER_BC);
     }
 }


### PR DESCRIPTION
The EdDSA signature algorithm always returned the value false during verification in the case that no message was provided to the user. This behavior diverges from other cryptographic providers. This update allows for verification of null messages.

The EdDSA interop test was modified to ensure that sign and verify operations between bouncy castle and OpenJCEPlus providers work including sign and verify options without any message sent to the Signature instance. The test was also converted to a parameterized test and now uses the JCE framework instead of the bouncy castle key factory.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>