### PR TITLE
Refactor HKDF to use the KDFSpi instead of the KeyGeneratorSpi

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/HKDFKeyDerivation.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/HKDFKeyDerivation.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package com.ibm.crypto.plus.provider;
+
+import com.ibm.crypto.plus.provider.ock.HKDF;
+import com.ibm.crypto.plus.provider.ock.OCKException;
+import java.io.ByteArrayOutputStream;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.security.ProviderException;
+import java.security.spec.AlgorithmParameterSpec;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.crypto.KDFParameters;
+import javax.crypto.KDFSpi;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.HKDFParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * KeyGenerator implementation for the SSL/TLS master secret derivation.
+ */
+public class HKDFKeyDerivation extends KDFSpi {
+    private OpenJCEPlusProvider provider = null;
+    private HKDF hkdfObj = null;
+
+    private final int hmacLen;
+    private final String hmacAlgName;
+    private final String digestAlgName;
+
+    private enum SupportedHmac {
+        SHA256("HmacSHA256", "SHA256",32),
+        SHA384("HmacSHA384", "SHA384", 48),
+        SHA512("HmacSHA512", "SHA512", 64);
+
+        private final String hmacAlg;
+        private final String digestAlg;
+        private final int hmacLen;
+        SupportedHmac(String hmacAlg, String digestAlg, int hmacLen) {
+            this.hmacAlg = hmacAlg;
+            this.digestAlg = digestAlg;
+            this.hmacLen = hmacLen;
+        }
+    };
+
+    /**
+     * The sole constructor.
+     *
+     * @param kdfParameters
+     *         the initialization parameters (may be {@code null})
+     *
+     * @throws InvalidAlgorithmParameterException
+     *         if the initialization parameters are inappropriate for this
+     *         {@code KDFSpi}
+     */
+    private HKDFKeyDerivation(OpenJCEPlusProvider provider, SupportedHmac supportedHmac,
+                              KDFParameters kdfParameters)
+            throws InvalidAlgorithmParameterException {
+        super(kdfParameters);
+        if (kdfParameters != null) {
+            throw new InvalidAlgorithmParameterException(
+                    supportedHmac.hmacAlg + " does not support parameters");
+        }
+        
+
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this.getClass())) {
+            throw new SecurityException("Integrity check failed for: " + provider.getName());
+        }
+
+        this.provider = provider;
+        this.hmacAlgName = supportedHmac.hmacAlg;
+        this.digestAlgName = supportedHmac.digestAlg;
+        this.hmacLen = supportedHmac.hmacLen;
+        try {
+            hkdfObj = HKDF.getInstance(this.provider.getOCKContext(), this.digestAlgName);
+            if (hkdfObj.getMacLength() != this.hmacLen) {
+                throw new ProviderException("Mismatch between expected and OCK provided HMAC length");
+            }
+        } catch (Exception ex) {
+            throw provider.providerException("Cannot initialize hkdf", ex);
+        }
+    }
+
+    /**
+     * Derive a key, returned as a {@code SecretKey} object.
+     *
+     * @return a derived {@code SecretKey} object of the specified algorithm
+     *
+     * @throws InvalidAlgorithmParameterException
+     *         if the information contained within the {@code derivationSpec} is
+     *         invalid or if the combination of {@code alg} and the
+     *         {@code derivationSpec} results in something invalid
+     * @throws NoSuchAlgorithmException
+     *         if {@code alg} is empty
+     * @throws NullPointerException
+     *         if {@code alg} is {@code null}
+     */
+    @Override
+    protected SecretKey engineDeriveKey(String alg,
+                                        AlgorithmParameterSpec derivationSpec)
+            throws InvalidAlgorithmParameterException,
+                   NoSuchAlgorithmException {
+
+        if (alg == null) {
+            throw new NullPointerException(
+                    "the algorithm for the SecretKey return value must not be"
+                    + " null");
+        }
+        if (alg.isEmpty()) {
+            throw new NoSuchAlgorithmException(
+                    "the algorithm for the SecretKey return value must not be "
+                    + "empty");
+        }
+
+        return new SecretKeySpec(engineDeriveData(derivationSpec), alg);
+
+    }
+
+    /**
+     * Obtain raw data from a key derivation function.
+     *
+     * @return a derived {@code byte[]}
+     *
+     * @throws InvalidAlgorithmParameterException
+     *         if the information contained within the {@code KDFParameterSpec}
+     *         is invalid or incorrect for the type of key to be derived
+     * @throws UnsupportedOperationException
+     *         if the derived keying material is not extractable
+     */
+    @Override
+    protected byte[] engineDeriveData(AlgorithmParameterSpec derivationSpec)
+            throws InvalidAlgorithmParameterException {
+        List<SecretKey> ikms, salts;
+        byte[] inputKeyMaterial, salt, pseudoRandomKey, info;
+        int length;
+        if (derivationSpec instanceof HKDFParameterSpec.Extract anExtract) {
+            ikms = anExtract.ikms();
+            salts = anExtract.salts();
+            // we should be able to combine both of the above Lists of key
+            // segments into one SecretKey object each, unless we were passed
+            // something bogus or an unexportable P11 key
+            inputKeyMaterial = null;
+            salt = null;
+            try {
+                inputKeyMaterial = consolidateKeyMaterial(ikms);
+                salt = consolidateKeyMaterial(salts);
+
+                // perform extract
+                return hkdfObj.extract(salt, salt.length,
+                        inputKeyMaterial, inputKeyMaterial.length);
+                
+            } catch (InvalidKeyException ike) {
+                throw new InvalidAlgorithmParameterException(
+                        "an HKDF Extract could not be initialized with the "
+                        + "given key or salt material", ike);
+            } catch (OCKException e) {
+                throw new IllegalStateException("Unable to extract bytes:" + e.getMessage());
+            } finally {
+                if (inputKeyMaterial != null) {
+                    Arrays.fill(inputKeyMaterial, (byte) 0x00);
+                }
+                if (salt != null) {
+                    Arrays.fill(salt, (byte) 0x00);
+                }
+            }
+        } else if (derivationSpec instanceof HKDFParameterSpec.Expand anExpand) {
+            // set this value in the "if"
+            if ((pseudoRandomKey = anExpand.prk().getEncoded()) == null) {
+                throw new InvalidAlgorithmParameterException(
+                        "Cannot retrieve PRK for HKDFParameterSpec.Expand");
+            }
+            // set this value in the "if"
+            if ((info = anExpand.info()) == null) {
+                info = new byte[0];
+            }
+            length = anExpand.length();
+            if (length > (hmacLen * 255)) {
+                throw new InvalidAlgorithmParameterException(
+                        "Requested length exceeds maximum allowed length");
+            }
+            // perform expand
+            try {
+                return hkdfObj.expand(pseudoRandomKey, (long) pseudoRandomKey.length, info,
+                        (long) info.length, length);
+            } catch (OCKException e) {
+                throw new IllegalStateException("Unable to expand bytes:" + e.getMessage());
+            } finally {
+                Arrays.fill(pseudoRandomKey, (byte) 0x00);
+            }
+        } else if (derivationSpec instanceof HKDFParameterSpec.ExtractThenExpand anExtractThenExpand) {
+            ikms = anExtractThenExpand.ikms();
+            salts = anExtractThenExpand.salts();
+            // we should be able to combine both of the above Lists of key
+            // segments into one SecretKey object each, unless we were passed
+            // something bogus or an unexportable P11 key
+            inputKeyMaterial = null;
+            salt = null;
+            pseudoRandomKey = null;
+            try {
+                inputKeyMaterial = consolidateKeyMaterial(ikms);
+                salt = consolidateKeyMaterial(salts);
+
+                // set this value in the "if"
+                if ((info = anExtractThenExpand.info()) == null) {
+                    info = new byte[0];
+                }
+                length = anExtractThenExpand.length();
+                if (length > (hmacLen * 255)) {
+                    throw new InvalidAlgorithmParameterException(
+                            "Requested length exceeds maximum allowed length");
+                }
+
+                // perform extract and then expand (derive in OCK)
+                return hkdfObj.derive(salt, (long) salt.length, inputKeyMaterial,
+                        (long) inputKeyMaterial.length, info, (long) info.length, length);
+            } catch (OCKException e) {
+                throw new IllegalStateException("Unable to derive (extract then expand) bytes: " + e.getMessage());
+            } catch (InvalidKeyException ike) {
+                throw new InvalidAlgorithmParameterException(
+                        "an HKDF ExtractThenExpand could not be initialized "
+                        + "with the given key or salt material", ike);
+            } finally {
+                if (inputKeyMaterial != null) {
+                    Arrays.fill(inputKeyMaterial, (byte) 0x00);
+                }
+                if (salt != null) {
+                    Arrays.fill(salt, (byte) 0x00);
+                }
+                if (pseudoRandomKey != null) {
+                    Arrays.fill(pseudoRandomKey, (byte) 0x00);
+                }
+            }
+        }
+        throw new InvalidAlgorithmParameterException(
+                "an HKDF derivation requires a valid HKDFParameterSpec");
+    }
+
+    // throws an InvalidKeyException if any key is unextractable
+    private byte[] consolidateKeyMaterial(List<SecretKey> keys)
+            throws InvalidKeyException {
+        if (keys != null && !keys.isEmpty()) {
+            ArrayList<SecretKey> localKeys = new ArrayList<>(keys);
+            if (localKeys.size() == 1) {
+                // return this element
+                SecretKey checkIt = localKeys.get(0);
+                return getKeyBytes(checkIt);
+            } else {
+                ByteArrayOutputStream os = new ByteArrayOutputStream();
+                for (SecretKey workItem : localKeys) {
+                    os.writeBytes(getKeyBytes(workItem));
+                }
+                // deliberately omitting os.flush(), since we are writing to
+                // memory, and toByteArray() reads like there isn't an explicit
+                // need for this call
+                return os.toByteArray();
+            }
+        } else if (keys != null) {
+            return new byte[0];
+        } else {
+            throw new InvalidKeyException(
+                    "List of key segments could not be consolidated");
+        }
+    }
+
+    protected KDFParameters engineGetParameters() {
+        return null;
+    }
+
+    /**
+     * Return the key bytes of the specified key. Throw an InvalidKeyException
+     * if the key is not usable.
+     */
+    private byte[] getKeyBytes(Key key) throws InvalidKeyException {
+        if (key == null) {
+            throw new InvalidKeyException("No key given");
+        }
+        // note: key.getFormat() may return null
+        if (!"RAW".equalsIgnoreCase(key.getFormat())) {
+            throw new InvalidKeyException("Wrong format: RAW bytes needed");
+        }
+        byte[] keyBytes = key.getEncoded();
+        if (keyBytes == null) {
+            throw new InvalidKeyException("RAW key bytes missing");
+        }
+        return keyBytes;
+    }
+
+    public static final class HKDFSHA256 extends HKDFKeyDerivation {
+        public HKDFSHA256(OpenJCEPlusProvider provider)
+                throws InvalidAlgorithmParameterException {
+            super(provider, SupportedHmac.SHA256, null);
+        }
+    }
+
+    public static final class HKDFSHA384 extends HKDFKeyDerivation {
+        public HKDFSHA384(OpenJCEPlusProvider provider)
+                throws InvalidAlgorithmParameterException {
+            super(provider, SupportedHmac.SHA384, null);
+        }
+    }
+
+    public static final class HKDFSHA512 extends HKDFKeyDerivation {
+        public HKDFSHA512(OpenJCEPlusProvider provider)
+                throws InvalidAlgorithmParameterException {
+            super(provider, SupportedHmac.SHA512, null);
+        }
+    }
+}

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
@@ -568,28 +568,40 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
         putService(new OpenJCEPlusService(jce, "MAC", "HmacSHA3-512",
                 "com.ibm.crypto.plus.provider.HmacCore$HmacSHA3_512", aliases));
 
+        if (allowLegacyHKDF) {
+            /* =======================================================================
+             * HKDF Algorithms use KeyGeneratorSpi - Legacy way of using
+             * =======================================================================
+             */
+            aliases = new String[] {"kda-hkdf-with-sha-1"};
+            putService(new OpenJCEPlusService(jce, "KeyGenerator", "kda-hkdf-with-sha1",
+                    "com.ibm.crypto.plus.provider.HKDFGenerator$HKDFwithSHA1", aliases));
+
+            aliases = new String[] {"kda-hkdf-with-sha-224"};
+            putService(new OpenJCEPlusService(jce, "KeyGenerator", "kda-hkdf-with-sha224",
+                    "com.ibm.crypto.plus.provider.HKDFGenerator$HKDFwithSHA224", aliases));
+
+            aliases = new String[] {"kda-hkdf-with-sha-256"};
+            putService(new OpenJCEPlusService(jce, "KeyGenerator", "kda-hkdf-with-sha256",
+                    "com.ibm.crypto.plus.provider.HKDFGenerator$HKDFwithSHA256", aliases));
+            aliases = new String[] {"kda-hkdf-with-sha-384"};
+            putService(new OpenJCEPlusService(jce, "KeyGenerator", "kda-hkdf-with-sha384",
+                    "com.ibm.crypto.plus.provider.HKDFGenerator$HKDFwithSHA384", aliases));
+            aliases = new String[] {"kda-hkdf-with-sha-512"};
+            putService(new OpenJCEPlusService(jce, "KeyGenerator", "kda-hkdf-with-sha512",
+                    "com.ibm.crypto.plus.provider.HKDFGenerator$HKDFwithSHA512", aliases));
+        }
+
         /* =======================================================================
-         * HKDF Algorithms - OIDs are not finalized -
-         *  Oracle does not go through provider. Directly calls HKDF.
+         * Key Derivation engines
          * =======================================================================
          */
-        aliases = new String[] {"kda-hkdf-with-sha-1"};
-        putService(new OpenJCEPlusService(jce, "KeyGenerator", "kda-hkdf-with-sha1",
-                "com.ibm.crypto.plus.provider.HKDFGenerator$HKDFwithSHA1", aliases));
-
-        aliases = new String[] {"kda-hkdf-with-sha-224"};;
-        putService(new OpenJCEPlusService(jce, "KeyGenerator", "kda-hkdf-with-sha224",
-                "com.ibm.crypto.plus.provider.HKDFGenerator$HKDFwithSHA224", aliases));
-
-        aliases = new String[] {"kda-hkdf-with-sha-256"};
-        putService(new OpenJCEPlusService(jce, "KeyGenerator", "kda-hkdf-with-sha256",
-                "com.ibm.crypto.plus.provider.HKDFGenerator$HKDFwithSHA256", aliases));
-        aliases = new String[] {"kda-hkdf-with-sha-384"};;
-        putService(new OpenJCEPlusService(jce, "KeyGenerator", "kda-hkdf-with-sha384",
-                "com.ibm.crypto.plus.provider.HKDFGenerator$HKDFwithSHA384", aliases));
-        aliases = new String[] {"kda-hkdf-with-sha-512"};;
-        putService(new OpenJCEPlusService(jce, "KeyGenerator", "kda-hkdf-with-sha512",
-                "com.ibm.crypto.plus.provider.HKDFGenerator$HKDFwithSHA512", aliases));
+        putService(new OpenJCEPlusService(jce, "KDF", "HKDF-SHA256",
+                "com.ibm.crypto.plus.provider.HKDFKeyDerivation$HKDFSHA256", null));
+        putService(new OpenJCEPlusService(jce, "KDF", "HKDF-SHA384",
+                "com.ibm.crypto.plus.provider.HKDFKeyDerivation$HKDFSHA384", null));
+        putService(new OpenJCEPlusService(jce, "KDF", "HKDF-SHA512",
+                "com.ibm.crypto.plus.provider.HKDFKeyDerivation$HKDFSHA512", null));
 
         /* =======================================================================
          * MessageDigest engines

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -407,27 +407,37 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
         putService(new OpenJCEPlusService(jce, "MAC", "HmacSHA3-512",
                 "com.ibm.crypto.plus.provider.HmacCore$HmacSHA3_512", aliases));
 
+        if (allowLegacyHKDF) {
+            /* =======================================================================
+             * HKDF Algorithms use KeyGeneratorSpi - Legacy way of using
+             * =======================================================================
+             */
+
+            aliases = new String[] {"kda-hkdf-with-sha-224"};
+            putService(new OpenJCEPlusService(jce, "KeyGenerator", "kda-hkdf-with-sha224",
+                    "com.ibm.crypto.plus.provider.HKDFGenerator$HKDFwithSHA224", aliases));
+
+            aliases = new String[] {"kda-hkdf-with-sha-256"};
+            putService(new OpenJCEPlusService(jce, "KeyGenerator", "kda-hkdf-with-sha256",
+                    "com.ibm.crypto.plus.provider.HKDFGenerator$HKDFwithSHA256", aliases));
+            aliases = new String[] {"kda-hkdf-with-sha-384"};
+            putService(new OpenJCEPlusService(jce, "KeyGenerator", "kda-hkdf-with-sha384",
+                    "com.ibm.crypto.plus.provider.HKDFGenerator$HKDFwithSHA384", aliases));
+            aliases = new String[] {"kda-hkdf-with-sha-512"};
+            putService(new OpenJCEPlusService(jce, "KeyGenerator", "kda-hkdf-with-sha512",
+                    "com.ibm.crypto.plus.provider.HKDFGenerator$HKDFwithSHA512", aliases));
+        }
+
         /* =======================================================================
-         * HKDF Algorithms use key generator spis - OIDs are not finalized 
-         * Oracle does not go through provider. Directly calls HKDF. Not supported till
-         * Next GSkit Crypto FIPS certification.
+         * Key Derivation engines
          * =======================================================================
          */
-
-        aliases = new String[] {"kda-hkdf-with-sha-224"};
-        putService(new OpenJCEPlusService(jce, "KeyGenerator", "kda-hkdf-with-sha224",
-                "com.ibm.crypto.plus.provider.HKDFGenerator$HKDFwithSHA224", aliases));
-
-        aliases = new String[] {"kda-hkdf-with-sha-256"};
-        putService(new OpenJCEPlusService(jce, "KeyGenerator", "kda-hkdf-with-sha256",
-                "com.ibm.crypto.plus.provider.HKDFGenerator$HKDFwithSHA256", aliases));
-        aliases = new String[] {"kda-hkdf-with-sha-384"};
-        putService(new OpenJCEPlusService(jce, "KeyGenerator", "kda-hkdf-with-sha384",
-                "com.ibm.crypto.plus.provider.HKDFGenerator$HKDFwithSHA384", aliases));
-        aliases = new String[] {"kda-hkdf-with-sha-512"};
-        putService(new OpenJCEPlusService(jce, "KeyGenerator", "kda-hkdf-with-sha512",
-                "com.ibm.crypto.plus.provider.HKDFGenerator$HKDFwithSHA512", aliases));
-
+        putService(new OpenJCEPlusService(jce, "KDF", "HKDF-SHA256",
+                "com.ibm.crypto.plus.provider.HKDFKeyDerivation$HKDFSHA256", null));
+        putService(new OpenJCEPlusService(jce, "KDF", "HKDF-SHA384",
+                "com.ibm.crypto.plus.provider.HKDFKeyDerivation$HKDFSHA384", null));
+        putService(new OpenJCEPlusService(jce, "KDF", "HKDF-SHA512",
+                "com.ibm.crypto.plus.provider.HKDFKeyDerivation$HKDFSHA512", null));
 
         /* =======================================================================
          * MessageDigest engines

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -25,6 +25,8 @@ public abstract class OpenJCEPlusProvider extends java.security.Provider {
     private static final String JAVA_VER = System.getProperty("java.specification.version");
 
     static final String DEBUG_VALUE = "jceplus";
+
+    static final boolean allowLegacyHKDF = Boolean.getBoolean("openjceplus.allowLegacyHKDF");
 
     //    private static boolean verifiedSelfIntegrity = false;
     private static final boolean verifiedSelfIntegrity = true;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHKDF.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHKDF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -7,9 +7,6 @@
  */
 package ibm.jceplus.junit.base;
 
-import ibm.security.internal.spec.HKDFExpandParameterSpec;
-import ibm.security.internal.spec.HKDFExtractParameterSpec;
-import ibm.security.internal.spec.HKDFParameterSpec;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
@@ -27,12 +24,15 @@ import java.util.Arrays;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KDF;
 import javax.crypto.KeyAgreement;
 import javax.crypto.KeyGenerator;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHKDF extends BaseTestJunit5 {
@@ -87,80 +87,21 @@ public class BaseTestHKDF extends BaseTestJunit5 {
 
                     "8da4e775a563c18f715f802a063c5a31" + "b8a11f5c5ee1879ec3454e5f3c738d2d"
                             + "9d201395faa4b61a96c8",
-                    "42"},
-            {"SHA1", "0b0b0b0b0b0b0b0b0b0b0b", "000102030405060708090a0b0c", "f0f1f2f3f4f5f6f7f8f9",
-                    "9b6c18c432a7bf8f0e71c8eb88f4b30baa2ba243",
-                    "085a01ea1b10f36933068b56efa5ad81" + "a4f14b822f5b091568a9cdd4f155fda2"
-                            + "c22e422478d305f3f896",
-                    "42"},
-            {"SHA1", "000102030405060708090a0b0c0d0e0f" + "101112131415161718191a1b1c1d1e1f"
-                    + "202122232425262728292a2b2c2d2e2f" + "303132333435363738393a3b3c3d3e3f"
-                    + "404142434445464748494a4b4c4d4e4f",
-
-                    "606162636465666768696a6b6c6d6e6f" + "707172737475767778797a7b7c7d7e7f"
-                            + "808182838485868788898a8b8c8d8e8f"
-                            + "909192939495969798999a9b9c9d9e9f"
-                            + "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
-
-                    "b0b1b2b3b4b5b6b7b8b9babbbcbdbebf" + "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf"
-                            + "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"
-                            + "e0e1e2e3e4e5e6e7e8e9eaebecedeeef"
-                            + "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
-
-                    "8adae09a2a307059478d309b26c4115a224cfaf6",
-
-                    "0bd770a74d1160f7c9f12cd5912a06eb" + "ff6adcae899d92191fe4305673ba2ffe"
-                            + "8fa3f1a4e5ad79f3f334b3b202b2173c"
-                            + "486ea37ce3d397ed034c7f9dfeb15c5e"
-                            + "927336d0441f4c4300e2cff0d0900b52" + "d3b4",
-                    "82"},
-            {"SHA1", "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b", "", "",
-                    "da8c8a73c7fa77288ec6f5e7c297786aa0d32d01",
-                    "0ac1af7002b3d761d1e55298da9d0506" + "b9ae52057220a306e07b6b87e8df21d0"
-                            + "ea00033de03984d34918",
-                    "42"},
-            {"SHA1", "0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c", "", "",
-                    "2adccada18779e7c2077ad2eb19d3f3e731385dd", "2c91117204d745f3500d636a62f64f0a"
-                            + "b3bae548aa53d423b0d1f27ebba6f5e5" + "673a081d70cce7acfc48",
                     "42"},};
 
     @Test
-    public void testHKDF1() throws Exception {
-        if (getProviderName().equals("OpenJCEPlusFIPS")) {
-            //FIPS does not support SHA1. So skip the test
-            return;
-        }
-
-        aesHKDF(128, "kda-hkdf-with-sha1", "AES", "AES", getProviderName());
-        aesHKDF(128, "kda-hkdf-with-sha-1", "AES", "AES", getProviderName());
-    }
-
-    @Test
-    public void testHKDF224() throws Exception {
-
-        aesHKDF(192, "kda-hkdf-with-sha224", "AES", "AES", getProviderName());
-        aesHKDF(192, "kda-hkdf-with-sha-224", "AES", "AES", getProviderName());
-    }
-
-    @Test
     public void testHKDF256() throws Exception {
-
-        aesHKDF(192, "kda-hkdf-with-sha256", "AES", "AES", getProviderName());
-        aesHKDF(192, "kda-hkdf-with-sha-256", "AES", "AES", getProviderName());
+        aesHKDF(192, "HKDF-SHA256", "AES", "AES", getProviderName());
     }
 
     @Test
     public void testHKDF384() throws Exception {
-
-        aesHKDF(256, "kda-hkdf-with-sha384", "AES", "AES", getProviderName());
-        aesHKDF(256, "kda-hkdf-with-sha-384", "AES", "AES", getProviderName());
+        aesHKDF(256, "HKDF-SHA384", "AES", "AES", getProviderName());
     }
 
     @Test
     public void testHKDF512() throws Exception {
-
-        aesHKDF(256, "kda-hkdf-with-sha512", "AES", "AES", getProviderName());
-        aesHKDF(256, "kda-hkdf-with-sha-512", "AES", "AES", getProviderName());
+        aesHKDF(256, "HKDF-SHA512", "AES", "AES", getProviderName());
     }
 
     @Test
@@ -177,35 +118,14 @@ public class BaseTestHKDF extends BaseTestJunit5 {
         ECGenParameterSpec ecgn = new ECGenParameterSpec(curveName);
         byte[] sharedSecret = compute_ecdh_key(curveName, ecgn, getProviderName(), getProviderName());
 
-        HKDFParameterSpec hkdfDeriveSpec = new HKDFParameterSpec(sharedSecret, null, null,
-                (long) (192 / 8), "DESede");
-        KeyGenerator hkdfDerive = KeyGenerator.getInstance("kda-hkdf-with-sha256", getProviderName());
-        hkdfDerive.init(hkdfDeriveSpec);
-        SecretKey calcOkm = hkdfDerive.generateKey();
+        javax.crypto.spec.HKDFParameterSpec derive = javax.crypto.spec.HKDFParameterSpec.ofExtract().addIKM(sharedSecret).thenExpand(null, (192 / 8));
+        KDF hkdfDerive = KDF.getInstance("HKDF-SHA256", getProviderName());
+        SecretKey calcOkm = hkdfDerive.deriveKey("DESede", derive);
+
         String strToEncrypt = "Hello string to be encrypted";
         byte[] encryptedBytes = encrypt(calcOkm, strToEncrypt, "DESede/CBC/PKCS5Padding");
         String plainStr = decrypt(calcOkm, encryptedBytes, "DESede/CBC/PKCS5Padding");
         assertTrue(plainStr.equals(strToEncrypt));
-
-    }
-
-    @Test
-    public void testLongOKM() throws InvalidKeyException, NoSuchAlgorithmException,
-            InvalidAlgorithmParameterException, NoSuchProviderException, NoSuchPaddingException,
-            IllegalBlockSizeException, BadPaddingException, UnsupportedEncodingException {
-        String curveName = "secp256r1";
-
-        ECGenParameterSpec ecgn = new ECGenParameterSpec(curveName);
-        byte[] sharedSecret = compute_ecdh_key(curveName, ecgn, getProviderName(), getProviderName());
-
-        try {
-            new HKDFParameterSpec(sharedSecret, null, null,
-                    (long) ((255 * 64) + 1), "AES");
-            assertTrue(false);
-        } catch (IllegalArgumentException invalidPE) {
-            assertTrue(true);
-        }
-
     }
 
     @Test
@@ -216,10 +136,11 @@ public class BaseTestHKDF extends BaseTestJunit5 {
         byte[] sharedSecret = new byte[64];
 
         try {
-            new HKDFParameterSpec(sharedSecret, null, null,
-                    (long) 64, null);
+            javax.crypto.spec.HKDFParameterSpec derive = javax.crypto.spec.HKDFParameterSpec.ofExtract().addIKM(sharedSecret).thenExpand(null, 64);
+            KDF hkdfDerive = KDF.getInstance("HKDF-SHA256", getProviderName());
+            hkdfDerive.deriveKey(null, derive);
             assertTrue(false);
-        } catch (IllegalArgumentException iae) {
+        } catch (NullPointerException npe) {
             assertTrue(true);
         }
 
@@ -233,41 +154,13 @@ public class BaseTestHKDF extends BaseTestJunit5 {
         byte[] sharedSecret = new byte[64];
 
         try {
-            HKDFParameterSpec hkdfDeriveSpec = new HKDFParameterSpec(sharedSecret, null, null,
-                    (long) ((255 * 40)), "AES");
-            KeyGenerator hkdfDerive = KeyGenerator.getInstance("kda-hkdf-with-sha256",
-                    getProviderName());
-            hkdfDerive.init(hkdfDeriveSpec);
+            javax.crypto.spec.HKDFParameterSpec derive = javax.crypto.spec.HKDFParameterSpec.ofExtract().addIKM(sharedSecret).thenExpand(null, (255 * 40));
+            KDF hkdfDerive = KDF.getInstance("HKDF-SHA256", getProviderName());
+            hkdfDerive.deriveKey("AES", derive);
             assertTrue(false);
         } catch (InvalidAlgorithmParameterException iae) {
             assertTrue(true);
         }
-
-    }
-
-    @Test
-    public void testEcdhHKDF1() throws InvalidKeyException, NoSuchAlgorithmException,
-            InvalidAlgorithmParameterException, NoSuchProviderException, NoSuchPaddingException,
-            IllegalBlockSizeException, BadPaddingException, UnsupportedEncodingException {
-
-        if (getProviderName().equals("OpenJCEPlusFIPS")) {
-            //FIPS does not support SHA1. Skip test
-            return;
-        }
-        String curveName = "secp256r1";
-
-        ECGenParameterSpec ecgn = new ECGenParameterSpec(curveName);
-        byte[] sharedSecret = compute_ecdh_key(curveName, ecgn, getProviderName(), getProviderName());
-
-        HKDFParameterSpec hkdfDeriveSpec = new HKDFParameterSpec(sharedSecret, null, null,
-                (long) (192 / 8), "AES");
-        KeyGenerator hkdfDerive = KeyGenerator.getInstance("kda-hkdf-with-sha1", getProviderName());
-        hkdfDerive.init(hkdfDeriveSpec);
-        SecretKey calcOkm = hkdfDerive.generateKey();
-        String strToEncrypt = "Hello string to be encrypted";
-        byte[] encryptedBytes = encrypt(calcOkm, strToEncrypt, "AES/ECB/PKCS5Padding");
-        String plainStr = decrypt(calcOkm, encryptedBytes, "AES/ECB/PKCS5Padding");
-        assertTrue(plainStr.equals(strToEncrypt));
 
     }
 
@@ -280,16 +173,14 @@ public class BaseTestHKDF extends BaseTestJunit5 {
         ECGenParameterSpec ecgn = new ECGenParameterSpec(curveName);
         byte[] sharedSecret = compute_ecdh_key(curveName, ecgn, getProviderName(), getProviderName());
 
-        HKDFParameterSpec hkdfDeriveSpec = new HKDFParameterSpec(sharedSecret, null, null,
-                (long) (256 / 8), "AES");
-        KeyGenerator hkdfDerive = KeyGenerator.getInstance("kda-hkdf-with-sha256", getProviderName());
-        hkdfDerive.init(hkdfDeriveSpec);
-        SecretKey calcOkm = hkdfDerive.generateKey();
+        javax.crypto.spec.HKDFParameterSpec derive = javax.crypto.spec.HKDFParameterSpec.ofExtract().addIKM(sharedSecret).thenExpand(null, (256 / 8));
+        KDF hkdfDerive = KDF.getInstance("HKDF-SHA256", getProviderName());
+        SecretKey calcOkm = hkdfDerive.deriveKey("AES", derive);
+
         String strToEncrypt = "Hello string to be encrypted";
         byte[] encryptedBytes = encrypt(calcOkm, strToEncrypt, "AES/ECB/PKCS5Padding");
         String plainStr = decrypt(calcOkm, encryptedBytes, "AES/ECB/PKCS5Padding");
         assertTrue(plainStr.equals(strToEncrypt));
-
     }
 
     @Test
@@ -301,16 +192,15 @@ public class BaseTestHKDF extends BaseTestJunit5 {
         ECGenParameterSpec ecgn = new ECGenParameterSpec(curveName);
         byte[] sharedSecret = compute_ecdh_key(curveName, ecgn, getProviderName(), getProviderName());
 
-        HKDFParameterSpec hkdfDeriveSpec = new HKDFParameterSpec(sharedSecret, null, null,
-                (long) (256 / 8), "AES");
-        KeyGenerator hkdfDerive = KeyGenerator.getInstance("kda-hkdf-with-sha512", getProviderName());
-        hkdfDerive.init(hkdfDeriveSpec);
-        SecretKey calcOkm = hkdfDerive.generateKey();
+        javax.crypto.spec.HKDFParameterSpec derive = javax.crypto.spec.HKDFParameterSpec.ofExtract().addIKM(sharedSecret).thenExpand(null, (256 / 8));
+        KDF hkdfDerive = KDF.getInstance("HKDF-SHA512", getProviderName());
+        SecretKey calcOkm = hkdfDerive.deriveKey("AES", derive);
+        
+
         String strToEncrypt = "Hello string to be encrypted";
         byte[] encryptedBytes = encrypt(calcOkm, strToEncrypt, "AES/ECB/PKCS5Padding");
         String plainStr = decrypt(calcOkm, encryptedBytes, "AES/ECB/PKCS5Padding");
         assertTrue(plainStr.equals(strToEncrypt));
-
     }
 
     private void aesHKDF(int aesKeySize, String hashAlg, String extractAlg, String expandAlg,
@@ -321,28 +211,26 @@ public class BaseTestHKDF extends BaseTestJunit5 {
         keyGen.init(aesKeySize);
         SecretKey psk = keyGen.generateKey(); // System.out.println("Generated secretKey=" + psk);
 
-        MessageDigest md = MessageDigest.getInstance(hashAlg.replace("kda-hkdf-with-", ""),
+        MessageDigest md = MessageDigest.getInstance(hashAlg.replace("HKDF-", ""),
                 providerName);
-        KeyGenerator hkdfExtract = KeyGenerator.getInstance(hashAlg, providerName);
         byte[] zeros = new byte[md.getDigestLength()];
 
-        hkdfExtract.init(new HKDFExtractParameterSpec(psk.getEncoded(), zeros, extractAlg));
-        SecretKey earlySecret = hkdfExtract.generateKey();
-        assert (earlySecret != null);
+        KDF hkdfExtract = KDF.getInstance(hashAlg, getProviderName());
+        javax.crypto.spec.HKDFParameterSpec extractOnly = javax.crypto.spec.HKDFParameterSpec.ofExtract().addIKM(psk).addSalt(zeros).extractOnly();
+        SecretKey earlySecret = hkdfExtract.deriveKey(extractAlg, extractOnly);
+        assertTrue(earlySecret != null);
 
         byte[] label = ("tls13 res binder").getBytes();
-
         byte[] hkdfInfo = createHkdfInfo(label, new byte[0], md.getDigestLength());
-        KeyGenerator hkdfExpand = KeyGenerator.getInstance(hashAlg, providerName);
-        hkdfExpand.init(new HKDFExpandParameterSpec(earlySecret, hkdfInfo,
-                (aesKeySize / 8)/* md.getDigestLength() */, expandAlg));
-        SecretKey expandSecretKey = hkdfExpand.generateKey();
-        assert (expandSecretKey != null);
+        KDF hkdfExpand = KDF.getInstance(hashAlg, getProviderName());
+        javax.crypto.spec.HKDFParameterSpec expandOnly = javax.crypto.spec.HKDFParameterSpec.expandOnly(earlySecret, hkdfInfo, (aesKeySize / 8));
+        SecretKey expandSecretKey = hkdfExpand.deriveKey(expandAlg, expandOnly);
+        assertTrue(expandSecretKey != null);
+
         String strToEncrypt = "Hello string to be encrypted";
         byte[] encryptedBytes = encrypt(expandSecretKey, strToEncrypt, "AES/ECB/PKCS5Padding");
         String plainStr = decrypt(expandSecretKey, encryptedBytes, "AES/ECB/PKCS5Padding");
         assertTrue(plainStr.equals(strToEncrypt));
-
     }
 
     private byte[] encrypt(SecretKey secretKey, String strToEncrypt, String cipherAlgorithm)
@@ -409,19 +297,15 @@ public class BaseTestHKDF extends BaseTestJunit5 {
     }
 
     @Test
-    public void testThroguhProvider() throws Exception {
+    public void testThroughProvider() throws Exception {
         try {
-            // HKDF hkdf = HKDF.getInstance("kda-hkdf-with-sha256", providerName);
-
             for (int i = 0; i < HKDF_KA.length; i++) {
-
-                String digestAlgo = HKDF_KA[i][0];
                 byte[] ikmArray = hexStringToByteArray(HKDF_KA[i][1]);
                 byte[] saltArray = hexStringToByteArray(HKDF_KA[i][2]);
                 byte[] infoArray = hexStringToByteArray(HKDF_KA[i][3]);
                 byte[] prkArray = hexStringToByteArray(HKDF_KA[i][4]);
                 byte[] okmArray = hexStringToByteArray(HKDF_KA[i][5]);
-                long okmLength = Long.parseLong(HKDF_KA[i][6]);
+                int okmLength = Integer.parseInt(HKDF_KA[i][6]);
                 assert (ikmArray != null);
                 assert (saltArray != null);
                 assert (infoArray != null);
@@ -429,75 +313,27 @@ public class BaseTestHKDF extends BaseTestJunit5 {
                 assert (okmArray != null);
                 assert (okmLength > 0);
                 // System.out.println("i=" + i);
-                if (digestAlgo.equals("SHA256")) {
-                    KeyGenerator hkdfExtract = KeyGenerator.getInstance("kda-hkdf-with-sha256",
-                            getProviderName());
-                    // System.out.println("HKDF digest algorithm " +
-                    // hkdfExtract.getDigestAlgorithm());
 
-                    if (HKDF_KA[i][2].equals("")) {
-                        saltArray = null;
-                    }
-                    HKDFExtractParameterSpec extractSpec = new HKDFExtractParameterSpec(ikmArray,
-                            saltArray, "TlsEarlySecret");
-                    hkdfExtract.init(extractSpec);
+                KDF hkdfExtract = KDF.getInstance("HKDF-SHA256", getProviderName());
 
-                    SecretKey calcPrk = hkdfExtract.generateKey();
-                    byte[] calcPrkArray = calcPrk.getEncoded();
-                    boolean prkequal = Arrays.equals(prkArray, calcPrkArray);
-                    assert (prkequal == true);
-
-                    KeyGenerator hkdfExpand = KeyGenerator.getInstance("kda-hkdf-with-sha256",
-                            getProviderName());
-                    HKDFExpandParameterSpec expandSpec = new HKDFExpandParameterSpec(prkArray,
-                            infoArray, okmLength, "TlsEarlySecret");
-                    hkdfExpand.init(expandSpec);
-                    SecretKey calcOkm = hkdfExpand.generateKey();
-
-                    byte[] calcOkmArray = calcOkm.getEncoded();
-                    boolean okmequal = Arrays.equals(okmArray, calcOkmArray);
-                    assert (okmequal == true);
-                    assert (calcOkmArray.length == okmLength);
-                } else {
-                    if (getProviderName().equals("OpenJCEPlusFIPS")) {
-                        //FIPS does not support SHA1. Skip test
-                        break;
-                    }
-                    KeyGenerator hkdfExtract = KeyGenerator.getInstance("kda-hkdf-with-sha1",
-                            getProviderName());
-                    // System.out.println("HKDF digest algorithm " +
-                    // hkdfExtract.getDigestAlgorithm());
-
-                    if (HKDF_KA[i][2].equals("")) {
-                        saltArray = null;
-                    }
-                    HKDFExtractParameterSpec extractSpec = new HKDFExtractParameterSpec(ikmArray,
-                            saltArray, "TlsEarlySecret");
-                    hkdfExtract.init(extractSpec);
-
-                    SecretKey calcPrk = hkdfExtract.generateKey();
-                    byte[] calcPrkArray = calcPrk.getEncoded();
-                    boolean prkequal = Arrays.equals(prkArray, calcPrkArray);
-                    assert (prkequal == true);
-
-                    KeyGenerator hkdfExpand = KeyGenerator.getInstance("kda-hkdf-with-sha1",
-                            getProviderName());
-                    HKDFExpandParameterSpec expandSpec = new HKDFExpandParameterSpec(prkArray,
-                            infoArray, okmLength, "TlsEarlySecret");
-                    hkdfExpand.init(expandSpec);
-                    SecretKey calcOkm = hkdfExpand.generateKey();
-
-                    byte[] calcOkmArray = calcOkm.getEncoded();
-                    boolean okmequal = Arrays.equals(okmArray, calcOkmArray);
-                    assert (okmequal == true);
-                    /*
-                     * System.err.println("calcOkm algorithm=" + calcOkm.getAlgorithm());
-                     * System.err.println("calcOkm encoded=" +
-                     * BaseUtils.bytesToHex(calcOkm.getEncoded()));
-                     * System.err.println("calcOkm format=" + calcOkm.getFormat());
-                     */
-
+                if (HKDF_KA[i][2].equals("")) {
+                    saltArray = new byte[0];
                 }
+
+                javax.crypto.spec.HKDFParameterSpec extractOnly = javax.crypto.spec.HKDFParameterSpec.ofExtract().addIKM(ikmArray).addSalt(saltArray).extractOnly();
+                SecretKey calcPrk = hkdfExtract.deriveKey("TlsEarlySecret", extractOnly);
+
+                byte[] calcPrkArray = calcPrk.getEncoded();
+                assertArrayEquals(prkArray, calcPrkArray, "Calculated key doesn't match hardcoded one");
+
+                KDF hkdfExpand = KDF.getInstance("HKDF-SHA256", getProviderName());
+                SecretKey prk = new SecretKeySpec(prkArray, "AES");
+                javax.crypto.spec.HKDFParameterSpec expandOnly = javax.crypto.spec.HKDFParameterSpec.expandOnly(prk, infoArray, okmLength);
+                SecretKey calcOkm = hkdfExpand.deriveKey("TlsEarlySecret", expandOnly);
+
+                byte[] calcOkmArray = calcOkm.getEncoded();
+                assertArrayEquals(okmArray, calcOkmArray, "Calculated okm doesn't match hardcoded one");
+                assertTrue(calcOkmArray.length == okmLength);
             }
         } catch (NoSuchAlgorithmException e) {
             e.printStackTrace();
@@ -513,16 +349,13 @@ public class BaseTestHKDF extends BaseTestJunit5 {
     @Test
     public void testDerive() throws Exception {
         try {
-
             for (int i = 0; i < HKDF_KA.length; i++) {
-
-                String digestAlgo = HKDF_KA[i][0];
                 byte[] ikmArray = hexStringToByteArray(HKDF_KA[i][1]);
                 byte[] saltArray = hexStringToByteArray(HKDF_KA[i][2]);
                 byte[] infoArray = hexStringToByteArray(HKDF_KA[i][3]);
                 byte[] prkArray = hexStringToByteArray(HKDF_KA[i][4]);
                 byte[] okmArray = hexStringToByteArray(HKDF_KA[i][5]);
-                long okmLength = Long.parseLong(HKDF_KA[i][6]);
+                int okmLength = Integer.parseInt(HKDF_KA[i][6]);
                 assert (ikmArray != null);
                 assert (saltArray != null);
                 assert (infoArray != null);
@@ -530,49 +363,18 @@ public class BaseTestHKDF extends BaseTestJunit5 {
                 assert (okmArray != null);
                 assert (okmLength > 0);
                 // System.out.println("i=" + i);
-                if (digestAlgo.equals("SHA256")) {
-                    KeyGenerator hkdfDerive = KeyGenerator.getInstance("kda-hkdf-with-sha256",
-                            getProviderName());
-                    // System.out.println("HKDF digest algorithm " +
-                    // hkdfExtract.getDigestAlgorithm());
 
-                    if (HKDF_KA[i][2].equals("")) {
-                        saltArray = null;
-                    }
-                    HKDFParameterSpec hkdfDeriveSpec = new HKDFParameterSpec(ikmArray, saltArray,
-                            infoArray, okmLength, "TlsEarlySecret");
-                    hkdfDerive.init(hkdfDeriveSpec);
-                    SecretKey calcOkm = hkdfDerive.generateKey();
-
-                    byte[] calcOkmArray = calcOkm.getEncoded();
-                    boolean okmequal = Arrays.equals(okmArray, calcOkmArray);
-                    assert (okmequal == true);
-                    assert (calcOkmArray.length == okmLength);
-                } else {
-                    if (getProviderName().equals("OpenJCEPlusFIPS")) {
-                        //FIPS does not support SHA1. Skip test
-                        break;
-                    }
-
-                    KeyGenerator hkdfDerive = KeyGenerator.getInstance("kda-hkdf-with-sha1",
-                            getProviderName());
-                    // System.out.println("HKDF digest algorithm " +
-                    // hkdfExtract.getDigestAlgorithm());
-
-                    if (HKDF_KA[i][2].equals("")) {
-                        saltArray = null;
-                    }
-                    HKDFParameterSpec hkdfDeriveSpec = new HKDFParameterSpec(ikmArray, saltArray,
-                            infoArray, okmLength, "TlsEarlySecret");
-                    hkdfDerive.init(hkdfDeriveSpec);
-                    SecretKey calcOkm = hkdfDerive.generateKey();
-
-                    byte[] calcOkmArray = calcOkm.getEncoded();
-                    boolean okmequal = Arrays.equals(okmArray, calcOkmArray);
-                    assert (okmequal == true);
-                    assert (calcOkmArray.length == okmLength);
-
+                if (HKDF_KA[i][2].equals("")) {
+                    saltArray = new byte[0];
                 }
+
+                javax.crypto.spec.HKDFParameterSpec derive = javax.crypto.spec.HKDFParameterSpec.ofExtract().addIKM(ikmArray).addSalt(saltArray).thenExpand(infoArray, okmLength);
+                KDF hkdfDerive = KDF.getInstance("HKDF-SHA256", getProviderName());
+                SecretKey calcOkm = hkdfDerive.deriveKey("TlsEarlySecret", derive);
+
+                byte[] calcOkmArray = calcOkm.getEncoded();
+                assertArrayEquals(okmArray, calcOkmArray, "Calculated okm doesn't match hardcoded one");
+                assertTrue(calcOkmArray.length == okmLength);
             }
         } catch (NoSuchAlgorithmException e) {
             e.printStackTrace();

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHKDFInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHKDFInterop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -7,9 +7,6 @@
  */
 package ibm.jceplus.junit.base;
 
-import ibm.security.internal.spec.HKDFExpandParameterSpec;
-import ibm.security.internal.spec.HKDFExtractParameterSpec;
-import ibm.security.internal.spec.HKDFParameterSpec;
 import java.io.UnsupportedEncodingException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -23,16 +20,16 @@ import java.util.Arrays;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KDF;
 import javax.crypto.KeyAgreement;
-import javax.crypto.KeyGenerator;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
-import org.bouncycastle.crypto.digests.SHA1Digest;
 import org.bouncycastle.crypto.digests.SHA256Digest;
 import org.bouncycastle.crypto.generators.HKDFBytesGenerator;
 import org.bouncycastle.crypto.params.HKDFParameters;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestHKDFInterop extends BaseTestJunit5Interop {
@@ -75,41 +72,6 @@ public class BaseTestHKDFInterop extends BaseTestJunit5Interop {
 
                     "8da4e775a563c18f715f802a063c5a31" + "b8a11f5c5ee1879ec3454e5f3c738d2d"
                             + "9d201395faa4b61a96c8",
-                    "42"},
-            {"SHA1", "0b0b0b0b0b0b0b0b0b0b0b", "000102030405060708090a0b0c", "f0f1f2f3f4f5f6f7f8f9",
-                    "9b6c18c432a7bf8f0e71c8eb88f4b30baa2ba243",
-                    "085a01ea1b10f36933068b56efa5ad81" + "a4f14b822f5b091568a9cdd4f155fda2"
-                            + "c22e422478d305f3f896",
-                    "42"},
-            {"SHA1", "000102030405060708090a0b0c0d0e0f" + "101112131415161718191a1b1c1d1e1f"
-                    + "202122232425262728292a2b2c2d2e2f" + "303132333435363738393a3b3c3d3e3f"
-                    + "404142434445464748494a4b4c4d4e4f",
-
-                    "606162636465666768696a6b6c6d6e6f" + "707172737475767778797a7b7c7d7e7f"
-                            + "808182838485868788898a8b8c8d8e8f"
-                            + "909192939495969798999a9b9c9d9e9f"
-                            + "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
-
-                    "b0b1b2b3b4b5b6b7b8b9babbbcbdbebf" + "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf"
-                            + "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"
-                            + "e0e1e2e3e4e5e6e7e8e9eaebecedeeef"
-                            + "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
-
-                    "8adae09a2a307059478d309b26c4115a224cfaf6",
-
-                    "0bd770a74d1160f7c9f12cd5912a06eb" + "ff6adcae899d92191fe4305673ba2ffe"
-                            + "8fa3f1a4e5ad79f3f334b3b202b2173c"
-                            + "486ea37ce3d397ed034c7f9dfeb15c5e"
-                            + "927336d0441f4c4300e2cff0d0900b52" + "d3b4",
-                    "82"},
-            {"SHA1", "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b", "", "",
-                    "da8c8a73c7fa77288ec6f5e7c297786aa0d32d01",
-                    "0ac1af7002b3d761d1e55298da9d0506" + "b9ae52057220a306e07b6b87e8df21d0"
-                            + "ea00033de03984d34918",
-                    "42"},
-            {"SHA1", "0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c", "", "",
-                    "2adccada18779e7c2077ad2eb19d3f3e731385dd", "2c91117204d745f3500d636a62f64f0a"
-                            + "b3bae548aa53d423b0d1f27ebba6f5e5" + "673a081d70cce7acfc48",
                     "42"},};
 
     @Test
@@ -117,14 +79,12 @@ public class BaseTestHKDFInterop extends BaseTestJunit5Interop {
             NoSuchAlgorithmException, NoSuchProviderException {
 
         for (int i = 0; i < HKDF_KA.length; i++) {
-
-            String digestAlgo = HKDF_KA[i][0];
             byte[] ikmArray = hexStringToByteArray(HKDF_KA[i][1]);
             byte[] saltArray = hexStringToByteArray(HKDF_KA[i][2]);
             byte[] infoArray = hexStringToByteArray(HKDF_KA[i][3]);
             byte[] prkArray = hexStringToByteArray(HKDF_KA[i][4]);
             byte[] okmArray = hexStringToByteArray(HKDF_KA[i][5]);
-            long okmLength = Long.parseLong(HKDF_KA[i][6]);
+            int okmLength = Integer.parseInt(HKDF_KA[i][6]);
             assert (ikmArray != null);
             assert (saltArray != null);
             assert (infoArray != null);
@@ -132,109 +92,49 @@ public class BaseTestHKDFInterop extends BaseTestJunit5Interop {
             assert (okmArray != null);
             assert (okmLength > 0);
 
-            if (digestAlgo.equals("SHA256")) {
-                KeyGenerator hkdfExtract = KeyGenerator.getInstance("kda-hkdf-with-sha256",
-                        getProviderName());
+            if (HKDF_KA[i][2].equals("")) {
+                saltArray = new byte[0];
+            }
 
+            KDF hkdfExtract = KDF.getInstance("HKDF-SHA256", getProviderName());
+            javax.crypto.spec.HKDFParameterSpec extractOnly = javax.crypto.spec.HKDFParameterSpec.ofExtract().addIKM(ikmArray).addSalt(saltArray).extractOnly();
+            SecretKey calcPrk = hkdfExtract.deriveKey("TlsEarlySecret", extractOnly);
+            byte[] calcPrkArray = calcPrk.getEncoded();
+            assertArrayEquals(prkArray, calcPrkArray, "Calculated key doesn't match hardcoded one");
 
-                if (HKDF_KA[i][2].equals("")) {
-                    saltArray = null;
-                }
-                HKDFExtractParameterSpec extractSpec = new HKDFExtractParameterSpec(ikmArray,
-                        saltArray, "TlsEarlySecret");
-                hkdfExtract.init(extractSpec);
+            KDF hkdfExpand = KDF.getInstance("HKDF-SHA256", getProviderName());
+            javax.crypto.spec.HKDFParameterSpec expandOnly = javax.crypto.spec.HKDFParameterSpec.expandOnly(calcPrk, infoArray, okmLength);
+            SecretKey calcOkm = hkdfExpand.deriveKey("TlsEarlySecret", expandOnly);
+            byte[] calcOkmArray = calcOkm.getEncoded();
 
-                SecretKey calcPrk = hkdfExtract.generateKey();
-                byte[] calcPrkArray = calcPrk.getEncoded();
-                boolean prkequal = Arrays.equals(prkArray, calcPrkArray);
-                assert (prkequal == true);
-                KeyGenerator hkdfExpand = KeyGenerator.getInstance("kda-hkdf-with-sha256",
-                        getProviderName());
-                HKDFExpandParameterSpec expandSpec = new HKDFExpandParameterSpec(prkArray,
-                        infoArray, okmLength, "TlsEarlySecret");
-                hkdfExpand.init(expandSpec);
-                SecretKey calcOkm = hkdfExpand.generateKey();
+            assertArrayEquals(okmArray, calcOkmArray, "Calculated okm doesn't match hardcoded one");
+            assertTrue (calcOkmArray.length == okmLength);
 
-                byte[] calcOkmArray = calcOkm.getEncoded();
-                boolean okmequal = Arrays.equals(okmArray, calcOkmArray);
-                assert (okmequal == true);
-                assert (calcOkmArray.length == okmLength);
+            SHA256Digest bcDigest = new SHA256Digest();
 
-                SHA256Digest bcDigest = new SHA256Digest();
+            HKDFBytesGenerator hkdfBytesGeneratorBC = new HKDFBytesGenerator(bcDigest);
+            HKDFParameters hkdfParametersBC = new HKDFParameters(ikmArray, saltArray,
+                    infoArray);
+            hkdfBytesGeneratorBC.init(hkdfParametersBC);
+            byte[] okmBC = new byte[(int) okmLength];
 
-                HKDFBytesGenerator hkdfBytesGeneratorBC = new HKDFBytesGenerator(bcDigest);
-                HKDFParameters hkdfParametersBC = new HKDFParameters(ikmArray, saltArray,
-                        infoArray);
-                hkdfBytesGeneratorBC.init(hkdfParametersBC);
-                byte[] okmBC = new byte[(int) okmLength];
+            hkdfBytesGeneratorBC.generateBytes(okmBC, 0, (int) okmLength);
 
-                hkdfBytesGeneratorBC.generateBytes(okmBC, 0, (int) okmLength);
-
-                assertTrue(Arrays.equals(calcOkmArray, okmBC));
-
-
-            } else {
-                if (getProviderName().equals("OpenJCEPlusFIPS")) {
-                    //FIPS does not support SHA1. Skip test
-                    break;
-                }
-
-                KeyGenerator hkdfExtract = KeyGenerator.getInstance("kda-hkdf-with-sha1",
-                        getProviderName());
-
-
-                if (HKDF_KA[i][2].equals("")) {
-                    saltArray = null;
-                }
-                HKDFExtractParameterSpec extractSpec = new HKDFExtractParameterSpec(ikmArray,
-                        saltArray, "TlsEarlySecret");
-                hkdfExtract.init(extractSpec);
-
-                SecretKey calcPrk = hkdfExtract.generateKey();
-                byte[] calcPrkArray = calcPrk.getEncoded();
-                boolean prkequal = Arrays.equals(prkArray, calcPrkArray);
-                assert (prkequal == true);
-
-                KeyGenerator hkdfExpand = KeyGenerator.getInstance("kda-hkdf-with-sha1",
-                        getProviderName());
-                HKDFExpandParameterSpec expandSpec = new HKDFExpandParameterSpec(prkArray,
-                        infoArray, okmLength, "TlsEarlySecret");
-                hkdfExpand.init(expandSpec);
-                SecretKey calcOkm = hkdfExpand.generateKey();
-
-                byte[] calcOkmArray = calcOkm.getEncoded();
-                boolean okmequal = Arrays.equals(okmArray, calcOkmArray);
-                assert (okmequal == true);
-
-                SHA1Digest bcDigest = new SHA1Digest();
-
-                HKDFBytesGenerator hkdfBytesGeneratorBC = new HKDFBytesGenerator(bcDigest);
-                HKDFParameters hkdfParametersBC = new HKDFParameters(ikmArray, saltArray,
-                        infoArray);
-                hkdfBytesGeneratorBC.init(hkdfParametersBC);
-                byte[] okmBC = new byte[(int) okmLength];
-
-                hkdfBytesGeneratorBC.generateBytes(okmBC, 0, (int) okmLength);
-                assertTrue(Arrays.equals(calcOkmArray, okmBC));
-
-            } /* if */
-        } /* for */
+            assertArrayEquals(calcOkmArray, okmBC, "OpenJCEPlus and BC results don't match");
+        }
     }
 
     // One OCK call does both extract and derive
     @Test
     public void testDerive() throws Exception {
         try {
-
             for (int i = 0; i < HKDF_KA.length; i++) {
-
-                String digestAlgo = HKDF_KA[i][0];
                 byte[] ikmArray = hexStringToByteArray(HKDF_KA[i][1]);
                 byte[] saltArray = hexStringToByteArray(HKDF_KA[i][2]);
                 byte[] infoArray = hexStringToByteArray(HKDF_KA[i][3]);
                 byte[] prkArray = hexStringToByteArray(HKDF_KA[i][4]);
                 byte[] okmArray = hexStringToByteArray(HKDF_KA[i][5]);
-                long okmLength = Long.parseLong(HKDF_KA[i][6]);
+                int okmLength = Integer.parseInt(HKDF_KA[i][6]);
                 assert (ikmArray != null);
                 assert (saltArray != null);
                 assert (infoArray != null);
@@ -242,64 +142,26 @@ public class BaseTestHKDFInterop extends BaseTestJunit5Interop {
                 assert (okmArray != null);
                 assert (okmLength > 0);
 
-                if (digestAlgo.equals("SHA256")) {
-                    KeyGenerator hkdfDerive = KeyGenerator.getInstance("kda-hkdf-with-sha256",
-                            getProviderName());
-
-
-                    if (HKDF_KA[i][2].equals("")) {
-                        saltArray = null;
-                    }
-                    HKDFParameterSpec hkdfDeriveSpec = new HKDFParameterSpec(ikmArray, saltArray,
-                            infoArray, okmLength, "TlsEarlySecret");
-                    hkdfDerive.init(hkdfDeriveSpec);
-                    SecretKey calcOkm = hkdfDerive.generateKey();
-
-                    byte[] calcOkmArray = calcOkm.getEncoded();
-                    boolean okmequal = Arrays.equals(okmArray, calcOkmArray);
-                    assert (okmequal == true);
-                    assert (calcOkmArray.length == okmLength);
-
-                    SHA256Digest bcDigest = new SHA256Digest();
-                    HKDFBytesGenerator hkdfBytesGeneratorBC = new HKDFBytesGenerator(bcDigest);
-                    HKDFParameters hkdfParametersBC = new HKDFParameters(ikmArray, saltArray,
-                            infoArray);
-                    hkdfBytesGeneratorBC.init(hkdfParametersBC);
-                    byte[] okmBC = new byte[(int) okmLength];
-
-                    hkdfBytesGeneratorBC.generateBytes(okmBC, 0, (int) okmLength);
-                    assertTrue(Arrays.equals(calcOkmArray, okmBC));
-                } else {
-                    if (getProviderName().equals("OpenJCEPlusFIPS")) {
-                        //FIPS does not support SHA1. Skip test
-                        break;
-                    }
-                    KeyGenerator hkdfDerive = KeyGenerator.getInstance("kda-hkdf-with-sha1",
-                            getProviderName());
-
-
-                    if (HKDF_KA[i][2].equals("")) {
-                        saltArray = null;
-                    }
-                    HKDFParameterSpec hkdfDeriveSpec = new HKDFParameterSpec(ikmArray, saltArray,
-                            infoArray, okmLength, "TlsEarlySecret");
-                    hkdfDerive.init(hkdfDeriveSpec);
-                    SecretKey calcOkm = hkdfDerive.generateKey();
-
-                    byte[] calcOkmArray = calcOkm.getEncoded();
-                    boolean okmequal = Arrays.equals(okmArray, calcOkmArray);
-                    assert (okmequal == true);
-                    assert (calcOkmArray.length == okmLength);
-                    SHA1Digest bcDigest = new SHA1Digest();
-                    HKDFBytesGenerator hkdfBytesGeneratorBC = new HKDFBytesGenerator(bcDigest);
-                    HKDFParameters hkdfParametersBC = new HKDFParameters(ikmArray, saltArray,
-                            infoArray);
-                    hkdfBytesGeneratorBC.init(hkdfParametersBC);
-                    byte[] okmBC = new byte[(int) okmLength];
-
-                    hkdfBytesGeneratorBC.generateBytes(okmBC, 0, (int) okmLength);
-                    assertTrue(Arrays.equals(calcOkmArray, okmBC));
+                if (HKDF_KA[i][2].equals("")) {
+                    saltArray = new byte[0];
                 }
+
+                javax.crypto.spec.HKDFParameterSpec derive = javax.crypto.spec.HKDFParameterSpec.ofExtract().addIKM(ikmArray).addSalt(saltArray).thenExpand(infoArray, okmLength);
+                KDF hkdfDerive = KDF.getInstance("HKDF-SHA256", getProviderName());
+                SecretKey calcOkm = hkdfDerive.deriveKey("TlsEarlySecret", derive);
+                byte[] calcOkmArray = calcOkm.getEncoded();
+                assertArrayEquals(okmArray, calcOkmArray);
+                assertTrue(calcOkmArray.length == okmLength);
+
+                SHA256Digest bcDigest = new SHA256Digest();
+                HKDFBytesGenerator hkdfBytesGeneratorBC = new HKDFBytesGenerator(bcDigest);
+                HKDFParameters hkdfParametersBC = new HKDFParameters(ikmArray, saltArray,
+                        infoArray);
+                hkdfBytesGeneratorBC.init(hkdfParametersBC);
+                byte[] okmBC = new byte[(int) okmLength];
+
+                hkdfBytesGeneratorBC.generateBytes(okmBC, 0, (int) okmLength);
+                assertArrayEquals(calcOkmArray, okmBC, "OpenJCEPlus and BC results don't match");
             }
         } catch (NoSuchAlgorithmException e) {
             e.printStackTrace();
@@ -320,12 +182,10 @@ public class BaseTestHKDFInterop extends BaseTestJunit5Interop {
         ECGenParameterSpec ecgn = new ECGenParameterSpec(curveName);
         byte[] sharedSecret = compute_ecdh_key(curveName, ecgn, getProviderName(), getProviderName());
 
+        javax.crypto.spec.HKDFParameterSpec derive = javax.crypto.spec.HKDFParameterSpec.ofExtract().addIKM(sharedSecret).thenExpand(null, (256 / 8));
+        KDF hkdfDerive = KDF.getInstance("HKDF-SHA256", getProviderName());
+        SecretKey calcOkm = hkdfDerive.deriveKey("AES", derive);
 
-        HKDFParameterSpec hkdfDeriveSpec = new HKDFParameterSpec(sharedSecret, null, null,
-                (long) (256 / 8), "AES");
-        KeyGenerator hkdfDerive = KeyGenerator.getInstance("kda-hkdf-with-sha256", getProviderName());
-        hkdfDerive.init(hkdfDeriveSpec);
-        SecretKey calcOkm = hkdfDerive.generateKey();
         String strToEncrypt = "Hello string to be encrypted";
         byte[] encryptedBytes = encrypt(calcOkm, strToEncrypt, "AES/ECB/PKCS5Padding");
         String plainStr = decrypt(calcOkm, encryptedBytes, "AES/ECB/PKCS5Padding",
@@ -345,12 +205,10 @@ public class BaseTestHKDFInterop extends BaseTestJunit5Interop {
         byte[] sharedSecret = compute_ecdh_key(curveName, ecgn, getInteropProviderName(),
                 getInteropProviderName());
 
+        javax.crypto.spec.HKDFParameterSpec derive = javax.crypto.spec.HKDFParameterSpec.ofExtract().addIKM(sharedSecret).thenExpand(null, (256 / 8));
+        KDF hkdfDerive = KDF.getInstance("HKDF-SHA256", getProviderName());
+        SecretKey calcOkm = hkdfDerive.deriveKey("AES", derive);
 
-        HKDFParameterSpec hkdfDeriveSpec = new HKDFParameterSpec(sharedSecret, null, null,
-                (long) (256 / 8), "AES");
-        KeyGenerator hkdfDerive = KeyGenerator.getInstance("kda-hkdf-with-sha256");
-        hkdfDerive.init(hkdfDeriveSpec);
-        SecretKey calcOkm = hkdfDerive.generateKey();
         String strToEncrypt = "Hello string to be encrypted";
         byte[] encryptedBytes = encrypt(calcOkm, strToEncrypt, "AES/ECB/PKCS5Padding",
                 getInteropProviderName());


### PR DESCRIPTION
Since `HKDF` wasn't supported as a service offered through any provider in previous Java versions, `OpenJCEPlus` had to adapt it to be offered as a `KeyGenerator`.

Starting in `Java25`, key derivation functions can now be registered as services extending the `KDFSpi`, so `HKDF` is refactored to use that.

Tests are updated to use the the refactored functionality.

The `-Dopenjceplus.allowLegacyHKDF` flag is introduced that allow use of `HKDF` thorough the previously used `KeyGeneratorSpi`.

Resolves https://github.com/IBM/OpenJCEPlus/issues/599

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>