### PR TITLE
Throw InvalidKeyException when XDH small order

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
@@ -34,7 +34,7 @@ abstract class XDHKeyAgreement extends KeyAgreementSpi {
     private long genCtx;
     private XECKey ockXecKeyPub = null;
     private XECKey ockXecKeyPriv = null;
-    private byte[] secret = null;
+    private byte[] secret = {};
     private String alg = null;
 
     XDHKeyAgreement(OpenJCEPlusProvider provider) {
@@ -110,20 +110,22 @@ abstract class XDHKeyAgreement extends KeyAgreementSpi {
             this.secret = XECKey.computeECDHSecret(provider.getOCKContext(), genCtx,
                     ockXecKeyPub.getPKeyId(), ockXecKeyPriv.getPKeyId(), secrectBufferSize);
         } catch (OCKException e) {
+            //Validate the secret value for a small order point condition.
+            byte orValue = (byte) 0;
+            for (int i = 0; i < secret.length; i++) {
+                orValue |= secret[i];
+            }
+
+            if (orValue == (byte) 0) {
+                throw new InvalidKeyException("Point has small order.", e);
+            }
+
             throw new IllegalStateException("Failed to generate secret", e);
         } catch (Exception e) {
             throw new InvalidKeyException("Failed to generate secret", e);
         }
 
-        //Valdate the secret for Point has small order
-        byte orValue = (byte) 0;
-        for (int i = 0; i < secret.length; i++) {
-            orValue |= secret[i];
-        }
 
-        if (orValue == (byte) 0) {
-            throw new InvalidKeyException("Point has small order.");
-        }
 
         return null;
     }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
@@ -31,6 +31,7 @@ import java.security.spec.XECPublicKeySpec;
 import java.util.Arrays;
 import javax.crypto.KeyAgreement;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestXDH extends BaseTestJunit5 {
@@ -338,10 +339,10 @@ public class BaseTestXDH extends BaseTestJunit5 {
 
         try {
             runDiffieHellmanTest(name, a_pri, b_pub, result);
-        } catch (IllegalStateException ex) {
-            return;
+            throw new RuntimeException("Expected exception not thrown on small-order point test.");
+        } catch (InvalidKeyException ex) {
+            assertEquals("Point has small order.", ex.getMessage());
         }
-        throw new RuntimeException("No exception on small-order point");
     }
 
     private void runNonCanonicalTest() throws Exception {


### PR DESCRIPTION
This update matches JDK behavior for XDH key agreement when a small point order is encountered.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>