### PR TITLE
Remove commons-beanutils-1.9.4.jar dependency due to vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -573,6 +573,10 @@
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-beanutils</groupId>
+                    <artifactId>commons-beanutils</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -584,6 +588,12 @@
             <groupId>org.apache.maven.reporting</groupId>
             <artifactId>maven-reporting-impl</artifactId>
             <version>4.0.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-beanutils</groupId>
+                    <artifactId>commons-beanutils</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
This update remove the commons-beanutils-1.9.4.jar dependency due to vulnerability.