### PR TITLE
Check PSSParameterSpec with different message digest

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPSSSignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPSSSignature.java
@@ -437,7 +437,16 @@ public final class RSAPSSSignature extends SignatureSpi {
 
                 // No need to check other messageDigest Strings since
                 // mgfMessageDigest can only assume values of SHA-1, SHA-224, SHA-256, SHA-384, and SHA-512, or variations those.
-
+                /*
+                 * According to [PKCS#1v2.1] the mask generation function (MGF) 
+                 * – if based on a hash algo is recommended to use the same hash 
+                 * function as the hash function fingerprinting the message. 
+                 * 
+                 * However the structures in [PKCS#1v2.1] allow for separate 
+                 * parameterization of the MGF and the message digest.
+                 * 
+                 * https://datatracker.ietf.org/doc/html/rfc3447#page-29
+                 */
                 if (throwException) {
                     InvalidAlgorithmParameterException ex = new InvalidAlgorithmParameterException(
                             "The message digest within the PSSParameterSpec does not match the MGF message digest.");


### PR DESCRIPTION
The mask generation function (MGF) based on a hash algo is recommended to use the same hash function as the hash function fingerprinting the message for RSA-PSS. For example
```
new PSSParameterSpec("SHA-384", "MGF1",
                MGF1ParameterSpec.SHA384, 48,
                PSSParameterSpec.TRAILER_FIELD_BC);
```
However the structures in [PKCS#1v2.1] allow for separate parameterization of the MGF and the message digest. For example
```
new PSSParameterSpec("SHA-384", "MGF1",
                MGF1ParameterSpec.SHA512, 48,
                PSSParameterSpec.TRAILER_FIELD_BC);
```

OpenJCEPlus restricts to use the same hash algo for both MGF and message digest. Adding test cases to ensure that OpenJCEPlus will fail the case if different message digest algos are used for MGF and md.