### PR TITLE
Fixes for PQC test cases and Fix Serialization issues with keys.

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
@@ -256,6 +256,12 @@ final class DHPrivateKey extends PKCS8Key implements javax.crypto.interfaces.DHP
         return "DH";
     }
 
+    @java.io.Serial
+    protected Object writeReplace() throws java.io.ObjectStreamException {
+        checkDestroyed();
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PRIVATE, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
+    } 
+    
     /**
      * Returns the encoding format of this key: "PKCS#8"
      */

--- a/src/main/java/com/ibm/crypto/plus/provider/DHPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHPublicKey.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
 import java.security.InvalidKeyException;
-import java.security.KeyRep;
 import java.security.spec.InvalidParameterSpecException;
 import javax.crypto.spec.DHParameterSpec;
 import javax.security.auth.DestroyFailedException;
@@ -394,7 +393,7 @@ final class DHPublicKey extends X509Key
      */
     private Object writeReplace() throws java.io.ObjectStreamException {
         checkDestroyed();
-        return new KeyRep(KeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded());
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
     }
 
     public String toString() {

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAPrivateKey.java
@@ -249,6 +249,12 @@ final class DSAPrivateKey extends PKCS8Key
         }
     }
 
+    @java.io.Serial
+    protected Object writeReplace() throws java.io.ObjectStreamException {
+        checkDestroyed();
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PRIVATE, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
+    } 
+    
     /**
      * Compares two private keys. This returns false if the object with which
      * to compare is not of type <code>Key</code>.

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAPublicKey.java
@@ -14,7 +14,6 @@ import java.io.Serializable;
 import java.math.BigInteger;
 import java.security.AlgorithmParameters;
 import java.security.InvalidKeyException;
-import java.security.KeyRep;
 import java.security.interfaces.DSAParams;
 import java.security.spec.DSAParameterSpec;
 import java.security.spec.InvalidParameterSpecException;
@@ -229,7 +228,7 @@ final class DSAPublicKey extends X509Key
      */
     private Object writeReplace() throws java.io.ObjectStreamException {
         checkDestroyed();
-        return new KeyRep(KeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded());
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
     }
 
     /**

--- a/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
@@ -582,6 +582,12 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
                     "Unexpected error calculating public key", exc);
         }
     }
+    
+    @java.io.Serial
+    protected Object writeReplace() throws java.io.ObjectStreamException {
+        checkDestroyed();
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PRIVATE, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
+    } 
 
     /**
      * Parse the key. Called by PKCS8Key. "key" is a byte array containing the

--- a/src/main/java/com/ibm/crypto/plus/provider/ECPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECPublicKey.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.security.AlgorithmParameters;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
-import java.security.KeyRep;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
 import java.security.spec.InvalidParameterSpecException;
@@ -191,7 +190,7 @@ final class ECPublicKey extends X509Key
      */
     private Object writeReplace() throws java.io.ObjectStreamException {
         checkDestroyed();
-        return new KeyRep(KeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded());
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
     }
 
     /*

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAPrivateKeyImpl.java
@@ -15,7 +15,6 @@ import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
-import java.security.KeyRep;
 import java.security.interfaces.EdECPrivateKey;
 import java.security.spec.NamedParameterSpec;
 import java.util.Arrays;
@@ -330,8 +329,9 @@ final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKey {
         return "EdDSA";
     }
 
+    @java.io.Serial
     protected Object writeReplace() throws java.io.ObjectStreamException {
-        return new KeyRep(KeyRep.Type.PRIVATE, getAlgorithm(), getFormat(), getEncoded());
-    }
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PRIVATE, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
+    } 
 }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAPublicKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAPublicKeyImpl.java
@@ -15,7 +15,6 @@ import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
-import java.security.KeyRep;
 import java.security.interfaces.EdECPublicKey;
 import java.security.spec.EdECPoint;
 import java.security.spec.NamedParameterSpec;
@@ -311,7 +310,7 @@ final class EdDSAPublicKeyImpl extends X509Key implements EdECPublicKey {
     }
 
     protected Object writeReplace() throws java.io.ObjectStreamException {
-        return new KeyRep(KeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded());
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
     }
 
     /**

--- a/src/main/java/com/ibm/crypto/plus/provider/JCEPlusKeyRep.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/JCEPlusKeyRep.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package com.ibm.crypto.plus.provider;
+
+import java.io.NotSerializableException;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.security.KeyFactory;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Locale;
+import javax.crypto.spec.SecretKeySpec;
+
+class JCEPlusKeyRep implements Serializable {
+
+    @java.io.Serial
+    private static final long serialVersionUID = -4441922173618237196L;
+
+    protected enum Type {
+
+        /** Type for secret keys. */
+        SECRET,
+
+        /** Type for public keys. */
+        PUBLIC,
+
+        /** Type for private keys. */
+        PRIVATE
+    }
+
+    private static final String PKCS8 = "PKCS#8";
+    private static final String X509 = "X.509";
+    private static final String RAW = "RAW";
+
+    private final Type keyType;
+
+    private final String keyAlg;
+
+    private final String encodingFormat;
+
+    private final byte[] encodedKey;
+
+    private final String provider;
+
+    public JCEPlusKeyRep(Type type, String algorithm,
+            String format, byte[] encoded, String oJcePlusProvider) {
+ 
+        if (oJcePlusProvider == null || type == null || algorithm == null ||
+            format == null || encoded == null) {
+            throw new NullPointerException("invalid null input(s)");
+        }
+        
+        this.keyType = type;
+        this.keyAlg = algorithm;
+        this.encodingFormat = format.toUpperCase(Locale.ENGLISH);
+        this.encodedKey = encoded.clone();
+        this.provider = oJcePlusProvider;
+    }
+     
+    @java.io.Serial
+    protected Object readResolve() throws ObjectStreamException {
+        try {
+            if (keyType == Type.SECRET && RAW.equals(encodingFormat)) {
+                return new SecretKeySpec(encodedKey, keyAlg);
+            } else if (keyType == Type.PUBLIC && X509.equals(encodingFormat)) {
+                KeyFactory f = KeyFactory.getInstance(keyAlg, provider);
+                return f.generatePublic(new X509EncodedKeySpec(encodedKey));
+            } else if (keyType == Type.PRIVATE && PKCS8.equals(encodingFormat)) {
+                KeyFactory f = KeyFactory.getInstance(keyAlg, provider);
+                return f.generatePrivate(new PKCS8EncodedKeySpec(encodedKey));
+            } else {
+                throw new NotSerializableException("Key type and format combination invalid: " +
+                    keyType + " " + encodingFormat);
+            }
+        } catch (NotSerializableException nse) {
+            throw nse;
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            NotSerializableException nse = new NotSerializableException("java.security.Key: " +
+                "[" + keyType + "] " +
+                "[" + keyAlg + "] " +
+                "[" + encodingFormat + "]");
+            nse.initCause(e);
+            throw nse;
+        }
+    }
+}

--- a/src/main/java/com/ibm/crypto/plus/provider/MLKEMImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/MLKEMImpl.java
@@ -127,7 +127,7 @@ public class MLKEMImpl implements KEMSpi {
             AlgorithmParameterSpec spec)
             throws InvalidAlgorithmParameterException, InvalidKeyException {
  
-        if (privateKey == null || !(privateKey instanceof PQCPrivateKey)) {
+        if (privateKey == null) {
             throw new InvalidKeyException("unsupported key");
         }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCPrivateKey.java
@@ -19,10 +19,10 @@ import sun.security.util.DerValue;
 import sun.security.x509.AlgorithmId;
 
 /*
- * A PQC private key for the NIST FIPS 203 Algorithm.
+ * A PQC private key for the NIST FIPS 203, 204, 205 Algorithm.
  */
 @SuppressWarnings("restriction")
-final class PQCPrivateKey extends PKCS8Key {
+public final class PQCPrivateKey extends PKCS8Key {
 
     private static final long serialVersionUID = -3168962080315231494L;
 
@@ -179,6 +179,12 @@ final class PQCPrivateKey extends PKCS8Key {
     PQCKey getPQCKey() {
         return this.pqcKey;
     }
+
+    @java.io.Serial
+    protected Object writeReplace() throws java.io.ObjectStreamException {
+        checkDestroyed();
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PRIVATE, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
+    } 
 
     /**
      * Destroys this key. A call to any of its other methods after this will

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCPublicKey.java
@@ -139,6 +139,11 @@ final class PQCPublicKey extends X509Key
         return this.pqcKey;
     }
 
+    private Object writeReplace() throws java.io.ObjectStreamException {
+        checkDestroyed();
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
+    }
+    
     /**
      * Destroys this key. A call to any of its other methods after this will cause
      * an IllegalStateException to be thrown.

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateCrtKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateCrtKey.java
@@ -293,6 +293,12 @@ final class RSAPrivateCrtKey extends PKCS8Key
         return this.publicExponent;
     }
 
+    @java.io.Serial
+    protected Object writeReplace() throws java.io.ObjectStreamException {
+        checkDestroyed();
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PRIVATE, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
+    } 
+
     /**
      * Destroys this key. A call to any of its other methods after this will
      * cause an IllegalStateException to be thrown.

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateKey.java
@@ -228,6 +228,12 @@ final class RSAPrivateKey extends PKCS8Key
         return this.modulus;
     }
 
+    @java.io.Serial
+    protected Object writeReplace() throws java.io.ObjectStreamException {
+        checkDestroyed();
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PRIVATE, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
+    } 
+
     /**
      * Destroys this key. A call to any of its other methods after this will
      * cause an IllegalStateException to be thrown.

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPublicKey.java
@@ -13,7 +13,6 @@ import com.ibm.crypto.plus.provider.ock.RSAKey;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.InvalidKeyException;
-import java.security.KeyRep;
 import java.security.ProviderException;
 import java.security.spec.AlgorithmParameterSpec;
 import javax.security.auth.DestroyFailedException;
@@ -244,7 +243,7 @@ final class RSAPublicKey extends X509Key
      */
     private Object writeReplace() throws java.io.ObjectStreamException {
         checkDestroyed();
-        return new KeyRep(KeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded());
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
     }
 
     /**

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
@@ -17,7 +17,6 @@ import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
-import java.security.KeyRep;
 import java.security.ProviderException;
 import java.security.PublicKey;
 import java.security.interfaces.XECPrivateKey;
@@ -559,7 +558,7 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
     }
 
     protected Object writeReplace() throws java.io.ObjectStreamException {
-        return new KeyRep(KeyRep.Type.PRIVATE, getAlgorithm(), getFormat(), getEncoded());
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PRIVATE, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
     }
 
     /**

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
@@ -16,7 +16,6 @@ import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
-import java.security.KeyRep;
 import java.security.interfaces.XECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidParameterSpecException;
@@ -490,6 +489,6 @@ final class XDHPublicKeyImpl extends X509Key implements XECPublicKey, Destroyabl
     }
 
     protected Object writeReplace() throws java.io.ObjectStreamException {
-        return new KeyRep(KeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded());
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
     }
 }

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/OCKException.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/OCKException.java
@@ -41,6 +41,12 @@ public final class OCKException extends java.lang.Exception {
         this.code = GKR_UNSPECIFIED;
     }
 
+    public OCKException(String s, Throwable cause) {
+        super(s, cause);
+        this.code = GKR_UNSPECIFIED;
+    }
+
+
     public OCKException(int code) {
         super(errorMessage(code));
         this.code = code;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/PQCKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/PQCKey.java
@@ -36,10 +36,10 @@ public final class PQCKey implements AsymmetricKey {
             keyId = NativeInterface.MLKEY_generate(ockContext.getId(), NoDashAlg);
 
             if (keyId == 0) {   
-                throw new OCKException("OCKPQCKey.generateKeyPair: MLKEY_generate failed");
+                throw new OCKException("PQCKey.generateKeyPair: MLKEY_generate failed");
             }    
         } catch (Exception e) {
-            throw new OCKException("OCKPQCKey.generateKeyPair: Exception " + e.getCause());
+            throw new OCKException("PQCKey.generateKeyPair: Exception " + e.getMessage(), e);
         }
         return new PQCKey(ockContext, keyId, unobtainedKeyBytes, unobtainedKeyBytes, algName);
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/PQCSignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/PQCSignature.java
@@ -28,7 +28,7 @@ public final class PQCSignature {
     public static PQCSignature getInstance(OCKContext ockContext)
             throws OCKException {
         if (ockContext == null) {
-            throw new IllegalArgumentException("context is null");
+            throw new IllegalArgumentException("Context is null");
         }
         return new PQCSignature(ockContext);
     }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeySerialization.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeySerialization.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+package ibm.jceplus.junit.base;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import javax.crypto.KEM;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class BaseTestPQCKeySerialization extends BaseTestJunit5 {
+    
+    final String PQCKEM_KEYAGREEMENT_ALG = "MLKEMKeyAgreement";
+    String algorithm = "ML_KEM_768";
+
+    @Test
+    public void SerializationTest () throws Exception {
+        KeyPairGenerator kpg = null;
+
+        try {
+            kpg = KeyPairGenerator.getInstance(algorithm, getProviderName());
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+            throw e;
+        } catch (NoSuchProviderException e) {
+            e.printStackTrace();
+            throw e;
+        }
+
+        KeyPair keyPair = kpg.generateKeyPair();
+
+        KEM kem = KEM.getInstance(algorithm, getProviderName());
+
+        // serialize and de-serialize the public key while storing in file
+        File publicKeyFile = createTempFile();
+        serializeKey(keyPair.getPublic(), publicKeyFile);
+        PublicKey deserializedPublicKey = (PublicKey) deserializeKey(publicKeyFile);
+
+        // private key serialize and de-serialize
+        File privateKeyFile = createTempFile();
+        serializeKey(keyPair.getPrivate(), privateKeyFile);
+        PrivateKey deserializedPrivateKey = (PrivateKey) deserializeKey(privateKeyFile);
+
+        assertArrayEquals(keyPair.getPublic().getEncoded(), 
+            deserializedPublicKey.getEncoded(),
+            "Public deserialized does not match original");
+
+        assertArrayEquals(keyPair.getPrivate().getEncoded(), 
+            deserializedPrivateKey.getEncoded(),
+            "Public deserialized does not match original");
+
+        KEM.Encapsulator encr = kem.newEncapsulator(keyPair.getPublic());
+        KEM.Encapsulated enc = encr.encapsulate(0,31,"AES");
+
+        SecretKey keyE = enc.key();
+
+        KEM.Decapsulator decr = kem.newDecapsulator(deserializedPrivateKey);
+        SecretKey keyD = decr.decapsulate(enc.encapsulation(),0,31,"AES");
+
+        assertArrayEquals(keyE.getEncoded(),keyD.getEncoded(),"Secrets do NOT match");
+
+        encr = kem.newEncapsulator(deserializedPublicKey);
+        enc = encr.encapsulate(0,31,"AES");
+
+        keyE = enc.key();
+
+        decr = kem.newDecapsulator(keyPair.getPrivate());
+        keyD = decr.decapsulate(enc.encapsulation(),0,31,"AES");
+
+        assertArrayEquals(keyE.getEncoded(),keyD.getEncoded(),"Secrets do NOT match");
+    }
+
+    protected KeyPair generateKeyPair(KeyPairGenerator keyPairGen) throws Exception {
+        KeyPair keyPair = keyPairGen.generateKeyPair();
+
+        if (keyPair.getPrivate() == null) {
+            fail("Private key is null");
+        }
+
+        if (keyPair.getPublic() == null) {
+            fail("Public key is null");
+        }
+
+        return keyPair;
+    }
+
+    private File createTempFile() {
+        File file = null;
+        try {
+            file = File.createTempFile("key", ".ser");
+            return file;
+        } catch (IOException e) {
+            fail("temporary file cannot be created");
+        }
+        return file;
+    }
+
+    private boolean destroyFile(File file) {
+        return file.delete();
+    }
+
+    private void serializeKey(Object key, File file) {
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(new FileOutputStream(file))) {
+            objectOutputStream.writeObject(key);
+        } catch (IOException e) {
+            file.deleteOnExit();
+            fail("Error during serialization: " + e.getMessage());
+        }
+    }
+
+    private Object deserializeKey(File file) {
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new FileInputStream(file))) {
+            Object object = objectInputStream.readObject();
+            return object;
+        } catch (IOException | ClassNotFoundException e) {
+            file.deleteOnExit();
+            fail("Error during deserialization: " + e.getMessage());
+        }
+        return null;
+    }
+}    

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKEMMultiThread.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKEMMultiThread.java
@@ -13,13 +13,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.condition.OS;
 
 @TestInstance(Lifecycle.PER_CLASS)
 @DisabledOnOs(value = OS.MAC, architectures = "x86_64")
-@EnabledForJreRange(min = JRE.JAVA_17)
 public class TestPQCKEMMultiThread extends BaseTestPQCKEMMultiThread  {
 
     @BeforeAll

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKeyInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKeyInteropBC.java
@@ -13,13 +13,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.condition.OS;
 
 @TestInstance(Lifecycle.PER_CLASS)
 @DisabledOnOs(value = OS.MAC, architectures = "x86_64")
-@EnabledForJreRange(min = JRE.JAVA_17)
 public class TestPQCKeyInteropBC extends BaseTestPQCKeyInterop {
 
     @BeforeAll

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKeySerialization.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKeySerialization.java
@@ -8,17 +8,14 @@
 
 package ibm.jceplus.junit.openjceplus;
 
-import ibm.jceplus.junit.base.BaseTestKEM;
+import ibm.jceplus.junit.base.BaseTestPQCKeySerialization;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 @TestInstance(Lifecycle.PER_CLASS)
-@DisabledOnOs(value = OS.MAC, architectures = "x86_64")
-public class TestPQCKEM extends BaseTestKEM {
-
+public class TestPQCKeySerialization extends BaseTestPQCKeySerialization {
+   
     @BeforeAll
     public void beforeAll() {
         Utils.loadProviderTestSuite();

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKeys.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKeys.java
@@ -13,13 +13,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.condition.OS;
 
 @TestInstance(Lifecycle.PER_CLASS)
 @DisabledOnOs(value = OS.MAC, architectures = "x86_64")
-@EnabledForJreRange(min = JRE.JAVA_17)
 public class TestPQCKeys extends BaseTestPQCKeys {
 
     @BeforeAll

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKeystore.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKeystore.java
@@ -13,13 +13,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.condition.OS;
 
 @TestInstance(Lifecycle.PER_CLASS)
 @DisabledOnOs(value = OS.MAC, architectures = "x86_64")
-@EnabledForJreRange(min = JRE.JAVA_17)
 public class TestPQCKeystore extends BaseTestPQCKeystore {
 
     @BeforeAll

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCSignatureWithAliases.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCSignatureWithAliases.java
@@ -13,13 +13,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.condition.OS;
 
 @TestInstance(Lifecycle.PER_CLASS)
 @DisabledOnOs(value = OS.MAC, architectures = "x86_64")
-@EnabledForJreRange(min = JRE.JAVA_17)
 public class TestPQCSignatureWithAliases extends BaseTestPQCSignatureWithAliases {
 
     @BeforeAll

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCSignatures.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCSignatures.java
@@ -13,13 +13,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.condition.OS;
 
 @TestInstance(Lifecycle.PER_CLASS)
 @DisabledOnOs(value = OS.MAC, architectures = "x86_64")
-@EnabledForJreRange(min = JRE.JAVA_17)
 public class TestPQCSignatures extends BaseTestPQCSignature {
 
     @BeforeAll


### PR DESCRIPTION
Needed to remove the dependency of JDK17 in the testcases.
Also, there is an issue with serialization. When KeyRep is used to serialize the key the provider order is used to de serialize the key which can cause the wrong key to be created.  So, added a new KeyRep class that contains the provider which will allow the correct key to be created.