### PR TITLE
Allow OpenJCEPlus to run in developer mode

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -278,17 +278,9 @@ def getTestFlag(hardware, software) {
         return " -Dtest=${SPECIFIC_TEST}"
     }
 
-    // Based on platform, decide whether FIPS tests should be run.
-    if ((software == "mac") || ((software == "linux") && (hardware == "aarch64"))) {
-        echo "Only non-FIPS tests can be run in ${hardware}_${software}"
-        return " -Dtest=ibm.jceplus.junit.openjceplus.TestAll," +
-                       "ibm.jceplus.junit.TestMemStressAll," +
-                       "ibm.jceplus.junit.TestMultithread," +
-                       "ibm.jceplus.junit.openjceplus.integration.TestAll"
-    } else {
-        echo "All tests (both FIPS and non-FIPS) can be run in ${hardware}_${software}"
-        return "";
-    }
+    // Run all tests. Some platforms will naturally run in developer mode.
+    echo "All tests (both FIPS and non-FIPS) can be run in ${hardware}_${software}"
+    return "";
 }
 
 /*

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ Build Status:
 `OpenJCEPlus` and `OpenJCEPlusFIPS` providers are currently supported on the following architectures and operating system combinations as reported by `mvn --version` in the values `OS name` and `arch`:
 | OS name                 | arch        |
 | ----------------------- | ----------- |
+| linux                   | aarch64     |
 | linux                   | amd64       |
 | linux                   | s390x       |
 | linux                   | ppc64le     |
 | Windows Server 2022     | amd64       |
 | AIX                     | ppc64       |
-| Mac OS X*               | aarch64*    |
-| Mac OS X*               | amd64*      |
-* Mac OS X currently is only able to compile and run tests using the `OpenJCEPlus` provider, not `OpenJCEPlusFIPS`. The provider `OpenJCEPlusFIPS` will not load.
+| Mac OS X                | aarch64     |
+| Mac OS X                | amd64       |
 
 Follow these steps to build the `OpenJCEPlus` and `OpenJCEPlusFIPS` providers along with a dependent Java Native Interface library. Keep in mind that `$PROJECT_HOME` can represent any directory on your system and will be referred to as such in the subsequent instructions. Also keep in mind that the value `$JAVA_VERSION` below must match the same version of the branch of OpenJCEPlus being built. For example if building the `java21` branch the `$JAVA_VERSION` must match the Java 21 SDK version such as `21.0.2+13`.
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyPairGenerator.java
@@ -251,7 +251,8 @@ public class BaseTestECKeyPairGenerator extends BaseTestJunit5 {
             assertTrue(true);
         }
 
-        if (getProviderName().equalsIgnoreCase("OpenJCEPlusFIPS")) {
+        boolean isDeveloperModePlatform = BaseUtils.getIsFIPSCertifiedPlatform();
+        if (getProviderName().equalsIgnoreCase("OpenJCEPlusFIPS") && isDeveloperModePlatform) {
             try {
                 generictestECKeyGenCurve("secp112r1");
                 assertTrue(false);

--- a/src/test/java/ibm/jceplus/junit/base/BaseUtils.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseUtils.java
@@ -9,6 +9,9 @@
 package ibm.jceplus.junit.base;
 
 import java.security.Provider;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 abstract public class BaseUtils {
 
@@ -97,5 +100,40 @@ abstract public class BaseUtils {
         return loadProvider(PROVIDER_OpenJCEPlusFIPS,
                 "com.ibm.crypto.plus.provider.OpenJCEPlusFIPS");
     }
-}
 
+
+    /**
+     * Determines if we are running on an environment where a FIPS
+     * certified library is known to exist.
+     * 
+     * @return true if running within a known FIPS envionrment, false otherwise.
+     */
+    public static boolean getIsFIPSCertifiedPlatform() {
+        Map<String, List<String>> supportedPlatforms = new HashMap<>();
+        String osName;
+        String osArch;
+
+        supportedPlatforms.put("Arch", List.of("amd64", "ppc64", "s390x"));
+        supportedPlatforms.put("OS", List.of("Linux", "AIX", "Windows"));
+
+        osName = System.getProperty("os.name");
+        osArch = System.getProperty("os.arch");;
+
+        boolean isOsSupported, isArchSupported;
+        isOsSupported = false;
+        for (String os: supportedPlatforms.get("OS")) {
+            if (osName.contains(os)) {
+                isOsSupported = true;
+                break;
+            }
+        }
+        isArchSupported = false;
+        for (String arch: supportedPlatforms.get("Arch")) {
+            if (osArch.contains(arch)) {
+                isArchSupported = true;
+                break;
+            }
+        }
+        return isOsSupported && isArchSupported;
+    }
+}


### PR DESCRIPTION
Users may wish to develop on various platforms in which the OpenJCEPlusFIPS provider currently does not function. This update allows for execution on such platforms while issuing a warning to users when loading the provider.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>