### PR TITLE
Throw exception for negative digest len or offset

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/MessageDigest.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/MessageDigest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -37,11 +37,8 @@ abstract class MessageDigest extends MessageDigestSpi implements Cloneable {
         if (input == null) {
             throw new IllegalArgumentException("No input buffer given");
         }
-        if (offset < 0) {
-            throw new ArrayIndexOutOfBoundsException("offset is negative");
-        }
-        if ((input.length - offset) < length) {
-            throw new IllegalArgumentException("Input buffer too short");
+        if ((offset < 0) || (length < 0) || (offset > input.length - length)) {
+            throw new ArrayIndexOutOfBoundsException("Range out of bounds for buffer of length " + input.length +" using offset: " + offset + ", input length: " + length);
         }
         try {
             this.digest.update(input, offset, length);

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestMD5.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestMD5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -13,7 +13,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BaseTestMD5 extends BaseTestMessageDigestClone {
+public class BaseTestMD5 extends BaseTestMessageDigest {
 
     static byte[] each = {(byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x1, (byte) 0x0, (byte) 0x73,
             (byte) 0x0, (byte) 0x75, (byte) 0x0, (byte) 0x62, (byte) 0x0, (byte) 0x2d, (byte) 0x0,

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestMessageDigest.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestMessageDigest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -12,9 +12,11 @@ import java.security.MessageDigest;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
-abstract public class BaseTestMessageDigestClone extends BaseTestJunit5 {
+abstract public class BaseTestMessageDigest extends BaseTestJunit5 {
 
     final byte[] input_1 = {(byte) 0x61, (byte) 0x61, (byte) 0x61, (byte) 0x61, (byte) 0x61,
             (byte) 0x61, (byte) 0x61, (byte) 0x61, (byte) 0x61, (byte) 0x61};
@@ -82,5 +84,50 @@ abstract public class BaseTestMessageDigestClone extends BaseTestJunit5 {
         byte[] digest2 = mdCopy.digest(input_3);
 
         assertFalse(Arrays.equals(digest1, digest2), "Digest of original matches clone's digest when it shouldn't");
+    }
+
+    /**
+     * Ensure a ArrayIndexOutOfBoundsException is thrown with negative offset parameter.
+     */
+    @Test
+    public void tesNegativeOffset() throws Exception {
+        MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
+        byte[] bytes = new byte[] {1, 1, 1, 1, 1};
+        try {
+            md.update(bytes, -1, 1);
+            fail("Expected exception not thrown.");
+        } catch (ArrayIndexOutOfBoundsException e) {
+            assertEquals("Range out of bounds for buffer of length 5 using offset: -1, input length: 1", e.getMessage());
+        }
+    }
+
+    /**
+     * Ensure a ArrayIndexOutOfBoundsException is thrown with negative length parameter.
+     */
+    @Test
+    public void testNegativeLength() throws Exception {
+        MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
+        byte[] bytes = new byte[] {1, 1, 1, 1, 1};
+        try {
+            md.update(bytes, 1, -1);
+            fail("Expected exception not thrown.");
+        } catch (ArrayIndexOutOfBoundsException e) {
+            assertEquals("Range out of bounds for buffer of length 5 using offset: 1, input length: -1", e.getMessage());
+        }
+    }
+
+    /**
+     * Ensure a IllegalArgumentException is thrown when using a short buffer.
+     */
+    @Test
+    public void testShortBuffer() throws Exception {
+        MessageDigest md = MessageDigest.getInstance(getAlgorithm(), getProviderName());
+        byte[] bytes = new byte[] {1, 1, 1, 1, 1};
+        try {
+            md.update(bytes, 1, 5);
+            fail("Expected exception not thrown.");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Input buffer too short", e.getMessage());
+        }
     }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA1.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BaseTestSHA1 extends BaseTestMessageDigestClone {
+public class BaseTestSHA1 extends BaseTestMessageDigest {
 
     static byte[] each = {(byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x1, (byte) 0x0, (byte) 0x73,
             (byte) 0x0, (byte) 0x75, (byte) 0x0, (byte) 0x62, (byte) 0x0, (byte) 0x2d, (byte) 0x0,

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA224.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA224.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BaseTestSHA224 extends BaseTestMessageDigestClone {
+public class BaseTestSHA224 extends BaseTestMessageDigest {
     static final byte[] input_1 = {(byte) 0x61, (byte) 0x62, (byte) 0x63};
     static final byte[] digest_1 = {(byte) 0x23, (byte) 0x09, (byte) 0x7d, (byte) 0x22, (byte) 0x34,
             (byte) 0x05, (byte) 0xd8, (byte) 0x22, (byte) 0x86, (byte) 0x42, (byte) 0xa4,

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA256.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA256.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BaseTestSHA256 extends BaseTestMessageDigestClone {
+public class BaseTestSHA256 extends BaseTestMessageDigest {
 
     final byte[] input_1 = {(byte) 0x61, (byte) 0x61, (byte) 0x61, (byte) 0x61, (byte) 0x61,
             (byte) 0x61, (byte) 0x61, (byte) 0x61, (byte) 0x61, (byte) 0x61};

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA384.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA384.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BaseTestSHA384 extends BaseTestMessageDigestClone {
+public class BaseTestSHA384 extends BaseTestMessageDigest {
 
     final byte[] input_1 = {(byte) 0x61, (byte) 0x61, (byte) 0x61, (byte) 0x61, (byte) 0x61,
             (byte) 0x61, (byte) 0x61, (byte) 0x61, (byte) 0x61, (byte) 0x61};

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_224KAT.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_224KAT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BaseTestSHA3_224KAT extends BaseTestMessageDigestClone {
+public class BaseTestSHA3_224KAT extends BaseTestMessageDigest {
 
     final String[][] tests = {{
             "31c82d71785b7ca6b651cb6c8c9ad5e2aceb0b0633c088d33aa247ada7a594ff4936c023251319820a9b19fc6c48de8a6f7ada214176ccdaadaeef51ed43714ac0c8269bbd497e46e78bb5e58196494b2471b1680e2d4c6dbd249831bd83a4d3be06c8a2e903933974aa05ee748bfe6ef359f7a143edf0d4918da916bd6f15e26a790cff514b40a5da7f72e1ed2fe63a05b8149587bea05653718cc8980eadbfeca85b7c9c286dd040936585938be7f98219700c83a9443c2856a80ff46852b26d1b1edf72a30203cf6c44a10fa6eaf1920173cedfb5c4cf3ac665b37a86ed02155bbbf17dc2e786af9478fe0889d86c5bfa85a242eb0854b1482b7bd16f67f80bef9c7a628f05a107936a64273a97b0088b0e515451f916b5656230a12ba6dc78",

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_256KAT.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_256KAT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BaseTestSHA3_256KAT extends BaseTestMessageDigestClone {
+public class BaseTestSHA3_256KAT extends BaseTestMessageDigest {
 
     final String[][] tests = {{
             "b1caa396771a09a1db9bc20543e988e359d47c2a616417bbca1b62cb02796a888fc6eeff5c0b5c3d5062fcb4256f6ae1782f492c1cf03610b4a1fb7b814c057878e1190b9835425c7a4a0e182ad1f91535ed2a35033a5d8c670e21c575ff43c194a58a82d4a1a44881dd61f9f8161fc6b998860cbe4975780be93b6f87980bad0a99aa2cb7556b478ca35d1f3746c33e2bb7c47af426641cc7bbb3425e2144820345e1d0ea5b7da2c3236a52906acdc3b4d34e474dd714c0c40bf006a3a1d889a632983814bbc4a14fe5f159aa89249e7c738b3b73666bac2a615a83fd21ae0a1ce7352ade7b278b587158fd2fabb217aa1fe31d0bda53272045598015a8ae4d8cec226fefa58daa05500906c4d85e7567",

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_384KAT.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_384KAT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BaseTestSHA3_384KAT extends BaseTestMessageDigestClone {
+public class BaseTestSHA3_384KAT extends BaseTestMessageDigest {
 
     final String[][] tests = {{
             "5fe35923b4e0af7dd24971812a58425519850a506dfa9b0d254795be785786c319a2567cbaa5e35bcf8fe83d943e23fa5169b73adc1fcf8b607084b15e6a013df147e46256e4e803ab75c110f77848136be7d806e8b2f868c16c3a90c14463407038cb7d9285079ef162c6a45cedf9c9f066375c969b5fcbcda37f02aacff4f31cded3767570885426bebd9eca877e44674e9ae2f0c24cdd0e7e1aaf1ff2fe7f80a1c4f5078eb34cd4f06fa94a2d1eab5806ca43fd0f06c60b63d5402b95c70c21ea65a151c5cfaf8262a46be3c722264b",

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_512KAT.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA3_512KAT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BaseTestSHA3_512KAT extends BaseTestMessageDigestClone {
+public class BaseTestSHA3_512KAT extends BaseTestMessageDigest {
 
     final String[][] tests = {{
             "664ef2e3a7059daf1c58caf52008c5227e85cdcb83b4c59457f02c508d4f4f69f826bd82c0cffc5cb6a97af6e561c6f96970005285e58f21ef6511d26e709889a7e513c434c90a3cf7448f0caeec7114c747b2a0758a3b4503a7cf0c69873ed31d94dbef2b7b2f168830ef7da3322c3d3e10cafb7c2c33c83bbf4c46a31da90cff3bfd4ccc6ed4b310758491eeba603a76",

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA512.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA512.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BaseTestSHA512 extends BaseTestMessageDigestClone {
+public class BaseTestSHA512 extends BaseTestMessageDigest {
 
     final byte[] input_1 = {(byte) 0x61, (byte) 0x61, (byte) 0x61, (byte) 0x61, (byte) 0x61,
             (byte) 0x61, (byte) 0x61, (byte) 0x61, (byte) 0x61, (byte) 0x61};

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA512_224.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA512_224.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BaseTestSHA512_224 extends BaseTestMessageDigestClone {
+public class BaseTestSHA512_224 extends BaseTestMessageDigest {
 
     // Test vectors obtained from
     // http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA512_224.pdf

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA512_256.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA512_256.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BaseTestSHA512_256 extends BaseTestMessageDigestClone {
+public class BaseTestSHA512_256 extends BaseTestMessageDigest {
 
     // Test vectors obtained from
     // http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA512_256.pdf


### PR DESCRIPTION
The length passed into the MessageDigest update method was not being checked for a negative value. This update consolidates buffer length checking in `MessageDigest` for negative length, negative offset, and insufficient buffer size.

New tests were added to ensure expected behavior for for all digests implemented.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>