### PR TITLE
Throw exception in case of incorrect EC key size

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ KeyGenerator                | kda-hkdf-with-sha384       |X                |X   
 KeyGenerator                | kda-hkdf-with-sha512       |X                |X             |              |
 KeyPairGenerator            | DSA                        |                 |X             |              |
 KeyPairGenerator            | DiffieHellman              |X                |X             |              |
-KeyPairGenerator            | EC                         |X                |X             |              |
+KeyPairGenerator            | EC                         |X                |X             |[ECKeyPairGenerator incorrect keysize](#eckeypairgenerator-incorrect-keysize)|
 KeyPairGenerator            | Ed25519                    |                 |X             |              |
 KeyPairGenerator            | Ed448                      |                 |X             |              |
 KeyPairGenerator            | EdDSA                      |                 |X             |              |
@@ -431,6 +431,16 @@ OpenJCEPlus provider enhances the security of Java applications by providing an 
 No keytool or certificate support was added other than what is already in a given Java runtime environment.
 
 The `ML-DSA` algorithm is supported in all OpenJCEPlus environments listed in section [How to Build `OpenJCEPlus` and Java Native Interface Library](#how-to-build-openjceplus-and-java-native-interface-library) except for MacOS on x86.
+
+### ECKeyPairGenerator incorrect keysize
+
+The behaviour for initializing an `ECKeyPairGenerator` with a keysize that is incorrect (i.e., doesn't correspond to the size of one of the expected curves) has changed.
+
+In previous releases, an incorrect keysize would cause a default initialization to `256`.
+
+A `ProviderException` is thrown now if the user attempts to use an `ECKeyPairGenerator` that was initialized with an incorrect keysize.
+
+**NOTE**: One can revert to the previous behaviour using the `-Dopenjceplus.ec.allowIncorrectKeysizes=true` command line argument.
 
 # Contributions
 

--- a/src/main/native/ECKey.c
+++ b/src/main/native/ECKey.c
@@ -91,8 +91,8 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_ECKEY_1generate__JI(
             curveidx = 4;
             break;
         default:
-            curveidx = 2;
-            break;
+            throwOCKException(env, 0, "Incorrect key size");
+            return (jlong)0;
     }
 #ifdef DEBUG_EC_DETAIL
     if (debug) {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDSASignature.java
@@ -638,25 +638,6 @@ public class BaseTestECDSASignature extends BaseTestJunit5Signature {
     }
 
     @Test
-    public void testDatawithECDSA_longdgst_err_512() throws Exception {
-        KeyPair keyPair = generateKeyPair(512);
-        MessageDigest md = MessageDigest.getInstance("SHA-512", getProviderName());
-        md.update(origMsg);
-        byte[] digest = md.digest();
-        byte[] digestLarge = new byte[digest.length * 2];
-        digestLarge = Arrays.copyOf(digest, digest.length);
-
-        try {
-            doSignVerify("NONEwithECDSA", digestLarge, keyPair.getPrivate(), keyPair.getPublic());
-            assertTrue(false);
-        } catch (SignatureException ex) {
-            assertTrue(true);
-        } catch (Exception ex) {
-            assertTrue(true);
-        }
-    }
-
-    @Test
     public void testDatawithECDSA_longdgst_521() throws Exception {
         KeyPair keyPair = generateKeyPair(521);
         MessageDigest md = MessageDigest.getInstance("SHA-512", getProviderName());

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyPairGenerator.java
@@ -38,6 +38,16 @@ public class BaseTestECKeyPairGenerator extends BaseTestJunit5 {
     }
 
     @Test
+    public void testECKeyGen_IncorrectSize() throws Exception {
+        try {
+            doECKeyGen(255);
+            throw new RuntimeException("Expected excepton for incorrect key size not thrown");
+        } catch (ProviderException pe) {
+            // expected
+        }
+    }
+
+    @Test
     public void testECKeyGen_192() throws Exception {
         if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS no longer supports P-192 key gen

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestIsAssignableFromOrder.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestIsAssignableFromOrder.java
@@ -69,7 +69,7 @@ public class BaseTestIsAssignableFromOrder extends BaseTestJunit5 {
         // KeyFactory DH, DSA, EC, RSA, XDH
         testKeySpec("DH", 1024, DHPublicKeySpec.class, DHPrivateKeySpec.class);
         testKeySpec("DSA", 1024, DSAPublicKeySpec.class, DSAPrivateKeySpec.class);
-        testKeySpec("EC", 1024, ECPublicKeySpec.class, ECPrivateKeySpec.class);
+        testKeySpec("EC", 521, ECPublicKeySpec.class, ECPrivateKeySpec.class);
         testKeySpec("RSA", 1024, RSAPublicKeySpec.class, RSAPrivateKeySpec.class);
         testKeySpec("XDH", 255, XECPublicKeySpec.class, XECPrivateKeySpec.class);
     }

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressECKeyFactory.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressECKeyFactory.java
@@ -82,8 +82,8 @@ public class BaseTestMemStressECKeyFactory extends BaseTestJunit5 {
             // creating the object of KeyPairGenerator
             KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
 
-            // initializing with 1024
-            kpg.initialize(1024);
+            // initializing with 521
+            kpg.initialize(521);
 
             // getting key pairs
             // using generateKeyPair() method
@@ -118,8 +118,8 @@ public class BaseTestMemStressECKeyFactory extends BaseTestJunit5 {
             // creating the object of KeyPairGenerator
             KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
 
-            // initializing with 1024
-            kpg.initialize(1024);
+            // initializing with 521
+            kpg.initialize(521);
 
             // getting key pairs
             // using generateKeyPair() method


### PR DESCRIPTION
If the user provides an EC key size that doesn't correspond to one of the available curves, throw an exception instead of defaulting to 256.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/737

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>