### PR TITLE
Check for acceptable values in NamedParameterSpec

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/CurveUtil.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/CurveUtil.java
@@ -9,7 +9,10 @@
 package com.ibm.crypto.plus.provider;
 
 import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidParameterException;
+import java.security.ProviderException;
+import java.security.spec.NamedParameterSpec;
 import java.util.HashMap;
 import java.util.Map;
 import sun.security.util.KnownOIDs;
@@ -117,25 +120,44 @@ class CurveUtil {
     }
 
     /**
-     * Returns the curve type based on the provided curve name.
+     * Returns the Ed curve type based on the provided named parameter spec.
      *
-     * @param curveName
-     * @return curveType
-     * @throws InvalidParameterException
+     * @param   params
+     * @return  CURVE
+     * @throws  InvalidAlgorithmParameterException
      */
-    public static CURVE getCurve(String curveName)
-            throws InvalidParameterException {
+    public static CURVE getEdCurve(NamedParameterSpec params)
+            throws InvalidAlgorithmParameterException {
+        String curveName = params.getName();
         if (curveName == null)
-            throw new InvalidParameterException();
+            throw new InvalidAlgorithmParameterException("Invalid AlgorithmParameterSpec: " + params);
+        switch (curveName.toUpperCase()) {
+            case "ED25519":
+                return CURVE.Ed25519;
+            case "ED448":
+                return CURVE.Ed448;
+            default:
+                throw new InvalidAlgorithmParameterException("Invalid AlgorithmParameterSpec: " + params);
+        }
+    }
+
+    /**
+     * Returns the XEC curve type based on the provided named parameter spec.
+     *
+     * @param   params
+     * @return  CURVE
+     * @throws  InvalidAlgorithmParameterException
+     */
+    public static CURVE getXCurve(NamedParameterSpec params)
+            throws InvalidAlgorithmParameterException {
+        String curveName = params.getName();
+        if (curveName == null)
+            throw new InvalidAlgorithmParameterException("Invalid AlgorithmParameterSpec: " + params);
         switch (curveName.toUpperCase()) {
             case "X25519":
                 return CURVE.X25519;
             case "X448":
                 return CURVE.X448;
-            case "ED25519":
-                return CURVE.Ed25519;
-            case "ED448":
-                return CURVE.Ed448;
             case "FFDHE2048":
                 return CurveUtil.CURVE.FFDHE2048;
             case "FFDHE3072":
@@ -147,7 +169,7 @@ class CurveUtil {
             case "FFDHE8192":
                 return CurveUtil.CURVE.FFDHE8192;
             default:
-                throw new InvalidParameterException("Curve not supported: " + curveName);
+                throw new InvalidAlgorithmParameterException("Invalid AlgorithmParameterSpec: " + params);
         }
     }
 
@@ -159,7 +181,25 @@ class CurveUtil {
      * @throws IOException
      */
     public static AlgorithmId getAlgId(String curveName) throws IOException {
-        return getAlgId(getCurve(curveName));
+        try {
+            CURVE curve;
+            curveName = curveName.toUpperCase();
+            NamedParameterSpec spec = new NamedParameterSpec(curveName);
+            if (curveName.contains("ED")) {
+                curve = getEdCurve(spec);
+            } else if (curveName.contains("X") || curveName.contains("FFDHE")) {
+                curve = getXCurve(spec);
+            } else {
+                // Should never happen, since this is used by the key impls created
+                // from the key generators.
+                throw new ProviderException("getAldId was called with a non-supported curve: " + curveName);
+            }
+            return getAlgId(curve);
+        } catch (InvalidAlgorithmParameterException iape) {
+            // Should never happen, since this is used by the key impls created
+            // from the key generators.
+            throw new ProviderException("getAldId was called with a non-supported curve", iape);
+        }
     }
 
     /**

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAKeyFactory.java
@@ -8,6 +8,7 @@
 
 package com.ibm.crypto.plus.provider;
 
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.KeyFactorySpi;
@@ -55,7 +56,11 @@ public class EdDSAKeyFactory extends KeyFactorySpi {
             if (key instanceof com.ibm.crypto.plus.provider.EdDSAPublicKeyImpl) {
                 return key;
             } else {
-                return new EdDSAPublicKeyImpl(provider, params, publicKey.getPoint());
+                try {
+                    return new EdDSAPublicKeyImpl(provider, params, publicKey.getPoint());
+                } catch (InvalidAlgorithmParameterException iape) {
+                    throw new InvalidKeyException(iape);
+                }
             }
         } else if (key instanceof EdECPrivateKey) {
             EdDSAPrivateKeyImpl privKey = null;
@@ -69,7 +74,11 @@ public class EdDSAKeyFactory extends KeyFactorySpi {
             if (key instanceof com.ibm.crypto.plus.provider.EdDSAPrivateKeyImpl) {
                 privKey = (com.ibm.crypto.plus.provider.EdDSAPrivateKeyImpl) key;
             } else {
-                privKey = new EdDSAPrivateKeyImpl(provider, params, Optional.of(privateKeyBytes));
+                try {
+                    privKey = new EdDSAPrivateKeyImpl(provider, params, Optional.of(privateKeyBytes));
+                } catch (InvalidAlgorithmParameterException iape) {
+                    throw new InvalidKeyException(iape);
+                }
             }
             return privKey;
         } else if (key instanceof PublicKey && key.getFormat().equals("X.509")) {
@@ -131,7 +140,11 @@ public class EdDSAKeyFactory extends KeyFactorySpi {
             EdECPublicKeySpec publicKeySpec = (EdECPublicKeySpec) keySpec;
             NamedParameterSpec params = publicKeySpec.getParams();
             checkLockedParams(params);
-            return new EdDSAPublicKeyImpl(provider, params, publicKeySpec.getPoint());
+            try {
+                return new EdDSAPublicKeyImpl(provider, params, publicKeySpec.getPoint());
+            } catch (InvalidAlgorithmParameterException iape) {
+                throw new InvalidKeySpecException(iape);
+            }
         } else {
             throw new InvalidKeySpecException(
                     "Only X509EncodedKeySpec and EdECPublicKeySpec are supported");
@@ -160,6 +173,8 @@ public class EdDSAKeyFactory extends KeyFactorySpi {
             byte[] bytes = privateKeySpec.getBytes();
             try {
                 return new EdDSAPrivateKeyImpl(provider, params, Optional.of(bytes));
+            } catch (InvalidAlgorithmParameterException iape) {
+                throw new InvalidKeySpecException(iape);
             } finally {
                 Arrays.fill(bytes, (byte) 0);
             }

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAKeyPairGenerator.java
@@ -94,7 +94,7 @@ abstract class EdDSAKeyPairGenerator extends KeyPairGeneratorSpi {
             throw new InvalidAlgorithmParameterException("Parameters must be " + this.alg);
         }
 
-        this.curve = CurveUtil.getCurve(this.namedSpec.getName());
+        this.curve = CurveUtil.getEdCurve(this.namedSpec);
     }
 
     @Override

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAPrivateKeyImpl.java
@@ -12,6 +12,7 @@ import com.ibm.crypto.plus.provider.CurveUtil.CURVE;
 import com.ibm.crypto.plus.provider.ock.XECKey;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
 import java.security.KeyRep;
@@ -72,12 +73,12 @@ final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKey {
 
     EdDSAPrivateKeyImpl(OpenJCEPlusProvider provider,
             NamedParameterSpec params, Optional<byte[]> h)
-            throws InvalidParameterException, InvalidKeyException {
+            throws InvalidAlgorithmParameterException, InvalidParameterException, InvalidKeyException {
 
         this.provider = provider;
         this.paramSpec = params;
 
-        this.curve = CurveUtil.getCurve(params.getName());
+        this.curve = CurveUtil.getEdCurve(params);
 
         try {
             this.algid = CurveUtil.getAlgId(this.curve);

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAPublicKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAPublicKeyImpl.java
@@ -12,6 +12,7 @@ import com.ibm.crypto.plus.provider.CurveUtil.CURVE;
 import com.ibm.crypto.plus.provider.ock.XECKey;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
 import java.security.KeyRep;
@@ -85,14 +86,14 @@ final class EdDSAPublicKeyImpl extends X509Key implements EdECPublicKey {
 
     EdDSAPublicKeyImpl(OpenJCEPlusProvider provider,
             NamedParameterSpec params, EdECPoint point)
-            throws InvalidParameterException, InvalidKeyException {
+            throws InvalidAlgorithmParameterException, InvalidParameterException, InvalidKeyException {
 
         if (provider == null)
             throw new InvalidKeyException("provider cannot be null");
         this.paramSpec = params;
         this.point = point;
 
-        this.curve = CurveUtil.getCurve(params.getName());
+        this.curve = CurveUtil.getEdCurve(params);
 
         try {
             this.algid = CurveUtil.getAlgId(this.curve);

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
@@ -9,6 +9,7 @@
 package com.ibm.crypto.plus.provider;
 
 
+import com.ibm.crypto.plus.provider.CurveUtil.CURVE;
 import com.ibm.crypto.plus.provider.ock.OCKException;
 import com.ibm.crypto.plus.provider.ock.XECKey;
 import java.security.InvalidAlgorithmParameterException;
@@ -224,8 +225,15 @@ abstract class XDHKeyAgreement extends KeyAgreementSpi {
             throws InvalidKeyException, InvalidAlgorithmParameterException {
 
         // Check if parameter is a valid NamedParameterSpec instance
-        if ((params != null) && !(params instanceof NamedParameterSpec)) {
-            throw new InvalidAlgorithmParameterException("Invalid Parameters: " + params);
+        if (params != null) {
+            if (params instanceof NamedParameterSpec nps) {
+                CURVE curve = CurveUtil.getXCurve(nps);
+                if ((this.alg != null) && !this.alg.equalsIgnoreCase(curve.name())) {
+                    throw new InvalidAlgorithmParameterException("Invalid Parameters: " + params);
+                }
+            } else {
+                throw new InvalidAlgorithmParameterException("Invalid Parameters: " + params);
+            }
         }
 
         if (!(key instanceof XDHPrivateKeyImpl)) {
@@ -245,7 +253,8 @@ abstract class XDHKeyAgreement extends KeyAgreementSpi {
         if (this.alg != null
                 && !(((NamedParameterSpec) ((XDHPrivateKeyImpl) key).getParams())
                         .getName().equals(this.alg))) {
-            throw new InvalidKeyException("Parameters must be " + this.alg);
+            throw new InvalidKeyException("Parameters must be " + this.alg + " but is " + ((NamedParameterSpec) ((XDHPrivateKeyImpl) key).getParams())
+            .getName());
         }
 
         ockXecKeyPriv = xdhPrivateKeyImpl.getOCKKey();

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyFactory.java
@@ -9,6 +9,7 @@
 package com.ibm.crypto.plus.provider;
 
 import java.math.BigInteger;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
 import java.security.Key;
@@ -68,7 +69,11 @@ class XDHKeyFactory extends KeyFactorySpi {
                 }
 
                 BigInteger u = publicKeySpec.getU();
-                return new XDHPublicKeyImpl(provider, params, u);
+                try {
+                    return new XDHPublicKeyImpl(provider, params, u);
+                } catch (InvalidAlgorithmParameterException iape) {
+                    throw new InvalidKeySpecException(iape);
+                }
             } else if (keySpec instanceof X509EncodedKeySpec) {
                 return new XDHPublicKeyImpl(provider, ((X509EncodedKeySpec) keySpec).getEncoded());
             } else
@@ -100,7 +105,11 @@ class XDHKeyFactory extends KeyFactorySpi {
                 }
 
                 Optional<byte[]> scalar = Optional.of(privateKeySpec.getScalar());
-                return new XDHPrivateKeyImpl(provider, params, scalar);
+                try {
+                    return new XDHPrivateKeyImpl(provider, params, scalar);
+                } catch (InvalidAlgorithmParameterException iape) {
+                    throw new InvalidKeySpecException(iape);
+                }
             } else if (keySpec instanceof PKCS8EncodedKeySpec) {
                 return new XDHPrivateKeyImpl(provider,
                         ((PKCS8EncodedKeySpec) keySpec).getEncoded());

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.math.BigInteger;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
 import java.security.KeyRep;
@@ -114,7 +115,7 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
      * @param params   must be of type NamedParameterSpec
      */
     public XDHPrivateKeyImpl(OpenJCEPlusProvider provider, AlgorithmParameterSpec params,
-            Optional<byte[]> scalar) throws InvalidParameterException {
+            Optional<byte[]> scalar) throws InvalidAlgorithmParameterException, InvalidParameterException {
 
         if (provider == null) {
             throw new InvalidParameterException("provider must not be null");
@@ -126,7 +127,7 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
             throw new InvalidParameterException("Invalid Parameters: " + params);
         }
 
-        this.curve = CurveUtil.getCurve(this.params.getName());
+        this.curve = CurveUtil.getXCurve(this.params);
 
         try {
             if (CurveUtil.isFFDHE(this.curve))

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
@@ -13,6 +13,7 @@ import com.ibm.crypto.plus.provider.ock.XECKey;
 import java.io.IOException;
 import java.io.Serializable;
 import java.math.BigInteger;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
 import java.security.KeyRep;
@@ -146,7 +147,7 @@ final class XDHPublicKeyImpl extends X509Key implements XECPublicKey, Destroyabl
      * @throws InvalidParameterException
      */
     public XDHPublicKeyImpl(OpenJCEPlusProvider provider, AlgorithmParameterSpec params,
-            BigInteger u) throws InvalidParameterException, InvalidKeyException {
+            BigInteger u) throws InvalidAlgorithmParameterException, InvalidParameterException, InvalidKeyException {
 
         if (provider == null) {
             throw new InvalidParameterException("provider must not be null");
@@ -158,7 +159,7 @@ final class XDHPublicKeyImpl extends X509Key implements XECPublicKey, Destroyabl
             throw new InvalidParameterException("Invalid Parameters: " + params);
         }
 
-        this.curve = CurveUtil.getCurve(this.params.getName());
+        this.curve = CurveUtil.getXCurve(this.params);
 
         try {
             if (CurveUtil.isFFDHE(this.curve))

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
@@ -33,6 +33,7 @@ import javax.crypto.KeyAgreement;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestXDH extends BaseTestJunit5 {
 
@@ -88,6 +89,19 @@ public class BaseTestXDH extends BaseTestJunit5 {
         System.out.println(
                 "\n\n\n\n************************** Starting runCurveMixTest ************************");
         runCurveMixTest();
+    }
+
+    @Test
+    public void testInvalidSpec() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("XDH", getProviderName());
+        KeyPair kp = kpg.generateKeyPair();
+        KeyAgreement ka = KeyAgreement.getInstance("XDH", getProviderName());
+        try {
+            ka.init(kp.getPrivate(), new NamedParameterSpec("invalid"));
+            fail("Expected InvalidAlgorithmParameterException not thrown");
+        } catch (InvalidAlgorithmParameterException iape) {
+            // expected
+        }
     }
 
     void compute_xdh_key(String idString, NamedParameterSpec algParameterSpec)

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyPairGenerator.java
@@ -8,6 +8,7 @@
 
 package ibm.jceplus.junit.base;
 
+import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import sun.security.util.InternalPrivateKey;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestXDHKeyPairGenerator extends BaseTestJunit5 {
 
@@ -64,6 +66,24 @@ public class BaseTestXDHKeyPairGenerator extends BaseTestJunit5 {
     @Test
     public void testXECKeyGen_FFDHE8192() throws Exception {
         doXECKeyGen(8192);
+    }
+
+    @Test
+    public void testInvalidSpec() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("XDH", getProviderName());
+        try {
+            kpg.initialize(new NamedParameterSpec("invalid"));
+            fail("Expected InvalidAlgorithmParameterException not thrown");
+        } catch (InvalidAlgorithmParameterException iape) {
+            // expected
+        }
+
+        try {
+            kpg.initialize(new NamedParameterSpec("Ed25519"));
+            fail("Expected InvalidAlgorithmParameterException not thrown");
+        } catch (InvalidAlgorithmParameterException iape) {
+            // expected
+        }
     }
 
     public void doXECKeyGen(int keypairSize) throws Exception {
@@ -112,8 +132,6 @@ public class BaseTestXDHKeyPairGenerator extends BaseTestJunit5 {
         generictestXECKeyGenCurve("FFDHE4096");
         generictestXECKeyGenCurve("FFDHE6144");
         generictestXECKeyGenCurve("FFDHE8192");
-        generictestXECKeyGenCurve("Ed25519");
-        generictestXECKeyGenCurve("Ed448");
     }
 
     protected void generictestXECKeyGenCurve(String curveName) throws Exception {


### PR DESCRIPTION
When initializing `XDH` or `Ed` instances of keypair generator, key factory and/or key agreement classes using a `NamedParameterSpec` instance, ensure that only appropriate values are accepted or throw an `InvalidAlgorithmParameterException`.

Tests to check that functionality are also added.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/593

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>