### PR TITLE
Update hashCode() and equals() in keys to match OpenJDK's version

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/AESKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKey.java
@@ -12,6 +12,7 @@ import java.security.InvalidKeyException;
 import java.security.KeyRep;
 import java.util.Arrays;
 import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 import javax.security.auth.DestroyFailedException;
 
 /**
@@ -72,11 +73,8 @@ final class AESKey implements SecretKey {
     public int hashCode() {
         checkDestroyed();
 
-        int retval = 0;
-        for (int i = 1; i < this.key.length; i++) {
-            retval += this.key[i] * i;
-        }
-        return (retval ^= "aes".hashCode());
+        SecretKeySpec keySpec = new SecretKeySpec(this.key, getAlgorithm());
+        return keySpec.hashCode();
     }
 
     @Override

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Key.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Key.java
@@ -12,6 +12,7 @@ import java.security.InvalidKeyException;
 import java.security.KeyRep;
 import java.util.Arrays;
 import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 import javax.security.auth.DestroyFailedException;
 
 /**
@@ -73,11 +74,8 @@ final class ChaCha20Key implements SecretKey, ChaCha20Constants {
     public int hashCode() {
         checkDestroyed();
 
-        int retval = 0;
-        for (int i = 1; i < this.key.length; i++) {
-            retval += this.key[i] * i;
-        }
-        return (retval ^= "ChaCha20".hashCode());
+        SecretKeySpec keySpec = new SecretKeySpec(this.key, getAlgorithm());
+        return keySpec.hashCode();
     }
 
     @Override

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeKey.java
@@ -13,6 +13,7 @@ import java.security.KeyRep;
 import java.util.Arrays;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.DESedeKeySpec;
+import javax.crypto.spec.SecretKeySpec;
 import javax.security.auth.DestroyFailedException;
 import javax.security.auth.Destroyable;
 
@@ -75,11 +76,8 @@ final class DESedeKey implements SecretKey, Destroyable {
     public int hashCode() {
         checkDestroyed();
 
-        int retval = 0;
-        for (int i = 1; i < this.key.length; i++) {
-            retval += this.key[i] * i;
-        }
-        return (retval ^= "desede".hashCode());
+        SecretKeySpec keySpec = new SecretKeySpec(this.key, getAlgorithm());
+        return keySpec.hashCode();
     }
 
     @Override

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAPrivateKey.java
@@ -14,7 +14,6 @@ import java.io.Serializable;
 import java.math.BigInteger;
 import java.security.AlgorithmParameters;
 import java.security.InvalidKeyException;
-import java.security.Key;
 import java.security.interfaces.DSAParams;
 import java.security.spec.DSAParameterSpec;
 import java.security.spec.InvalidParameterSpecException;
@@ -247,38 +246,6 @@ final class DSAPrivateKey extends PKCS8Key
         if (destroyed) {
             throw new IllegalStateException("This key is no longer valid");
         }
-    }
-
-    /**
-     * Compares two private keys. This returns false if the object with which
-     * to compare is not of type <code>Key</code>.
-     * Otherwise, we compare the private part of the key and the params to validate equivalence.
-     * We can not compare encodings because there are 2 different ones and both can be the same
-     * key.
-     *
-     * @param object the object with which to compare
-     * @return {@code true} if this key has the same encoding as the
-     *          object argument; {@code false} otherwise.
-     */
-    public boolean equals(Object object) {
-        try {
-            BigInteger i = (BigInteger) (object.getClass().getDeclaredMethod("getX")
-                    .invoke(object));
-
-            if (this == object) {
-                return true;
-            }
-            if (object instanceof Key) {
-                if (this.x.equals(i) && equals(this.getParams(), (DSAParams) (object
-                        .getClass().getDeclaredMethod("getParams").invoke(object)))) {
-                    return true;
-                }
-            }
-        } catch (Exception e1) {
-            //Should never get here
-            //System.out.println("Object = Exception - " + e1.toString());
-        }
-        return false;
     }
 
     public static boolean equals(DSAParams spec1, DSAParams spec2) {

--- a/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.security.AlgorithmParameters;
 import java.security.InvalidKeyException;
-import java.security.Key;
 import java.security.ProviderException;
 import java.security.PublicKey;
 import java.security.spec.ECParameterSpec;
@@ -679,38 +678,6 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
         if (destroyed) {
             throw new IllegalStateException("This key is no longer valid");
         }
-    }
-
-    /**
-     * Compares two private keys. This returns false if the object with which
-     * to compare is not of type <code>Key</code>.
-     * Otherwise, we compare the private part of the key and the params to validate equivalence.
-     * We can not compare encodings because there are 2 different ones and both can be the same 
-     * key.
-     *
-     * @param object the object with which to compare
-     * @return {@code true} if this key has the same encoding as the
-     *          object argument; {@code false} otherwise.
-     */
-    public boolean equals(Object object) {
-        try {
-            BigInteger i = (BigInteger) (object.getClass().getDeclaredMethod("getS")
-                    .invoke(object));
-
-            if (this == object) {
-                return true;
-            }
-            if (object instanceof Key) {
-                if (this.s.equals(i) && ECUtils.equals(this.getParams(), (ECParameterSpec) (object
-                        .getClass().getDeclaredMethod("getParams").invoke(object)))) {
-                    return true;
-                }
-            }
-        } catch (Exception e1) {
-            //Should never get here
-            //System.out.println("Object = Exception - " + e1.toString());
-        }
-        return false;
     }
 
 }

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAKeyFactory.java
@@ -24,7 +24,6 @@ import java.security.spec.NamedParameterSpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
-import java.util.Optional;
 
 public class EdDSAKeyFactory extends KeyFactorySpi {
 
@@ -75,7 +74,7 @@ public class EdDSAKeyFactory extends KeyFactorySpi {
                 privKey = (com.ibm.crypto.plus.provider.EdDSAPrivateKeyImpl) key;
             } else {
                 try {
-                    privKey = new EdDSAPrivateKeyImpl(provider, params, Optional.of(privateKeyBytes));
+                    privKey = new EdDSAPrivateKeyImpl(provider, params, privateKeyBytes);
                 } catch (InvalidAlgorithmParameterException iape) {
                     throw new InvalidKeyException(iape);
                 }
@@ -172,7 +171,7 @@ public class EdDSAKeyFactory extends KeyFactorySpi {
             checkLockedParams(params);
             byte[] bytes = privateKeySpec.getBytes();
             try {
-                return new EdDSAPrivateKeyImpl(provider, params, Optional.of(bytes));
+                return new EdDSAPrivateKeyImpl(provider, params, bytes);
             } catch (InvalidAlgorithmParameterException iape) {
                 throw new InvalidKeySpecException(iape);
             } finally {

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAPrivateKeyImpl.java
@@ -18,7 +18,6 @@ import java.security.InvalidParameterException;
 import java.security.KeyRep;
 import java.security.interfaces.EdECPrivateKey;
 import java.security.spec.NamedParameterSpec;
-import java.util.Arrays;
 import java.util.Optional;
 import sun.security.pkcs.PKCS8Key;
 import sun.security.util.DerInputStream;
@@ -33,7 +32,7 @@ final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKey {
 
     private static final byte TAG_PARAMETERS_ATTRS = 0x00;
     private OpenJCEPlusProvider provider = null;
-    private transient Optional<byte[]> h;
+    private transient byte[] h;
     private transient NamedParameterSpec paramSpec;
     private CURVE curve;
     private Exception exception = null; // In case an exception happened and the API did
@@ -44,7 +43,8 @@ final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKey {
     private void setFieldsFromXeckey() throws Exception {
         if (this.privKeyMaterial == null) {
             this.privKeyMaterial = extractPrivateKeyFromOCK(xecKey.getPrivateKeyBytes()); // Extract key from GSKit and sets params
-            this.h = Optional.of(this.privKeyMaterial);
+            DerInputStream derStream = new DerInputStream(this.privKeyMaterial);
+            this.h = derStream.getOctetString();
             this.algid = CurveUtil.getAlgId(this.curve);
         }
     }
@@ -72,7 +72,7 @@ final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKey {
     }
 
     EdDSAPrivateKeyImpl(OpenJCEPlusProvider provider,
-            NamedParameterSpec params, Optional<byte[]> h)
+            NamedParameterSpec params, byte[] h)
             throws InvalidAlgorithmParameterException, InvalidParameterException, InvalidKeyException {
 
         this.provider = provider;
@@ -84,8 +84,13 @@ final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKey {
             this.algid = CurveUtil.getAlgId(this.curve);
 
             if (h != null) {
-                this.privKeyMaterial = h.get().clone();
-                this.h = Optional.of(this.privKeyMaterial);
+                this.h = h.clone();
+                DerValue val = new DerValue(DerValue.tag_OctetString, h);
+                try {
+                    this.privKeyMaterial = val.toByteArray();
+                } finally {
+                    val.clear();
+                }
             }
 
             if (this.privKeyMaterial == null) {
@@ -110,7 +115,7 @@ final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKey {
 
     EdDSAPrivateKeyImpl(OpenJCEPlusProvider provider, byte[] encoded)
             throws InvalidKeyException, IOException {
-
+        super(encoded);
         this.provider = provider;
         try {
             byte[] alteredEncoded = processEncodedPrivateKey(encoded); // Sets params, key, and algid, and alters encoded
@@ -130,9 +135,9 @@ final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKey {
 
     void checkLength(CURVE curve) throws InvalidKeyException {
 
-        if (CurveUtil.getCurveSize(curve) != this.h.get().length) {
+        if (CurveUtil.getCurveSize(curve) != this.h.length) {
             throw new InvalidKeyException(
-                    "key length is " + this.h.get().length + ", key length must be "
+                    "key length is " + this.h.length + ", key length must be "
                             + CurveUtil.getCurveSize(curve));
         }
     }
@@ -176,13 +181,10 @@ final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKey {
 
         // Read, convert, then write private key
         this.privKeyMaterial = inputValue[2].getOctetString(); // Get octet string
-        //Need to remove seq tag from key
-        this.privKeyMaterial = Arrays.copyOfRange(this.privKeyMaterial, 2, this.privKeyMaterial.length);
-        this.h = Optional.of(this.privKeyMaterial);
+        DerInputStream derStream = new DerInputStream(this.privKeyMaterial);
+        this.h = derStream.getOctetString();
 
-        DerOutputStream encodedKey = new DerOutputStream();
-        encodedKey.putOctetString(this.privKeyMaterial); // Put in another octet string
-        outStream.putOctetString(encodedKey.toByteArray());
+        outStream.putOctetString(this.privKeyMaterial);
 
         DerOutputStream asn1Key = new DerOutputStream();
         asn1Key.write(DerValue.tag_Sequence, outStream);
@@ -244,7 +246,6 @@ final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKey {
         byte[] privData = null;
         if (inputValue.length > 2) {
             privData = inputValue[2].getOctetString();
-            privData = new DerInputStream(privData).getOctetString();
             return privData;
         }
         return null;
@@ -269,9 +270,7 @@ final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKey {
         mainSeq.write(DerValue.tag_Sequence, oidSeq.toByteArray());
 
         // Adding Key
-        DerOutputStream keyOctetString = new DerOutputStream();
-        keyOctetString.putOctetString(this.privKeyMaterial);
-        mainSeq.putOctetString(keyOctetString.toByteArray());
+        mainSeq.putOctetString(this.privKeyMaterial);
 
         // Wrapping up in a sequence
         DerOutputStream outStream = new DerOutputStream();
@@ -295,7 +294,7 @@ final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKey {
         } catch (Exception exception) {
             this.exception = exception;
         }
-        return this.h;
+        return Optional.of(this.h);
     }
 
     @Override


### PR DESCRIPTION
Several keys, like `AESKey`, `ChaCha20Key`, `DESedeKey`, `DSAPrivateKey`, `ECPrivateKey` and `EdDSAPrivateKey`, are updated so that the result of their `hashCode()` and `equals()` methods matches the one produced by the `OpenJDK` equivalent.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/682

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>