### PR TITLE
Check for appropriate curve before matching algorithm

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyPairGenerator.java
@@ -111,13 +111,14 @@ abstract class XDHKeyPairGenerator extends KeyPairGeneratorSpi {
      * @throws InvalidParameterException
      */
     private void initializeImpl(NamedParameterSpec params) throws InvalidAlgorithmParameterException {
+        CurveUtil.CURVE sc = CurveUtil.getXCurve(params);
         //Validate that the parameters match the alg specified on creation of this object
         if (this.alg != null && !params.getName().equals(this.alg)) {
             namedSpec = null;
             throw new InvalidParameterException("Parameters must be " + this.alg);
         }
 
-        serviceCurve = CurveUtil.getXCurve(params);
+        serviceCurve = sc;
         namedSpec = params;
     }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyPairGenerator.java
@@ -69,7 +69,7 @@ public class BaseTestXDHKeyPairGenerator extends BaseTestJunit5 {
     }
 
     @Test
-    public void testInvalidSpec() throws Exception {
+    public void testInvalidSpecXDH() throws Exception {
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("XDH", getProviderName());
         try {
             kpg.initialize(new NamedParameterSpec("invalid"));
@@ -80,6 +80,28 @@ public class BaseTestXDHKeyPairGenerator extends BaseTestJunit5 {
 
         try {
             kpg.initialize(new NamedParameterSpec("Ed25519"));
+            fail("Expected InvalidAlgorithmParameterException not thrown");
+        } catch (InvalidAlgorithmParameterException iape) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testInvalidSpecX25519() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("X25519", getProviderName());
+        try {
+            kpg.initialize(new NamedParameterSpec("invalid"));
+            fail("Expected InvalidAlgorithmParameterException not thrown");
+        } catch (InvalidAlgorithmParameterException iape) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testInvalidSpecX448() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("X448", getProviderName());
+        try {
+            kpg.initialize(new NamedParameterSpec("invalid"));
             fail("Expected InvalidAlgorithmParameterException not thrown");
         } catch (InvalidAlgorithmParameterException iape) {
             // expected


### PR DESCRIPTION
Ensure that the curve provided through the spec is a valid one before checking if it matches the keypair generators preset algorithm.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/605

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>