### PR TITLE
Update maven dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
                 <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
-                  <version>3.3.0</version>
+                  <version>3.5.3</version>
                   <configuration>
                     <useModulePath>false</useModulePath>
                     <!-- Could add -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0.0.0.0:8787 for debug -->
@@ -240,7 +240,7 @@
                 <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
-                  <version>3.3.0</version>
+                  <version>3.5.3</version>
                   <configuration>
                     <useModulePath>false</useModulePath>
                     <trimStackTrace>false</trimStackTrace>
@@ -314,7 +314,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.0</version>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
                     <consoleOutput>true</consoleOutput>
@@ -339,7 +339,7 @@
             <plugin>
               <groupId>org.codehaus.mojo</groupId>
               <artifactId>exec-maven-plugin</artifactId>
-              <version>3.4.1</version>
+              <version>3.5.0</version>
               <executions>
                 <execution>
                   <id>Execute Native Library Build Script</id>
@@ -359,7 +359,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.14.0</version>
                 <configuration>
                     <source>${jdk.build.target}</source>
                     <target>${jdk.build.target}</target>
@@ -528,7 +528,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.4.0-jre</version>
+            <version>33.4.8-jre</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.reporting</groupId>
@@ -538,7 +538,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>4.0.0-rc-2</version>
+            <version>4.0.0-rc-3</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.mojo</groupId>
@@ -553,7 +553,7 @@
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>3.5.2</version>
+            <version>3.5.3</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -564,25 +564,25 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-suite</artifactId>
-            <version>1.12.0</version>
+            <version>1.13.0-M3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.12.0</version>
+            <version>5.13.0-M3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.12.0</version>
+            <version>5.13.0-M3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.12.0</version>
+            <version>5.13.0-M3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -600,12 +600,12 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.18.0</version>
+            <version>2.19.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
-            <version>4.0.0-beta-1</version>
+            <version>3.4.2</version>
             <type>maven-plugin</type>
             <exclusions>
                 <exclusion>
@@ -662,7 +662,7 @@
         <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.12</version>
+            <version>0.8.13</version>
         </dependency>
     </dependencies>
     <groupId>crypto</groupId>


### PR DESCRIPTION
This update moves to the latest mvn dependencies available.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/592

Signed-off-by: Jason Katonica <katonica@us.ibm.com>

