### PR TITLE
Migrate to latest OCKC version

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: IBM/OpenCryptographyKitC
-          ref: 411a80674cedc6d4bdb9d808df341c7a29170699 # main branch on Aug 11th 2024.
+          ref: 6c9c7b5df836e4831f603ad934e4765e976e597d # main branch on May 8th 2025.
           path: ${{ github.workspace }}/OpenCryptographyKitC
       - name: Compile Open Cryptography Kit C
         run: |

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,7 +139,7 @@ def getOCKTarget(hardware, software) {
  */
 def getBinaries(hardware, software) {
     if (OCK_RELEASE == "") {
-        OCK_RELEASE = "20240521_8.9.6"
+        OCK_RELEASE = "20250522_8.9.11"
     }
     def target = getOCKTarget(hardware, software)
     def gskit_bin = "https://na.artifactory.swg-devops.com/artifactory/sec-gskit-javasec-generic-local/gskit8/$OCK_RELEASE/$target/jgsk_crypto.tar"

--- a/src/main/native/DHKey.c
+++ b/src/main/native/DHKey.c
@@ -375,8 +375,8 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_DHKEY_1createPrivateKey(
 #endif
         throwOCKException(env, 0, "NULL from GetPrimitiveArrayCritical!");
     } else {
-        unsigned char *pBytes = (unsigned char *)keyBytesNative;
-        jint           size   = (*env)->GetArrayLength(env, privateKeyBytes);
+        const unsigned char *pBytes = (const unsigned char *)keyBytesNative;
+        jint size = (*env)->GetArrayLength(env, privateKeyBytes);
 
         ockPKey = ICC_EVP_PKEY_new(ockCtx);
         if (NULL == ockPKey) {

--- a/src/main/native/ECKey.c
+++ b/src/main/native/ECKey.c
@@ -1186,7 +1186,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_XECKEY_1createPrivateKey(
 #endif
         throwOCKException(env, 0, "NULL from GetPrimitiveArrayCritical!");
     } else {
-        pBytes = (const unsigned char *)keyBytesNative;
+        pBytes = (unsigned char *)keyBytesNative;
         size   = (size_t)(*env)->GetArrayLength(env, privateKeyBytes);
 #ifdef DEBUG_EC_DATA
         if (debug) {
@@ -1195,8 +1195,8 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_XECKEY_1createPrivateKey(
             gslogMessageHex((char *)pBytes, 0, size, 0, 0, NULL);
         }
 #endif
-        ICC_d2i_PrivateKey(ockCtx, ICC_EVP_PKEY_EC, &ockEVPKey,
-                           (unsigned char **)&pBytes, (long)size);
+        ICC_d2i_PrivateKey(ockCtx, ICC_EVP_PKEY_EC, &ockEVPKey, &pBytes,
+                           (long)size);
 #ifdef DEBUG_EC_DETAIL
         if (debug) {
             gslogMessage("DETAIL_XEC ockEVPKey=%lx", (long)ockEVPKey);
@@ -1244,16 +1244,16 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_ECKEY_1createPublicKey(
     jbyteArray parameterBytes) {
     static const char *functionName = "NativeInterface.ECKEY_createPublicKey";
 
-    ICC_CTX       *ockCtx               = (ICC_CTX *)((intptr_t)ockContextId);
-    ICC_EC_KEY    *ockECKey             = NULL;
-    unsigned char *keyBytesNative       = NULL;
-    unsigned char *parameterBytesNative = NULL;
-    jboolean       isCopy               = 0;
-    jlong          ecKeyId              = 0;
-    unsigned char *pKeyBytes            = NULL;
-    unsigned char *pParamBytes          = NULL;
-    jint           size                 = 0;
-    jint           paramsize            = 0;
+    ICC_CTX             *ockCtx         = (ICC_CTX *)((intptr_t)ockContextId);
+    ICC_EC_KEY          *ockECKey       = NULL;
+    unsigned char       *keyBytesNative = NULL;
+    unsigned char       *parameterBytesNative = NULL;
+    jboolean             isCopy               = 0;
+    jlong                ecKeyId              = 0;
+    const unsigned char *pKeyBytes            = NULL;
+    unsigned char       *pParamBytes          = NULL;
+    jint                 size                 = 0;
+    jint                 paramsize            = 0;
 
     if (debug) {
         gslogFunctionEntry(functionName);

--- a/src/main/native/RSAKey.c
+++ b/src/main/native/RSAKey.c
@@ -73,14 +73,14 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_RSAKEY_1createPrivateKey(
     jbyteArray privateKeyBytes) {
     static const char *functionName = "NativeInterface.RSAKEY_createPrivateKey";
 
-    ICC_CTX       *ockCtx         = (ICC_CTX *)((intptr_t)ockContextId);
-    ICC_RSA       *ockRSA         = NULL;
-    ICC_EVP_PKEY  *ockPKey        = NULL;
-    unsigned char *keyBytesNative = NULL;
-    jboolean       isCopy         = 0;
-    jlong          rsaKeyId       = 0;
-    unsigned char *pBytes         = NULL;
-    jint           size           = 0;
+    ICC_CTX             *ockCtx         = (ICC_CTX *)((intptr_t)ockContextId);
+    ICC_RSA             *ockRSA         = NULL;
+    ICC_EVP_PKEY        *ockPKey        = NULL;
+    unsigned char       *keyBytesNative = NULL;
+    jboolean             isCopy         = 0;
+    jlong                rsaKeyId       = 0;
+    const unsigned char *pBytes         = NULL;
+    jint                 size           = 0;
 
     if (debug) {
         gslogFunctionEntry(functionName);
@@ -108,7 +108,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_RSAKEY_1createPrivateKey(
             gslogMessage("DETAIL_RSA KeyBytesNative allocated");
         }
         //  unsigned char * pBytes = (unsigned char *)keyBytesNative;
-        pBytes = (unsigned char *)keyBytesNative;
+        pBytes = (const unsigned char *)keyBytesNative;
         //  jint size = (*env)->GetArrayLength(env, privateKeyBytes);
         size = (*env)->GetArrayLength(env, privateKeyBytes);
 #ifdef DEBUG_RSA_DATA
@@ -195,14 +195,14 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_RSAKEY_1createPublicKey(
     jbyteArray publicKeyBytes) {
     static const char *functionName = "NativeInterface.RSAKEY_createPublicKey";
 
-    ICC_CTX       *ockCtx         = (ICC_CTX *)((intptr_t)ockContextId);
-    ICC_RSA       *ockRSA         = NULL;
-    ICC_EVP_PKEY  *ockPKey        = NULL;
-    unsigned char *keyBytesNative = NULL;
-    jboolean       isCopy         = 0;
-    jlong          rsaKeyId       = 0;
-    unsigned char *pBytes         = NULL;
-    jint           size           = 0;
+    ICC_CTX             *ockCtx         = (ICC_CTX *)((intptr_t)ockContextId);
+    ICC_RSA             *ockRSA         = NULL;
+    ICC_EVP_PKEY        *ockPKey        = NULL;
+    unsigned char       *keyBytesNative = NULL;
+    jboolean             isCopy         = 0;
+    jlong                rsaKeyId       = 0;
+    const unsigned char *pBytes         = NULL;
+    jint                 size           = 0;
 
     if (debug) {
         gslogFunctionEntry(functionName);
@@ -229,7 +229,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_RSAKEY_1createPublicKey(
             gslogMessage("DETAIL_RSA KeyBytesNative allocated");
         }
 #endif
-        pBytes = (unsigned char *)keyBytesNative;
+        pBytes = (const unsigned char *)keyBytesNative;
         size   = (*env)->GetArrayLength(env, publicKeyBytes);
 #ifdef DEBUG_RSA_DATA
         if (debug) {


### PR DESCRIPTION
This update picks up the latest OCKC version. Minor updates due to a header file change are also included along with clang-format related whitespace violations in these files.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/615

Signed-off-by: Jason Katonica <katonica@us.ibm.com>