### PR TITLE
Optimize SecureRandom usage in various services

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/AESCCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESCCMCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -45,7 +45,7 @@ public final class AESCCMCipher extends CipherSpi implements AESConstants, CCMCo
     private BigInteger generatedIVCtrField = null;
     private byte[] generatedIVDevField = null;
     private boolean generateIV = false;
-    private static SecureRandom random = null;
+    private SecureRandom cryptoRandom = null;
 
     private byte[] IV = null;
     private byte[] newIV = null;
@@ -626,8 +626,10 @@ public final class AESCCMCipher extends CipherSpi implements AESConstants, CCMCo
 
     private byte[] generateInternalIV() throws IllegalStateException {
         byte[] generatedIV = new byte[DEFAULT_AES_CCM_IV_LENGTH];
-        SecureRandom secureRandom = new SecureRandom();
-        secureRandom.nextBytes(generatedIV);
+        if (cryptoRandom == null) {
+            cryptoRandom = provider.getSecureRandom(null);
+        }
+        cryptoRandom.nextBytes(generatedIV);
         return generatedIV;
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/AESCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -41,6 +41,7 @@ public final class AESCipher extends CipherSpi implements AESConstants {
     private byte[] buffer = null;
     private boolean use_z_fast_command;
     private static int isHardwareSupport = 0;
+    private SecureRandom cryptoRandom = null;
 
     public AESCipher(OpenJCEPlusProvider provider) {
         if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
@@ -228,8 +229,9 @@ public final class AESCipher extends CipherSpi implements AESConstants {
             throw new InvalidKeyException("Parameters missing");
         }
 
-        SecureRandom cryptoRandom = provider.getSecureRandom(random);
-
+        if (cryptoRandom == null) {
+            cryptoRandom = provider.getSecureRandom(random);
+        }
         byte[] generatedIv = new byte[AES_BLOCK_SIZE];
         cryptoRandom.nextBytes(generatedIv);
 

--- a/src/main/java/com/ibm/crypto/plus/provider/AESGCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESGCMCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -46,7 +46,7 @@ public final class AESGCMCipher extends CipherSpi implements AESConstants, GCMCo
     private BigInteger generatedIVCtrField = null;
     private byte[] generatedIVDevField = null;
     private boolean generateIV = false;
-    private static SecureRandom random = null;
+    private SecureRandom cryptoRandom = null;
 
     private byte[] IV = null;
     private byte[] newIV = null;
@@ -778,16 +778,11 @@ public final class AESGCMCipher extends CipherSpi implements AESConstants, GCMCo
          */
 
         if (firstIV) {
-            // SecureRandom random = null;
-            if (random == null) {
-                synchronized (AESGCMCipher.class) {
-                    if (random == null) {
-                        random = provider.getSecureRandom(null);
-                    }
-                }
+            if (cryptoRandom == null) {
+                cryptoRandom = provider.getSecureRandom(null);
             }
             generatedIVDevField = new byte[GENERATED_IV_DEVICE_FIELD_LENGTH];
-            random.nextBytes(generatedIVDevField);
+            cryptoRandom.nextBytes(generatedIVDevField);
             generatedIVCtrField = new BigInteger(GENERATED_IV_MAX_INVOCATIONS);
         }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/AESKeyGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -25,7 +25,7 @@ public final class AESKeyGenerator extends KeyGeneratorSpi {
 
     private OpenJCEPlusProvider provider = null;
     private int keysize = 16; // default keysize (in bytes)
-    private SecureRandom cryptoRandom;
+    private SecureRandom cryptoRandom = null;
 
     /**
      * Empty constructor
@@ -45,12 +45,12 @@ public final class AESKeyGenerator extends KeyGeneratorSpi {
      */
     @Override
     protected SecretKey engineGenerateKey() {
-        if (this.cryptoRandom == null) {
-            this.cryptoRandom = provider.getSecureRandom(null);
+        if (cryptoRandom == null) {
+            cryptoRandom = provider.getSecureRandom(null);
         }
 
         byte[] keyBytes = new byte[this.keysize];
-        this.cryptoRandom.nextBytes(keyBytes);
+        cryptoRandom.nextBytes(keyBytes);
 
         try {
             return new AESKey(keyBytes);
@@ -75,7 +75,9 @@ public final class AESKeyGenerator extends KeyGeneratorSpi {
         // If in FIPS mode, SecureRandom must be internal and FIPS approved.
         // For FIPS mode, user provided random generator will be ignored.
         //
-        this.cryptoRandom = provider.getSecureRandom(random);
+        if (cryptoRandom == null) {
+            cryptoRandom = provider.getSecureRandom(random);
+        }
     }
 
     /**

--- a/src/main/java/com/ibm/crypto/plus/provider/CCMParameterGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/CCMParameterGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -23,7 +23,7 @@ public final class CCMParameterGenerator extends AlgorithmParameterGeneratorSpi
 
     private OpenJCEPlusProvider provider = null;
     private AlgorithmParameters generatedParameters;
-    private SecureRandom cryptoRandom;
+    private SecureRandom cryptoRandom = null;
 
     /**
      * Constructs a new CCMParameterGenerator instance.
@@ -40,20 +40,12 @@ public final class CCMParameterGenerator extends AlgorithmParameterGeneratorSpi
 
     @Override
     protected void engineInit(int tagLen, SecureRandom random) {
-        if (random == null) {
-            try {
-                this.cryptoRandom = SecureRandom.getInstance("SHA256DRBG");
-            } catch (Exception ex) {
-                RuntimeException rtex = new RuntimeException(
-                        "SecureRandom.getInstance(\"SHA256DRBG\") failed");
-                throw rtex;
-            }
-        } else {
-            this.cryptoRandom = random;
+        if (cryptoRandom == null) {
+            cryptoRandom = provider.getSecureRandom(random);
         }
 
         byte[] iv = new byte[DEFAULT_AES_CCM_IV_LENGTH];
-        this.cryptoRandom.nextBytes(iv);
+        cryptoRandom.nextBytes(iv);
         CCMParameterSpec ccmParameterSpec = new CCMParameterSpec(tagLen, iv); // tagLen is the tag length specified in bits
 
         AlgorithmParameters result;
@@ -77,16 +69,8 @@ public final class CCMParameterGenerator extends AlgorithmParameterGeneratorSpi
     protected void engineInit(AlgorithmParameterSpec algParamSpec, SecureRandom random)
             throws InvalidAlgorithmParameterException {
 
-        if (random == null) {
-            try {
-                this.cryptoRandom = SecureRandom.getInstance("SHA256DRBG");
-            } catch (Exception ex) {
-                RuntimeException rtex = new RuntimeException(
-                        "SecureRandom.getInstance(\"SHA256DRBG\") failed");
-                throw rtex;
-            }
-        } else {
-            this.cryptoRandom = random;
+        if (cryptoRandom == null) {
+            cryptoRandom = provider.getSecureRandom(random);
         }
 
         if (algParamSpec instanceof CCMParameterSpec) {

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Cipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Cipher.java
@@ -39,7 +39,7 @@ public final class ChaCha20Cipher extends CipherSpi implements ChaCha20Constants
     private int counter = 0;
     private boolean encrypting = false;
     private boolean initialized = false;
-    private SecureRandom random = null;
+    private SecureRandom cryptoRandom = null;
 
     public ChaCha20Cipher(OpenJCEPlusProvider provider) {
         if (!OpenJCEPlusProvider.verifySelfIntegrity(this.getClass())) {
@@ -372,9 +372,11 @@ public final class ChaCha20Cipher extends CipherSpi implements ChaCha20Constants
     }
 
     private byte[] generateRandomNonce(SecureRandom random) {
-        this.random = (random != null) ? random : provider.getSecureRandom(random);
+        if (cryptoRandom == null) {
+            cryptoRandom = provider.getSecureRandom(random);
+        }
         byte[] generatedNonce = new byte[ChaCha20_NONCE_SIZE];
-        random.nextBytes(generatedNonce);
+        cryptoRandom.nextBytes(generatedNonce);
 
         return generatedNonce;
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -25,7 +25,7 @@ public final class ChaCha20KeyGenerator extends KeyGeneratorSpi implements ChaCh
 
     private OpenJCEPlusProvider provider = null;
     private int keysize = ChaCha20_KEY_SIZE;
-    private SecureRandom cryptoRandom;
+    private SecureRandom cryptoRandom = null;
 
     /**
      * Empty constructor
@@ -45,12 +45,12 @@ public final class ChaCha20KeyGenerator extends KeyGeneratorSpi implements ChaCh
      */
     @Override
     protected SecretKey engineGenerateKey() {
-        if (this.cryptoRandom == null) {
-            this.cryptoRandom = provider.getSecureRandom(null);
+        if (cryptoRandom == null) {
+            cryptoRandom = provider.getSecureRandom(null);
         }
 
         byte[] keyBytes = new byte[this.keysize];
-        this.cryptoRandom.nextBytes(keyBytes);
+        cryptoRandom.nextBytes(keyBytes);
 
         try {
             return new ChaCha20Key(keyBytes);
@@ -75,7 +75,9 @@ public final class ChaCha20KeyGenerator extends KeyGeneratorSpi implements ChaCh
         // If in FIPS mode, SecureRandom must be internal and FIPS approved.
         // For FIPS mode, user provided random generator will be ignored.
         //
-        this.cryptoRandom = provider.getSecureRandom(random);
+        if (cryptoRandom == null) {
+            cryptoRandom = provider.getSecureRandom(random);
+        }
     }
 
     /**

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Poly1305Cipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Poly1305Cipher.java
@@ -48,7 +48,7 @@ public final class ChaCha20Poly1305Cipher extends CipherSpi
     private boolean initialized = false;
     private boolean aadDone = false;
     //final static String debPrefix = "ChaCha20Poly1305 ";
-    private SecureRandom random = null;
+    private SecureRandom cryptoRandom = null;
 
     public ChaCha20Poly1305Cipher(OpenJCEPlusProvider provider) {
         if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
@@ -514,9 +514,11 @@ public final class ChaCha20Poly1305Cipher extends CipherSpi
     }
 
     private byte[] generateRandomNonce(SecureRandom random) {
-        this.random = (random != null) ? random : provider.getSecureRandom(random);
+        if (cryptoRandom == null) {
+            cryptoRandom = provider.getSecureRandom(random);
+        }
         byte[] generatedNonce = new byte[ChaCha20_NONCE_SIZE];
-        random.nextBytes(generatedNonce);
+        cryptoRandom.nextBytes(generatedNonce);
 
         return generatedNonce;
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -37,6 +37,7 @@ public final class DESedeCipher extends CipherSpi implements DESConstants {
     private byte[] iv = null;
     private boolean encrypting = true;
     private boolean initialized = false;
+    private SecureRandom cryptoRandom = null;
 
     public DESedeCipher(OpenJCEPlusProvider provider) {
 
@@ -168,7 +169,9 @@ public final class DESedeCipher extends CipherSpi implements DESConstants {
             throw new InvalidKeyException("Parameters missing");
         }
 
-        SecureRandom cryptoRandom = provider.getSecureRandom(random);
+        if (cryptoRandom == null) {
+            cryptoRandom = provider.getSecureRandom(random);
+        }
 
         byte[] generatedIv = new byte[DES_BLOCK_SIZE];
         cryptoRandom.nextBytes(generatedIv);

--- a/src/main/java/com/ibm/crypto/plus/provider/GCMParameterGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/GCMParameterGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -24,7 +24,7 @@ public final class GCMParameterGenerator extends AlgorithmParameterGeneratorSpi
     private OpenJCEPlusProvider provider = null;
     private AlgorithmParameters generatedParameters;
     // private GCMParameterSpec gcmParamSpec;
-    private SecureRandom cryptoRandom;
+    private SecureRandom cryptoRandom = null;
 
     /**
      * Constructs a new GCMParameterGenerator instance.
@@ -43,12 +43,13 @@ public final class GCMParameterGenerator extends AlgorithmParameterGeneratorSpi
     protected void engineInit(int size, SecureRandom random) {
         // we don't care about a size for GCMParameters
 
-        this.cryptoRandom = provider.getSecureRandom(random);
-
+        if (cryptoRandom == null) {
+            cryptoRandom = provider.getSecureRandom(random);
+        }
         // we'll take the random and use it as an IV
         byte[] iv = new byte[AES_BLOCK_SIZE];
 
-        this.cryptoRandom.nextBytes(iv);
+        cryptoRandom.nextBytes(iv);
 
         GCMParameterSpec ivSpec = new GCMParameterSpec(DEFAULT_TAG_LENGTH, iv);
         // this.gcmParamSpec = ivSpec;
@@ -74,8 +75,9 @@ public final class GCMParameterGenerator extends AlgorithmParameterGeneratorSpi
     protected void engineInit(AlgorithmParameterSpec algParamSpec, SecureRandom random)
             throws InvalidAlgorithmParameterException {
 
-        this.cryptoRandom = provider.getSecureRandom(random);
-
+        if (cryptoRandom == null) {
+            cryptoRandom = provider.getSecureRandom(random);
+        }
         if (algParamSpec instanceof GCMParameterSpec) {
             AlgorithmParameters result;
             try {

--- a/src/main/java/com/ibm/crypto/plus/provider/HmacKeyGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/HmacKeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -21,7 +21,7 @@ abstract class HmacKeyGenerator extends KeyGeneratorSpi {
     private OpenJCEPlusProvider provider;
     private final String algo;
     private int keysize;
-    private SecureRandom cryptoRandom;
+    private SecureRandom cryptoRandom = null;
 
     HmacKeyGenerator(OpenJCEPlusProvider provider, String algo, int keysize) {
 
@@ -32,17 +32,16 @@ abstract class HmacKeyGenerator extends KeyGeneratorSpi {
         this.provider = provider;
         this.algo = algo;
         this.keysize = keysize; // default keysize in bytes
-        this.cryptoRandom = null;
     }
 
     @Override
     protected SecretKey engineGenerateKey() {
-        if (this.cryptoRandom == null) {
-            this.cryptoRandom = provider.getSecureRandom(null);
+        if (cryptoRandom == null) {
+            cryptoRandom = provider.getSecureRandom(null);
         }
 
         byte[] keyBytes = new byte[this.keysize];
-        this.cryptoRandom.nextBytes(keyBytes);
+        cryptoRandom.nextBytes(keyBytes);
 
         try {
             return new SecretKeySpec(keyBytes, algo);
@@ -58,7 +57,9 @@ abstract class HmacKeyGenerator extends KeyGeneratorSpi {
         // If in FIPS mode, SecureRandom must be internal and FIPS approved.
         // For FIPS mode, user provided random generator will be ignored.
         //
-        this.cryptoRandom = provider.getSecureRandom(random);
+        if (cryptoRandom == null) {
+            cryptoRandom = provider.getSecureRandom(random);
+        }
     }
 
     @Override

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDeterministic.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDeterministic.java
@@ -115,7 +115,7 @@ public class BaseTestDeterministic extends BaseTestJunit5 {
         var ct2 = c.doFinal("asimpleplaintext".getBytes(StandardCharsets.UTF_8));
 
         String algorithm = s.getAlgorithm();
-        if ((algorithm.equals("RSA"))) {
+        if ((algorithm.equals("RSA") || algorithm.contains("ChaCha20"))) {
             //OpenJCEPlus ignores random generators used when initializing ciphers.
             System.out.println(
                     "OpenJCEPlus ignores random generators used within Ciphers: " + algorithm);


### PR DESCRIPTION
`AESCCMCipher` was making use of the default `SecureRandom` algorithm configured on a system. This class should instead make use of the random associated with the provider in use.

`AESCCMCipher`, `AESCipher`, `AESKeyGenerator`, `ChaCha20KeyGenerator`, `DESedeCipher`, `DESedeKeyGenerator`, `ECKeyPairGenerator`, `GCMParameterGenerator`, `HmacKeyGenerator`,
`TlsRsaPremasterSecretGenerator` were modified to
reuse a single source of randomness instead of creating a new instance each time a service is initialized. Test execution times have improved due to this update.

All fields that reference sources of randomness are no longer static. There are concerns that a class may be initialized with a non FIPS provider prior to being used by the FIPS provider. In this case a wrong source of random could potentially be used. The `synchronized` block used in `AESGCMCipher` is no longer needed given this field is no longer static.

Various classes were updated to use a consistent field name, `cryptoRandom`, to hold a sources of randomness. This was done to avoid potential name conflicts with the commonly used `random` argument sent through various APIs. References to this field no longer make use of the `this` keyword given this refactor of the field name now being more unique. A bug was found in both the `ChaCha20Cipher` and `ChaCha20Poly1305Cipher` classes in which the user defined source of randomess was being accidentally being used due to a mix up between `this.random` and the method parameter `random`. The deterministic test was adjusted accordingly for the new behavior.

`CCMParameterGenerator` and `TlsRsaPremasterSecretGenerator` no longer honor a user defined source of randomness similar to our behavior in other services.

The unused field `random` was removed from `EdDSAKeyPairGenerator`.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/559

Signed-off-by: Jason Katonica <katonica@us.ibm.com>

