### PR TITLE
Update configuration doc for OpenJCEPlusFIPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ mvn '-Dock.library.path=$PROJECT_HOME/OCK/' test -Dtest=TestClassname
 
 ## OpenJCEPlus and OpenJCEPlusFIPS Provider SDK Installation
 
-1. There are two ways to configure and make use of the OpenJCEPlus and OpenJCEPlus providers:
+1. There are two ways to configure and make use of the OpenJCEPlus and OpenJCEPlusFIPS providers:
 
     - Approach 1: Modify your `java.security` file located in the `$JAVA_HOME/conf/security` directory by adding one, or both, of the following providers. The value `XX`
 below represents your desired preference order. Setting `XX` to 1 would install the provider as the top priority. Be sure to restart your application for the setting to


### PR DESCRIPTION
The documenation incorrectly specified OpenJCEPlus provider twice instead of correctly describing the two different provider names.

Fixes: https://github.com/IBM/OpenJCEPlus/issues/695

Signed-off-by: Jason Katonica <katonica@us.ibm.com>