### PR TITLE
Add PBKDF2 multithreaded tests

### DIFF
--- a/src/test/java/ibm/jceplus/junit/TestMultithread.java
+++ b/src/test/java/ibm/jceplus/junit/TestMultithread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -65,6 +65,8 @@ public class TestMultithread {
             "ibm.jceplus.junit.openjceplus.multithread.TestHmacSHA3_384",
             "ibm.jceplus.junit.openjceplus.multithread.TestHmacSHA3_512",
             "ibm.jceplus.junit.openjceplus.multithread.TestMiniRSAPSS2",
+            "ibm.jceplus.junit.openjceplus.multithread.TestPBKDF2",
+            "ibm.jceplus.junit.openjceplus.multithread.TestPBKDF2Interop",
             "ibm.jceplus.junit.openjceplus.multithread.TestRSASignature",
             "ibm.jceplus.junit.openjceplus.multithread.TestRSA_2048",
             "ibm.jceplus.junit.openjceplus.multithread.TestRSAKey",

--- a/src/test/java/ibm/jceplus/junit/TestMultithreadFIPS.java
+++ b/src/test/java/ibm/jceplus/junit/TestMultithreadFIPS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -61,6 +61,8 @@ public class TestMultithreadFIPS {
             "ibm.jceplus.junit.openjceplusfips.multithread.TestHmacSHA3_384",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestHmacSHA3_512",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestMiniRSAPSS2",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestPBKDF2",
+            "ibm.jceplus.junit.openjceplusfips.multithread.TestPBKDF2Interop",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestRSASignature",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestRSA_2048",
             "ibm.jceplus.junit.openjceplusfips.multithread.TestRSAKey",

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPBKDF2.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPBKDF2.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * 
  */
 public class BaseTestPBKDF2 extends BaseTestJunit5Interop {
-    static List<String> allowableFIPSAlgorithms = new ArrayList<String>(){{
+    List<String> allowableFIPSAlgorithms = new ArrayList<String>(){{
             add("PBKDF2WithHmacSHA224");
             add("PBKDF2WithHmacSHA256");
             add("PBKDF2WithHmacSHA384");

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPBKDF2Interop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPBKDF2Interop.java
@@ -28,11 +28,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class BaseTestPBKDF2Interop extends BaseTestJunit5Interop {
 
-    static final String PASSWORD = "Thequickbrownfoxjumpsoverthelazydog";
-    static byte[] randomSalt = new byte[32];
-    static SecureRandom random = new SecureRandom();
-    static PBEKeySpec pbeks = null;
-    static List<String> allowableFIPSAlgorithms = new ArrayList<String>(){{
+    final String PASSWORD = "Thequickbrownfoxjumpsoverthelazydog";
+    byte[] randomSalt = new byte[32];
+    SecureRandom random = new SecureRandom();
+    PBEKeySpec pbeks = null;
+    List<String> allowableFIPSAlgorithms = new ArrayList<String>(){{
             add("PBKDF2WithHmacSHA224");
             add("PBKDF2WithHmacSHA256");
             add("PBKDF2WithHmacSHA384");

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestPBKDF2.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestPBKDF2.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright IBM Corp. 2023, 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.junit.openjceplus.multithread;
+
+import ibm.jceplus.junit.base.BaseTestPBKDF2;
+import ibm.jceplus.junit.openjceplus.Utils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestPBKDF2 extends BaseTestPBKDF2 {
+
+    @BeforeAll
+    public void beforeAll() {
+        Utils.loadProviderTestSuite();
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
+    }
+}

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestPBKDF2Interop.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestPBKDF2Interop.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright IBM Corp. 2023, 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.junit.openjceplus.multithread;
+
+import ibm.jceplus.junit.base.BaseTestPBKDF2Interop;
+import ibm.jceplus.junit.openjceplus.Utils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestPBKDF2Interop extends BaseTestPBKDF2Interop {
+
+    @BeforeAll
+    public void beforeAll() {
+        Utils.loadProviderTestSuite();
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
+        setInteropProviderName(Utils.PROVIDER_SunJCE);
+    }
+}

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestPBKDF2.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestPBKDF2.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright IBM Corp. 2023, 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.junit.openjceplusfips.multithread;
+
+import ibm.jceplus.junit.base.BaseTestPBKDF2;
+import ibm.jceplus.junit.openjceplus.Utils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestPBKDF2 extends BaseTestPBKDF2 {
+
+    @BeforeAll
+    public void beforeAll() {
+        Utils.loadProviderTestSuite();
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
+    }
+}

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestPBKDF2Interop.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/multithread/TestPBKDF2Interop.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright IBM Corp. 2023, 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.junit.openjceplusfips.multithread;
+
+import ibm.jceplus.junit.base.BaseTestPBKDF2Interop;
+import ibm.jceplus.junit.openjceplus.Utils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestPBKDF2Interop extends BaseTestPBKDF2Interop {
+
+    @BeforeAll
+    public void beforeAll() {
+        Utils.loadProviderTestSuite();
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
+        setInteropProviderName(Utils.PROVIDER_SunJCE);
+    }
+}


### PR DESCRIPTION
Tests for the PBKDF2 algorithm have been found to not be running correctly when attempted to be run with multiple threads. This update removes some problematic static variables and adds the PBKDF2 related tests to the multi threaded test suites for both FIPS and non FIPS testing.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/642

Signed-off-by: Jason Katonica <katonica@us.ibm.com>