### PR TITLE
Accept spec using a lowercase x448 curve name

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyFactory.java
@@ -64,7 +64,7 @@ class XDHKeyFactory extends KeyFactorySpi {
                 }
 
                 //Validate algs match for key and keyfactory
-                if (this.alg != null && !(params.getName().equals(this.alg))) {
+                if (this.alg != null && !(params.getName().equalsIgnoreCase(this.alg))) {
                     throw new InvalidKeySpecException("Parameters must be " + this.alg);
                 }
 
@@ -100,7 +100,7 @@ class XDHKeyFactory extends KeyFactorySpi {
                 }
 
                 //Validate algs match for key and keyfactory
-                if (this.alg != null && !(params.getName().equals(this.alg))) {
+                if (this.alg != null && !(params.getName().equalsIgnoreCase(this.alg))) {
                     throw new InvalidKeySpecException("Parameters must be " + this.alg);
                 }
 
@@ -141,7 +141,7 @@ class XDHKeyFactory extends KeyFactorySpi {
 
                     //Validate algs match for key and keyfactory
                     if (this.alg != null && !(((NamedParameterSpec) params)
-                            .getName().equals(this.alg))) {
+                            .getName().equalsIgnoreCase(this.alg))) {
                         throw new InvalidKeySpecException("Parameters must be " + this.alg);
                     }
 
@@ -164,7 +164,7 @@ class XDHKeyFactory extends KeyFactorySpi {
 
                     //Validate algs match for key and keyfactory
                     if (this.alg != null && !(((NamedParameterSpec) params)
-                            .getName().equals(this.alg))) {
+                            .getName().equalsIgnoreCase(this.alg))) {
                         throw new InvalidKeySpecException("Parameters must be " + this.alg);
                     }
 
@@ -189,7 +189,7 @@ class XDHKeyFactory extends KeyFactorySpi {
                 //Validate algs match for key and keyfactory
                 if (this.alg != null
                         && !(((NamedParameterSpec) ((XECPublicKey) key)
-                                .getParams()).getName().equals(this.alg))) {
+                                .getParams()).getName().equalsIgnoreCase(this.alg))) {
                     throw new InvalidKeyException("Parameters must be " + this.alg);
                 }
 
@@ -208,7 +208,7 @@ class XDHKeyFactory extends KeyFactorySpi {
                 //Validate algs match for key and keyfactory
                 if (this.alg != null
                         && !(((NamedParameterSpec) ((XECPrivateKey) key)
-                                .getParams()).getName().equals(this.alg))) {
+                                .getParams()).getName().equalsIgnoreCase(this.alg))) {
                     throw new InvalidKeyException("Parameters must be " + this.alg);
                 }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
@@ -184,7 +184,7 @@ final class XDHPublicKeyImpl extends X509Key implements XECPublicKey, Destroyabl
                     BigInteger p;
                     BigInteger TWO = BigInteger.valueOf(2);
 
-                    if (this.params.getName().equals("X448")) {
+                    if (this.curve.name().equals("X448")) {
                         p = TWO.pow(448).subtract(TWO.pow(224)).subtract(BigInteger.ONE);
                     } else { //X25519
                         p = TWO.pow(255).subtract(BigInteger.valueOf(19));


### PR DESCRIPTION
In the XDHPublicKeyImpl class, when generating the value of p, the code checks whether the curve is X448 using the condition "this.params.getName().equals("X448”)". However, the “params.getName()” returns x448 (lowercase), the check fails, and the code falls into the “else” block, which is for the X25519 curve.

Changing from “this.params.getName()” to “this.curve.name()” will fix the issue. Inside the “CurveUtil.getCurve()” method, the curve name is changed to uppercase before comparison, and return the uppercase. This will guarantee that
“this.curve.name()” always return uppercase “X448".