### PR TITLE
Add test case for accepting spec with lowercase X448 curve name

### DIFF
--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
@@ -20,6 +20,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.interfaces.XECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
@@ -39,16 +40,28 @@ public class BaseTestXDH extends BaseTestJunit5 {
 
     @Test
     public void testXDH_X25519() throws Exception {
-        String curveName = "X25519";
-        NamedParameterSpec nps = new NamedParameterSpec(curveName);
-        compute_xdh_key(curveName, nps);
+        System.out.println(
+                "\n\n\n\n************************** Starting testXDH_X25519 ************************");
+        String[] curveNames = {"X25519", "x25519"};
+        for (String curveName : curveNames) {
+            System.out.println("Testing curve name: " + curveName);
+            NamedParameterSpec nps = new NamedParameterSpec(curveName);
+            compute_xdh_key(curveName, nps);
+            runKeyFactoryTest(curveName, nps);
+        }
     }
 
     @Test
     public void testXDH_X448() throws Exception {
-        String curveName = "X448";
-        NamedParameterSpec nps = new NamedParameterSpec(curveName);
-        compute_xdh_key(curveName, nps);
+        System.out.println(
+                "\n\n\n\n************************** Starting testXDH_X448 ************************");
+        String[] curveNames = {"X448", "x448"};
+        for (String curveName : curveNames) {
+            System.out.println("Testing curve name: " + curveName);
+            NamedParameterSpec nps = new NamedParameterSpec(curveName);
+            compute_xdh_key(curveName, nps);
+            runKeyFactoryTest(curveName, nps);
+        }
     }
 
     @Test
@@ -660,6 +673,36 @@ public class BaseTestXDH extends BaseTestJunit5 {
             // expected
         }
         assertTrue(true);
+    }
+
+    public void runKeyFactoryTest(String curveName, NamedParameterSpec spec) throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("XDH", getProviderName());
+        kpg.initialize(spec);
+        KeyPair keyPair = kpg.generateKeyPair();
+
+        AlgorithmParameterSpec params = ((XECPublicKey) keyPair.getPublic()).getParams();
+        if (!(params instanceof NamedParameterSpec)) {
+            throw new RuntimeException("Unexpected parameter type for public key.");
+        }
+
+        NamedParameterSpec namedParams = (NamedParameterSpec) params;
+        if (!curveName.equalsIgnoreCase(namedParams.getName())) {
+            throw new RuntimeException("Public key is not using " + curveName + " parameters!");
+        }
+
+        // Use KeyFactory to regenerate public key
+        KeyFactory keyFactory = KeyFactory.getInstance("XDH", getProviderName());
+        XECPublicKeySpec pubSpec = keyFactory.getKeySpec(
+            keyPair.getPublic(), XECPublicKeySpec.class);
+        PublicKey pubRegenerated = keyFactory.generatePublic(pubSpec);
+
+        // Compare regenerated key to original
+        if (keyPair.getPublic().equals(pubRegenerated)) {
+            System.out.println("Regenerated public key matches original.");
+            assertTrue(true);
+        } else {
+            throw new RuntimeException("Regenerated public key does not match original.");
+        }
     }
 
     // Convert from a byte array to a hexadecimal representation as a string.


### PR DESCRIPTION
This is a back port PR from PR https://github.com/IBM/OpenJCEPlus/pull/622

This test validates the fix for handling lowercase X448 curve names by comparing the public key generated via a key pair generator with the one reconstructed from a public key spec using a key factory. This ensures the correctness of the X448 path in the key factory implementation.