### PR TITLE
Remove unnecessary change of interop for z/OS

### DIFF
--- a/src/test/java/ibm/jceplus/junit/openjceplus/Utils.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/Utils.java
@@ -15,10 +15,6 @@ abstract public class Utils extends ibm.jceplus.junit.base.BaseUtils {
 
 
     public static java.security.Provider loadProviderTestSuite() {
-        if (System.getProperty("os.name").equals("z/OS")) {
-            Utils.PROVIDER_SunEC = "BC"; //jpf SunEC doesn't have the necessary EC algorithms use BouncyCastle instead "SunEC";
-        }
-
         try {
             return loadProviderOpenJCEPlus();
         } catch (Exception e) {


### PR DESCRIPTION
The `z/OS` specific change of the interop provider is removed, as there is no problem with the `SunEC` provider, which can be used as is.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/679

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>