### PR TITLE
Ignore case for X25519 and X448 curve names

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
@@ -101,9 +101,9 @@ abstract class XDHKeyAgreement extends KeyAgreementSpi {
         try {
             int secrectBufferSize = 0;
             String curveName = ((NamedParameterSpec) xdhPublicKeyImpl.getParams()).getName();
-            if (NamedParameterSpec.X25519.getName().equals(curveName)) {
+            if (NamedParameterSpec.X25519.getName().equalsIgnoreCase(curveName)) {
                 secrectBufferSize = SECRET_BUFFER_SIZE_X25519; // X25519 secret buffer size
-            } else if (NamedParameterSpec.X448.getName().equals(curveName)) {
+            } else if (NamedParameterSpec.X448.getName().equalsIgnoreCase(curveName)) {
                 secrectBufferSize = SECRET_BUFFER_SIZE_X448; // X448 secret buffer size
             } else {
                 secrectBufferSize = 0; // Let OCK decide the size


### PR DESCRIPTION
This update makes it so that casing is ignored for the X25519 and X448 curve names.

Signed-off-by: Tom Ginader [thomas.ginader@ibm.com](mailto:thomas.ginader@ibm.com)