### PR TITLE
Allow OpenJCEPlus to run in developer mode

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -275,17 +275,9 @@ def getTestFlag(hardware, software) {
         return " -Dtest=${SPECIFIC_TEST}"
     }
 
-    // Based on platform, decide whether FIPS tests should be run.
-    if ((software == "mac") || ((software == "linux") && (hardware == "aarch64"))) {
-        echo "Only non-FIPS tests can be run in ${hardware}_${software}"
-        return " -Dtest=ibm.jceplus.junit.openjceplus.TestAll," +
-                       "ibm.jceplus.junit.TestMemStressAll," +
-                       "ibm.jceplus.junit.TestMultithread," +
-                       "ibm.jceplus.junit.openjceplus.integration.TestAll"
-    } else {
-        echo "All tests (both FIPS and non-FIPS) can be run in ${hardware}_${software}"
-        return "";
-    }
+    // Run all tests. Some platforms will naturally run in developer mode.
+    echo "All tests (both FIPS and non-FIPS) can be run in ${hardware}_${software}"
+    return "";
 }
 
 /*

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ Build Status:
 `OpenJCEPlus` and `OpenJCEPlusFIPS` providers are currently supported on the following architectures and operating system combinations as reported by `mvn --version` in the values `OS name` and `arch`:
 | OS name                 | arch        |
 | ----------------------- | ----------- |
+| linux                   | aarch64     |
 | linux                   | amd64       |
 | linux                   | s390x       |
 | linux                   | ppc64le     |
 | Windows Server 2022     | amd64       |
 | AIX                     | ppc64       |
-| Mac OS X*               | aarch64*    |
-| Mac OS X*               | amd64*      |
-* Mac OS X currently is only able to compile and run tests using the `OpenJCEPlus` provider, not `OpenJCEPlusFIPS`. The provider `OpenJCEPlusFIPS` will not load.
+| Mac OS X                | aarch64     |
+| Mac OS X                | amd64       |
 
 Follow these steps to build the `OpenJCEPlus` and `OpenJCEPlusFIPS` providers along with a dependent Java Native Interface library. Keep in mind that `$PROJECT_HOME` can represent any directory on your system and will be referred to as such in the subsequent instructions. Also keep in mind that the value `$JAVA_VERSION` below must match the same version of the branch of OpenJCEPlus being built. For example if building the `java21` branch the `$JAVA_VERSION` must match the Java 21 SDK version such as `21.0.2+13`.
 

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -32,6 +32,8 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
     // Field serialVersionUID per tag [SERIALIZATION] in DesignNotes.txt
     private static final long serialVersionUID = 929669768004683845L;
 
+    private static final boolean printFipsDeveloperModeWarning = Boolean.parseBoolean(System.getProperty("openjceplus.fips.devmodewarn", "true"));
+
     private static final String info = "OpenJCEPlusFIPS Provider implements the following:\n" +
 
             "Algorithm parameter                : AES, DiffieHellman, DSA, EC, GCM, OAEP, RSAPSS\n"
@@ -68,7 +70,7 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
     private static boolean ockInitialized = false;
     private static OCKContext ockContext;
 
-    private static final boolean isPlatformSupported;
+    private static final boolean isFIPSCertifiedPlatform;
     private static final Map<String, List<String>> supportedPlatforms = new HashMap<>();
     private static final String osName;
     private static final String osArch;
@@ -96,7 +98,7 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
                 break;
             }
         }
-        isPlatformSupported = isOsSupported && isArchSupported;
+        isFIPSCertifiedPlatform = isOsSupported && isArchSupported;
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -106,9 +108,13 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
             debug.println("New OpenJCEPlusFIPS instance");
         }
 
-        if (!isPlatformSupported) {
-            throw new UnsupportedOperationException(
-                        "OpenJCEPlusFIPS is not supported on this non FIPS " + osName + " " + osArch + " platform");
+        if (!isFIPSCertifiedPlatform) {
+            if (printFipsDeveloperModeWarning) {
+                System.out.println("WARNING: OpenJCEPlusFIPS is running in developer mode. Non production workload assumed. This environment is not certified for FIPS 140-3: " + osName + ":" + osArch);
+            }
+            if (debug != null) {
+                debug.println("WARNING: OpenJCEPlusFIPS is running in developer mode.  Non production workload assumed. This environment is not certified for FIPS 140-3: " + osName + ":" + osArch);
+            }
         }
 
         final OpenJCEPlusProvider jce = this;
@@ -810,6 +816,15 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
 
         try {
             boolean useFIPSMode = true;
+            if (!isFIPSCertifiedPlatform) {
+                if (printFipsDeveloperModeWarning) {
+                    System.out.println("WARNING: OpenJCEPlusFIPS is about to load non FIPS 140-3 library!");
+                }
+                if (debug != null) {
+                    debug.println("WARNING: OpenJCEPlusFIPS is about to load non FIPS 140-3 library!");
+                }
+                useFIPSMode = false;
+            }
 
             ockContext = OCKContext.createContext(useFIPSMode);
             ockInitialized = true;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyPairGenerator.java
@@ -230,7 +230,8 @@ public class BaseTestECKeyPairGenerator extends BaseTestJunit5 {
             assertTrue(true);
         }
 
-        if (getProviderName().equalsIgnoreCase("OpenJCEPlusFIPS")) {
+        boolean isDeveloperModePlatform = BaseUtils.getIsFIPSCertifiedPlatform();
+        if (getProviderName().equalsIgnoreCase("OpenJCEPlusFIPS") && isDeveloperModePlatform) {
             try {
                 generictestECKeyGenCurve("secp112r1");
                 assertTrue(false);

--- a/src/test/java/ibm/jceplus/junit/base/BaseUtils.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseUtils.java
@@ -9,6 +9,9 @@
 package ibm.jceplus.junit.base;
 
 import java.security.Provider;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 abstract public class BaseUtils {
 
@@ -97,5 +100,40 @@ abstract public class BaseUtils {
         return loadProvider(PROVIDER_OpenJCEPlusFIPS,
                 "com.ibm.crypto.plus.provider.OpenJCEPlusFIPS");
     }
-}
 
+
+    /**
+     * Determines if we are running on an environment where a FIPS
+     * certified library is known to exist.
+     * 
+     * @return true if running within a known FIPS envionrment, false otherwise.
+     */
+    public static boolean getIsFIPSCertifiedPlatform() {
+        Map<String, List<String>> supportedPlatforms = new HashMap<>();
+        String osName;
+        String osArch;
+
+        supportedPlatforms.put("Arch", List.of("amd64", "ppc64", "s390x"));
+        supportedPlatforms.put("OS", List.of("Linux", "AIX", "Windows"));
+
+        osName = System.getProperty("os.name");
+        osArch = System.getProperty("os.arch");;
+
+        boolean isOsSupported, isArchSupported;
+        isOsSupported = false;
+        for (String os: supportedPlatforms.get("OS")) {
+            if (osName.contains(os)) {
+                isOsSupported = true;
+                break;
+            }
+        }
+        isArchSupported = false;
+        for (String arch: supportedPlatforms.get("Arch")) {
+            if (osArch.contains(arch)) {
+                isArchSupported = true;
+                break;
+            }
+        }
+        return isOsSupported && isArchSupported;
+    }
+}


### PR DESCRIPTION
Users may wish to develop on various platforms in which the OpenJCEPlusFIPS provider currently does not function. This update allows for execution on such platforms while issuing a warning to users when loading the provider.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/677

Signed-off-by: Jason Katonica <katonica@us.ibm.com>