### PR TITLE
Check for acceptable values in NamedParameterSpec

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
@@ -9,6 +9,7 @@
 package com.ibm.crypto.plus.provider;
 
 
+import com.ibm.crypto.plus.provider.CurveUtil.CURVE;
 import com.ibm.crypto.plus.provider.ock.OCKException;
 import com.ibm.crypto.plus.provider.ock.XECKey;
 import java.security.InvalidAlgorithmParameterException;
@@ -224,8 +225,16 @@ abstract class XDHKeyAgreement extends KeyAgreementSpi {
             throws InvalidKeyException, InvalidAlgorithmParameterException {
 
         // Check if parameter is a valid NamedParameterSpec instance
-        if ((params != null) && !(params instanceof NamedParameterSpec)) {
-            throw new InvalidAlgorithmParameterException("Invalid Parameters: " + params);
+        if (params != null) {
+            if (params instanceof NamedParameterSpec) {
+                NamedParameterSpec nps = (NamedParameterSpec) params;
+                CURVE curve = CurveUtil.getXCurve(nps);
+                if ((this.alg != null) && !this.alg.equalsIgnoreCase(curve.name())) {
+                    throw new InvalidAlgorithmParameterException("Invalid Parameters: " + params);
+                }
+            } else {
+                throw new InvalidAlgorithmParameterException("Invalid Parameters: " + params);
+            }
         }
 
         if (!(key instanceof XDHPrivateKeyImpl)) {
@@ -245,7 +254,8 @@ abstract class XDHKeyAgreement extends KeyAgreementSpi {
         if (this.alg != null
                 && !(((NamedParameterSpec) ((XDHPrivateKeyImpl) key).getParams())
                         .getName().equals(this.alg))) {
-            throw new InvalidKeyException("Parameters must be " + this.alg);
+            throw new InvalidKeyException("Parameters must be " + this.alg + " but is " + ((NamedParameterSpec) ((XDHPrivateKeyImpl) key).getParams())
+            .getName());
         }
 
         ockXecKeyPriv = xdhPrivateKeyImpl.getOCKKey();

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyFactory.java
@@ -9,6 +9,7 @@
 package com.ibm.crypto.plus.provider;
 
 import java.math.BigInteger;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
 import java.security.Key;
@@ -68,7 +69,11 @@ class XDHKeyFactory extends KeyFactorySpi {
                 }
 
                 BigInteger u = publicKeySpec.getU();
-                return new XDHPublicKeyImpl(provider, params, u);
+                try {
+                    return new XDHPublicKeyImpl(provider, params, u);
+                } catch (InvalidAlgorithmParameterException iape) {
+                    throw new InvalidKeySpecException(iape);
+                }
             } else if (keySpec instanceof X509EncodedKeySpec) {
                 return new XDHPublicKeyImpl(provider, ((X509EncodedKeySpec) keySpec).getEncoded());
             } else
@@ -100,7 +105,11 @@ class XDHKeyFactory extends KeyFactorySpi {
                 }
 
                 Optional<byte[]> scalar = Optional.of(privateKeySpec.getScalar());
-                return new XDHPrivateKeyImpl(provider, params, scalar);
+                try {
+                    return new XDHPrivateKeyImpl(provider, params, scalar);
+                } catch (InvalidAlgorithmParameterException iape) {
+                    throw new InvalidKeySpecException(iape);
+                }
             } else if (keySpec instanceof PKCS8EncodedKeySpec) {
                 return new XDHPrivateKeyImpl(provider,
                         ((PKCS8EncodedKeySpec) keySpec).getEncoded());

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.math.BigInteger;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
 import java.security.KeyRep;
@@ -112,7 +113,7 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
      * @param params   must be of type NamedParameterSpec
      */
     public XDHPrivateKeyImpl(OpenJCEPlusProvider provider, AlgorithmParameterSpec params,
-            Optional<byte[]> scalar) throws InvalidParameterException {
+            Optional<byte[]> scalar) throws InvalidAlgorithmParameterException, InvalidParameterException {
 
         if (provider == null) {
             throw new InvalidParameterException("provider must not be null");
@@ -124,7 +125,7 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
             throw new InvalidParameterException("Invalid Parameters: " + params);
         }
 
-        this.curve = CurveUtil.getCurve(this.params.getName());
+        this.curve = CurveUtil.getXCurve(this.params);
 
         try {
             if (CurveUtil.isFFDHE(this.curve))

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
@@ -13,6 +13,7 @@ import com.ibm.crypto.plus.provider.ock.XECKey;
 import java.io.IOException;
 import java.io.Serializable;
 import java.math.BigInteger;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
 import java.security.KeyRep;
@@ -146,7 +147,7 @@ final class XDHPublicKeyImpl extends X509Key implements XECPublicKey, Destroyabl
      * @throws InvalidParameterException
      */
     public XDHPublicKeyImpl(OpenJCEPlusProvider provider, AlgorithmParameterSpec params,
-            BigInteger u) throws InvalidParameterException, InvalidKeyException {
+            BigInteger u) throws InvalidAlgorithmParameterException, InvalidParameterException, InvalidKeyException {
 
         if (provider == null) {
             throw new InvalidParameterException("provider must not be null");
@@ -158,7 +159,7 @@ final class XDHPublicKeyImpl extends X509Key implements XECPublicKey, Destroyabl
             throw new InvalidParameterException("Invalid Parameters: " + params);
         }
 
-        this.curve = CurveUtil.getCurve(this.params.getName());
+        this.curve = CurveUtil.getXCurve(this.params);
 
         try {
             if (CurveUtil.isFFDHE(this.curve))

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
@@ -33,6 +33,7 @@ import javax.crypto.KeyAgreement;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestXDH extends BaseTestJunit5 {
 
@@ -88,6 +89,19 @@ public class BaseTestXDH extends BaseTestJunit5 {
         System.out.println(
                 "\n\n\n\n************************** Starting runCurveMixTest ************************");
         runCurveMixTest();
+    }
+
+    @Test
+    public void testInvalidSpec() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("XDH", getProviderName());
+        KeyPair kp = kpg.generateKeyPair();
+        KeyAgreement ka = KeyAgreement.getInstance("XDH", getProviderName());
+        try {
+            ka.init(kp.getPrivate(), new NamedParameterSpec("invalid"));
+            fail("Expected InvalidAlgorithmParameterException not thrown");
+        } catch (InvalidAlgorithmParameterException iape) {
+            // expected
+        }
     }
 
     void compute_xdh_key(String idString, NamedParameterSpec algParameterSpec)

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyPairGenerator.java
@@ -8,6 +8,7 @@
 
 package ibm.jceplus.junit.base;
 
+import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.interfaces.XECPrivateKey;
@@ -15,6 +16,7 @@ import java.security.interfaces.XECPublicKey;
 import java.security.spec.NamedParameterSpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestXDHKeyPairGenerator extends BaseTestJunit5 {
 
@@ -60,6 +62,24 @@ public class BaseTestXDHKeyPairGenerator extends BaseTestJunit5 {
     @Test
     public void testXECKeyGen_FFDHE8192() throws Exception {
         doXECKeyGen(8192);
+    }
+
+    @Test
+    public void testInvalidSpec() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("XDH", getProviderName());
+        try {
+            kpg.initialize(new NamedParameterSpec("invalid"));
+            fail("Expected InvalidAlgorithmParameterException not thrown");
+        } catch (InvalidAlgorithmParameterException iape) {
+            // expected
+        }
+
+        try {
+            kpg.initialize(new NamedParameterSpec("Ed25519"));
+            fail("Expected InvalidAlgorithmParameterException not thrown");
+        } catch (InvalidAlgorithmParameterException iape) {
+            // expected
+        }
     }
 
     public void doXECKeyGen(int keypairSize) throws Exception {


### PR DESCRIPTION
When initializing `XDH` or `Ed` instances of keypair generator, key factory and/or key agreement classes using a `NamedParameterSpec` instance, ensure that only appropriate values are accepted or throw an `InvalidAlgorithmParameterException`.

Tests to check that functionality are also added.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/593

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>