### PR TITLE
Add AESWrap for FIPS and non-FIPS based on Oracle Alaises

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,8 @@ KeyPairGenerator            | RSAPSS                     |X                |X   
 KeyPairGenerator            | X25519                     |                 |X             |              |
 KeyPairGenerator            | X448                       |                 |X             |              |
 KeyPairGenerator            | XDH                        |                 |X             |              |
+KeyWrap                     | AES/KW/NoPadding           |X                |X             |[AESKW](#AESKW)|
+KeyWrap                     | AES/KWP/NoPadding          |X                |X             |[AESKW](#AESKW)|
 Mac                         | HmacMD5                    |                 |X             |              |
 Mac                         | HmacSHA1                   |                 |X             |              |
 Mac                         | HmacSHA224                 |X                |X             |              |
@@ -441,6 +443,12 @@ In previous releases, an incorrect keysize would cause a default initialization 
 A `ProviderException` is thrown now if the user attempts to use an `ECKeyPairGenerator` that was initialized with an incorrect keysize.
 
 **NOTE**: One can revert to the previous behaviour using the `-Dopenjceplus.ec.allowIncorrectKeysizes=true` command line argument.
+
+### AESKW
+AES Key Wrap based on NIST SP800-38F.
+
+Code does not allow the specification of an IV. However, it will return the default ICV as defined in the NIST SP800-38F. 
+
 
 # Contributions
 

--- a/src/main/java/com/ibm/crypto/plus/provider/AESKeyWrapCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKeyWrapCipher.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package com.ibm.crypto.plus.provider;
+
+import com.ibm.crypto.plus.provider.ock.AESKeyWrap;
+import com.ibm.crypto.plus.provider.ock.OCKException;
+import java.security.AlgorithmParameters;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.InvalidParameterException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.security.ProviderException;
+import java.security.SecureRandom;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidParameterSpecException;
+import java.util.Arrays;
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.CipherSpi;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.ShortBufferException;
+import javax.crypto.spec.IvParameterSpec;
+
+abstract class AESKeyWrapCipher extends CipherSpi {
+
+    private OpenJCEPlusProvider provider = null;
+    private boolean wrappering = true;
+    private boolean initialized = false;
+    private AESKeyWrap cipher = null;
+    private int setKeySize = 0;
+    private byte[] buffer = null;
+    private int bufSize = 0;
+    private int opmode = 0;
+    private boolean setPadding = false;
+    static final byte[] ICV1 = { 
+        (byte) 0xA6, (byte) 0xA6, (byte) 0xA6, (byte) 0xA6,
+        (byte) 0xA6, (byte) 0xA6, (byte) 0xA6, (byte) 0xA6
+    };
+    static final byte[] ICV2 = { 
+        (byte) 0xA6, (byte) 0x59, (byte) 0x59, (byte) 0xA6
+    };
+
+    public AESKeyWrapCipher(OpenJCEPlusProvider provider, boolean padding, int keySize) {
+        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
+            throw new SecurityException("Integrity check failed for: " + provider.getName());
+        }
+        this.provider = provider;
+        this.setKeySize = keySize;
+        this.setPadding = padding;
+    }
+
+    private void add2Buffer(byte[] data, int offSet, int len) {
+        // In NIST SP 800-38F, KWP input size is limited to be no longer
+        // than 2^32 bytes. Otherwise, the length cannot be encoded in 32 bits
+        // However, given the current spec requirement that recovered text
+        // can only be returned after successful tag verification, we are
+        // bound by limiting the data size to the size limit of java byte array,
+        // e.g. Integer.MAX_VALUE, since all data are returned by doFinal().
+        int remain = Integer.MAX_VALUE - bufSize - 16;  //16 bytes required by OCKC call
+        if (len > remain) {
+            throw new ProviderException("Buffer can only take " +
+                remain + " more bytes");
+        }
+
+        if (buffer == null || buffer.length - bufSize < len) {
+            int newSize = Math.addExact(bufSize, len);
+
+            byte[] temp = new byte[newSize];
+            if (buffer != null && bufSize > 0) {
+                System.arraycopy(buffer, 0, temp, 0, bufSize);
+                Arrays.fill(buffer, (byte)0x00);
+            }
+            buffer = temp;
+        }
+
+        if (data != null) {
+            System.arraycopy(data, offSet, buffer, bufSize, len);
+            bufSize += len;
+        }
+    }
+
+    @Override
+    protected byte[] engineDoFinal(byte[] input, int inputOffset, int inputLen)
+            throws IllegalBlockSizeException, BadPaddingException {
+        
+        byte[] out = null;
+
+        if (!this.initialized) {
+            throw new IllegalStateException("Cipher has not been initialized"); 
+        }
+
+        if (opmode != Cipher.ENCRYPT_MODE && opmode != Cipher.DECRYPT_MODE) {
+            throw new IllegalStateException("Cipher not initialized for doFinal");
+        }
+
+        if (input == null || inputOffset >= input.length || (input.length < inputLen + inputOffset)) {
+            throw new IllegalStateException("Incorrect input to API.");
+        }
+
+        add2Buffer(input, inputOffset, inputLen);
+
+        try {
+            if (opmode == Cipher.ENCRYPT_MODE) {
+                out = cipher.wrap(buffer, 0, bufSize);
+            } else {
+                out = cipher.unwrap(buffer, 0, bufSize);
+            }
+        } catch (OCKException ocke) {
+            throw new ProviderException("Operation doFinal failed", ocke);
+        }
+        this.bufSize = 0;
+        Arrays.fill(buffer, (byte)0x00);
+        this.buffer = null;
+        return out;
+    }
+
+    @Override
+    protected int engineDoFinal(byte[] input, int inputOffset, int inputLen, byte[] output,
+            int outputOffset)
+            throws ShortBufferException, IllegalBlockSizeException, BadPaddingException {
+        byte[] out = null;
+        int estOutLen = engineGetOutputSize(inputLen + bufSize);
+
+        if (output.length - outputOffset < estOutLen) {
+            throw new ShortBufferException("Need at least " + estOutLen);
+        }
+
+        try {
+            out = engineDoFinal(input, inputOffset, inputLen);
+                            
+            if (out.length > estOutLen) {
+                throw new AssertionError("Actual output length exceeds estimated length");
+            }
+            System.arraycopy(out, 0, output, outputOffset, out.length);
+            
+            return out.length;
+        } catch (Exception e) {
+            throw e;
+
+        } finally {
+            if (out != null) {
+                Arrays.fill(out, (byte)0);
+            }
+        }
+    }
+
+    @Override
+    protected int engineGetBlockSize() {
+        return 8;
+    }
+
+    @Override
+    protected byte[] engineGetIV() {
+        byte [] iv = ICV2;
+        if (!setPadding) {
+            iv = ICV1;
+        }
+        return iv.clone();
+    }
+
+    @Override
+    protected int engineGetKeySize(Key key) throws InvalidKeyException {
+        if (key == null) {
+            throw new InvalidKeyException("Key missing.");
+        }
+
+        if (!key.getAlgorithm().equalsIgnoreCase("AES")) {
+            throw new InvalidKeyException("Key not an AES key.");
+        }
+        byte[] encoded = key.getEncoded();
+        if (!AESUtils.isKeySizeValid(encoded.length)) {
+            throw new InvalidKeyException("Invalid AES key length: " + encoded.length + " bytes");
+        }
+        return encoded.length << 3;
+    }
+
+    @Override
+    protected int engineGetOutputSize(int inputLen) {
+        int result = 0;
+        if (!wrappering) {
+            result = inputLen;
+        } else {
+            result = Math.addExact(inputLen, 16);
+        }
+        return (result < 0? 0:result);
+    }
+
+    @Override
+    protected AlgorithmParameters engineGetParameters() {
+        AlgorithmParameters params = null;
+        try {
+            params = AlgorithmParameters.getInstance("AES");
+            params.init(new IvParameterSpec(engineGetIV()));
+        } catch (NoSuchAlgorithmException | InvalidParameterSpecException e) {
+            // should never happen
+            throw new AssertionError();
+        }
+        return params;
+    }
+
+    @Override
+    protected void engineInit(int opmode, Key key, SecureRandom random) throws InvalidKeyException {
+
+        if (opmode == Cipher.UNWRAP_MODE || opmode == Cipher.DECRYPT_MODE) {
+            wrappering = false;
+        } else if (opmode == Cipher.WRAP_MODE || opmode == Cipher.ENCRYPT_MODE) {
+            wrappering = true;
+        } else {
+            throw new InvalidParameterException("Incorrect opmode passed in");
+        }
+        
+        this.opmode = opmode;
+        internalInit(opmode, key);
+    }
+
+    @Override
+    protected void engineInit(int opmode, Key key, AlgorithmParameterSpec params,
+            SecureRandom random) throws InvalidKeyException, InvalidAlgorithmParameterException {
+        if (params != null) {
+            throw new InvalidAlgorithmParameterException("This cipher " +
+                "does not accept any parameters");
+        }
+        engineInit(opmode, key, random);
+    }
+
+    @Override
+    protected void engineInit(int opmode, Key key, AlgorithmParameters params, SecureRandom random)
+            throws InvalidKeyException, InvalidAlgorithmParameterException {
+        if (params != null) {
+            throw new InvalidAlgorithmParameterException("This cipher " +
+                "does not accept any parameters");
+        }
+        engineInit(opmode, key, random);
+    }
+
+    private void internalInit(int opmode, Key key) throws InvalidKeyException {
+        if (key == null) {
+            throw new InvalidKeyException("Key missing");
+        }
+
+        if (!(key.getAlgorithm().equalsIgnoreCase("AES"))) {
+            throw new InvalidKeyException("Wrong algorithm: AES required");
+        }
+
+        byte[] rawKey = key.getEncoded();
+        if (rawKey == null) {
+            throw new InvalidKeyException("Key bytes are missing");
+        }
+
+        if (!checkKeySize(rawKey.length)) {
+            throw new InvalidKeyException("Invalid AES key length: " + rawKey.length + " bytes");
+        }
+
+        try {
+            this.cipher = new AESKeyWrap(provider.getOCKContext(), rawKey, setPadding);
+        } catch (Exception e) {
+            throw new InvalidKeyException("OCKC context null or bad key.", e);
+        } 
+        this.initialized = true;   
+    }
+
+    @Override
+    protected void engineSetMode(String mode) throws NoSuchAlgorithmException {
+        if (mode == null || (!mode.equalsIgnoreCase("KW") && !mode.equalsIgnoreCase("KWP"))) {
+            throw new NoSuchAlgorithmException("Only KW or KWP mode is supported.");
+        }
+    }
+
+    @Override
+    protected void engineSetPadding(String padding) throws NoSuchPaddingException {
+        if (!padding.equalsIgnoreCase("NoPadding")) {
+            throw new NoSuchPaddingException(padding + " can not be used.");
+        }
+    }
+
+    @Override
+    protected byte[] engineUpdate(byte[] input, int inputOffset, int inputLen) {
+        if (!this.initialized) {
+            throw new IllegalStateException("Cipher has not been initialized"); 
+        }
+
+        if (opmode != Cipher.ENCRYPT_MODE && opmode != Cipher.DECRYPT_MODE) {
+            throw new IllegalStateException("Cipher not initialized for update");
+        }
+
+        add2Buffer(input, inputOffset, inputLen);
+        return null;
+    }
+
+    @Override
+    protected int engineUpdate(byte[] input, int inputOffset, int inputLen, byte[] output,
+            int outputOffset) throws ShortBufferException {
+        if (!this.initialized) {
+            throw new IllegalStateException("Cipher has not been initialized"); 
+        }
+
+        if (opmode != Cipher.ENCRYPT_MODE && opmode != Cipher.DECRYPT_MODE) {
+            throw new IllegalStateException("Cipher not initialized for update");
+        }
+
+        add2Buffer(input, inputOffset, inputLen);
+        return 0;
+    }
+
+    // see JCE spec
+    protected byte[] engineWrap(Key key) throws InvalidKeyException, IllegalBlockSizeException {
+        checkCipherInitialized();
+        if (!wrappering) {
+            throw new IllegalStateException("Cipher not initialized for wrap");
+        }
+
+        byte[] encoded = key.getEncoded();
+        if ((encoded == null) || (encoded.length == 0)) {
+            throw new InvalidKeyException("Could not obtain encoded key");
+        }
+
+        try {
+            return cipher.wrap(encoded, 0, encoded.length);
+        } catch (Exception e) {
+            // should not occur
+            throw new InvalidKeyException("Wrapping failed", e);
+        }
+    }
+
+    // see JCE spec
+    protected Key engineUnwrap(byte[] wrappedKey, String algorithm, int type)
+            throws InvalidKeyException, NoSuchAlgorithmException {
+        checkCipherInitialized();
+
+        if (wrappering) {
+            throw new IllegalStateException("Cipher not initialized for unwrap");
+        }
+        try {
+            byte[] encoded = cipher.unwrap(wrappedKey, 0, wrappedKey.length);
+            return ConstructKeys.constructKey(provider, encoded, algorithm, type);
+        } catch (Exception e) {
+            // should not occur
+            throw new InvalidKeyException("Unwrapping failed", e);
+        }    
+    }
+
+    private void checkCipherInitialized() throws IllegalStateException {
+        if (!this.initialized) {
+            throw new IllegalStateException("Cipher has not been initialized");
+        }
+    }
+
+    private boolean checkKeySize(int keySize) {
+        if ((!AESUtils.isKeySizeValid(keySize) || (keySize != setKeySize)) && (setKeySize != -1)) {
+            return false;
+        }
+        return true;
+    }
+    public static final class KW extends AESKeyWrapCipher {
+
+        public KW(OpenJCEPlusProvider provider) {
+            super(provider, false, -1);
+        }
+    }
+
+    public static final class KWP extends AESKeyWrapCipher {
+
+        public KWP(OpenJCEPlusProvider provider) {
+            super(provider, true, -1);
+        }
+    }
+    
+    public static final class KW_128 extends AESKeyWrapCipher {
+
+        public KW_128(OpenJCEPlusProvider provider) {
+            super(provider, false, 16);
+        }
+    }
+
+    public static final class KWP_128 extends AESKeyWrapCipher {
+
+        public KWP_128(OpenJCEPlusProvider provider) {
+            super(provider, true, 16);
+        }
+    }
+        
+    public static final class KW_192 extends AESKeyWrapCipher {
+
+        public KW_192(OpenJCEPlusProvider provider) {
+            super(provider, false, 24);
+        }
+    }
+
+    public static final class KWP_192 extends AESKeyWrapCipher {
+
+        public KWP_192(OpenJCEPlusProvider provider) {
+            super(provider, true, 24);
+        }
+    }
+        
+    public static final class KW_256 extends AESKeyWrapCipher {
+
+        public KW_256(OpenJCEPlusProvider provider) {
+            super(provider, false, 32);
+        }
+    }
+
+    public static final class KWP_256 extends AESKeyWrapCipher {
+
+        public KWP_256(OpenJCEPlusProvider provider) {
+            super(provider, true, 32);
+        }
+    }
+}

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
@@ -215,6 +215,50 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
         putService(new OpenJCEPlusService(jce, "Cipher", "AES",
                 "com.ibm.crypto.plus.provider.AESCipher", aliases));
 
+        aliases = new String[] {"AESWrap"};
+        putService(new OpenJCEPlusService(jce, "Cipher", "AES/KW/NoPadding",
+                "com.ibm.crypto.plus.provider.AESKeyWrapCipher$KW", aliases));
+        
+        aliases = new String[] {"AESWrapPad"};
+        putService(new OpenJCEPlusService(jce, "Cipher", "AES/KWP/NoPadding",
+                "com.ibm.crypto.plus.provider.AESKeyWrapCipher$KWP", aliases));
+
+        aliases = new String[] {"AESWrap_128",
+                                "2.16.840.1.101.3.4.1.5",
+                                "OID.2.16.840.1.101.3.4.1.5"};
+        putService(new OpenJCEPlusService(jce, "Cipher", "AES_128/KW/NoPadding",
+                "com.ibm.crypto.plus.provider.AESKeyWrapCipher$KW_128", aliases));
+
+        aliases = new String[] {"AESWrapPad_128",
+                                "2.16.840.1.101.3.4.1.8",
+                                "OID.2.16.840.1.101.3.4.1.8"};
+        putService(new OpenJCEPlusService(jce, "Cipher", "AES_128/KWP/NoPadding",
+                "com.ibm.crypto.plus.provider.AESKeyWrapCipher$KWP_128", aliases));
+                
+        aliases = new String[] {"AESWrap_192",
+                                "2.16.840.1.101.3.4.1.25",
+                                "OID.2.16.840.1.101.3.4.1.25"};
+        putService(new OpenJCEPlusService(jce, "Cipher", "AES_192/KW/NoPadding",
+                "com.ibm.crypto.plus.provider.AESKeyWrapCipher$KW_192", aliases));
+                
+        aliases = new String[] {"AESWrapPad_192",
+                                "2.16.840.1.101.3.4.1.28",
+                                "OID.2.16.840.1.101.3.4.1.28"};
+        putService(new OpenJCEPlusService(jce, "Cipher", "AES_192/KWP/NoPadding",
+                "com.ibm.crypto.plus.provider.AESKeyWrapCipher$KWP_192", aliases));
+
+        aliases = new String[] {"AESWrap_256",
+                                "2.16.840.1.101.3.4.1.45",
+                                "OID.2.16.840.1.101.3.4.1.45"};
+        putService(new OpenJCEPlusService(jce, "Cipher", "AES_256/KW/NoPadding",
+                "com.ibm.crypto.plus.provider.AESKeyWrapCipher$KW_256", aliases));
+
+        aliases = new String[] {"AESWrapPad_256",
+                                "2.16.840.1.101.3.4.1.48",
+                                "OID.2.16.840.1.101.3.4.1.48"};                
+        putService(new OpenJCEPlusService(jce, "Cipher", "AES_256/KWP/NoPadding",
+                "com.ibm.crypto.plus.provider.AESKeyWrapCipher$KWP_256", aliases));
+
         aliases = new String[] {"TripleDES", "3DES"};
         putService(new OpenJCEPlusService(jce, "Cipher", "DESede",
                 "com.ibm.crypto.plus.provider.DESedeCipher", aliases));

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -234,6 +234,50 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
         putService(new OpenJCEPlusService(jce, "Cipher", "RSA", "com.ibm.crypto.plus.provider.RSA",
                 aliases));
 
+        aliases = new String[] {"AESWrap"};
+        putService(new OpenJCEPlusService(jce, "Cipher", "AES/KW/NoPadding",
+                "com.ibm.crypto.plus.provider.AESKeyWrapCipher$KW", aliases));
+        
+        aliases = new String[] {"AESWrapPad"};
+        putService(new OpenJCEPlusService(jce, "Cipher", "AES/KWP/NoPadding",
+                "com.ibm.crypto.plus.provider.AESKeyWrapCipher$KWP", aliases));
+
+        aliases = new String[] {"AESWrap_128",
+                                "2.16.840.1.101.3.4.1.5",
+                                "OID.2.16.840.1.101.3.4.1.5"};
+        putService(new OpenJCEPlusService(jce, "Cipher", "AES_128/KW/NoPadding",
+                "com.ibm.crypto.plus.provider.AESKeyWrapCipher$KW_128", aliases));
+
+        aliases = new String[] {"AESWrapPad_128",
+                                "2.16.840.1.101.3.4.1.8",
+                                "OID.2.16.840.1.101.3.4.1.8"};
+        putService(new OpenJCEPlusService(jce, "Cipher", "AES_128/KWP/NoPadding",
+                "com.ibm.crypto.plus.provider.AESKeyWrapCipher$KWP_128", aliases));
+                
+        aliases = new String[] {"AESWrap_192",
+                                "2.16.840.1.101.3.4.1.25",
+                                "OID.2.16.840.1.101.3.4.1.25"};
+        putService(new OpenJCEPlusService(jce, "Cipher", "AES_192/KW/NoPadding",
+                "com.ibm.crypto.plus.provider.AESKeyWrapCipher$KW_192", aliases));
+                
+        aliases = new String[] {"AESWrapPad_192",
+                                "2.16.840.1.101.3.4.1.28",
+                                "OID.2.16.840.1.101.3.4.1.28"};
+        putService(new OpenJCEPlusService(jce, "Cipher", "AES_192/KWP/NoPadding",
+                "com.ibm.crypto.plus.provider.AESKeyWrapCipher$KWP_192", aliases));
+
+        aliases = new String[] {"AESWrap_256",
+                                "2.16.840.1.101.3.4.1.45",
+                                "OID.2.16.840.1.101.3.4.1.45"};
+        putService(new OpenJCEPlusService(jce, "Cipher", "AES_256/KW/NoPadding",
+                "com.ibm.crypto.plus.provider.AESKeyWrapCipher$KW_256", aliases));
+
+        aliases = new String[] {"AESWrapPad_256",
+                                "2.16.840.1.101.3.4.1.48",
+                                "OID.2.16.840.1.101.3.4.1.48"};                
+        putService(new OpenJCEPlusService(jce, "Cipher", "AES_256/KWP/NoPadding",
+                "com.ibm.crypto.plus.provider.AESKeyWrapCipher$KWP_256", aliases));
+
         /* =======================================================================
          * Key agreement
          * =======================================================================

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/AESKeyWrap.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/AESKeyWrap.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package com.ibm.crypto.plus.provider.ock;
+
+import java.util.Arrays;
+
+public final class AESKeyWrap {
+
+    private OCKContext ockContext;
+    private byte [] key = null;
+    private boolean padding = false;
+
+    public AESKeyWrap(OCKContext ockContext, byte [] key, boolean padding)
+            throws OCKException {
+        if (ockContext == null || key == null) {
+            throw new OCKException("Invalid input data");
+        }        
+        this.ockContext = ockContext;
+        this.key = key;
+        this.padding = padding;
+    }
+
+    public byte [] wrap(byte [] data, int start, int length) throws OCKException {
+        if (data == null || start < 0 || data.length < start || data.length < (length + start)) {
+            throw new OCKException("Invalid input data");
+        }
+        byte [] output = null;
+        byte [] inData = Arrays.copyOfRange(data, start, length);
+        
+        int type = 1; //wrap
+        if (padding) {
+            type = type|4; // add padding
+        }
+
+        try {
+            output = NativeInterface.CIPHER_KeyWraporUnwrap(this.ockContext.getId(), inData, this.key, type);
+        } catch (Exception e) {
+            throw new OCKException("Failed to wrap data" + e.getMessage());
+        }  finally {
+            //Clear inData
+            Arrays.fill(inData, (byte)0);  
+        }   
+        return output;    
+    }
+
+    public byte [] unwrap(byte [] data, int start, int length) throws OCKException {
+        if (data == null || start < 0 || length < start || data.length < (length - start)) {
+            throw new OCKException("Invalid input data");
+        }
+        byte [] output = null;
+        byte [] inData = Arrays.copyOfRange(data, start, length);
+        int type = 0;
+
+        if (padding) {
+            type = 4; // add padding
+        }
+
+        try {
+            output = NativeInterface.CIPHER_KeyWraporUnwrap(this.ockContext.getId(), inData, this.key, type);
+        } catch (Exception e) {
+            throw new OCKException("Failed to unwrap data"+ e.getMessage());
+        }  finally {
+            //Clear inData
+            Arrays.fill(inData, (byte)0);  
+        }       
+        return output;    
+    }
+
+
+}

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
@@ -375,6 +375,9 @@ final class NativeInterface {
 
     static public native void CIPHER_delete(long ockContextId, long ockCipherId)
             throws OCKException;
+            
+    static public native byte[] CIPHER_KeyWraporUnwrap(long ockContextId, byte[] key, byte [] KEK, int type)
+            throws OCKException;
 
     static public native int z_kmc_native(byte[] input, int inputOffset, byte[] output,
             int outputOffset, long paramPointer, int inputLength, int mode);

--- a/src/main/native/AESKeyWrap.c
+++ b/src/main/native/AESKeyWrap.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+#include <jni.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <jcc_a.h>
+#include <icc.h>
+
+#include "com_ibm_crypto_plus_provider_ock_NativeInterface.h"
+#include "Utils.h"
+#include <stdint.h>
+#include <string.h>
+
+//============================================================================
+/*
+ * Class:     com_ibm_crypto_plus_provider_ock_NativeInterface
+ * Method:    CIPHER_KeyWraporUnwrap
+ * Signature: (J[B[B[BI)V
+ */
+JNIEXPORT jbyteArray JNICALL
+Java_com_ibm_crypto_plus_provider_ock_NativeInterface_CIPHER_1KeyWraporUnwrap(
+    JNIEnv *env, jclass thisObj, jlong ockContextId, jbyteArray input,
+    jbyteArray KEK, jint type) {
+    ICC_CTX       *ockCtx    = (ICC_CTX *)((intptr_t)ockContextId);
+    int            outputlen = 0;
+    int            rv        = 0;
+    jboolean       isCopy;
+    jbyteArray     outBytes       = NULL;
+    jbyteArray     retOutBytes    = NULL;
+    unsigned char *inputNative    = NULL;
+    unsigned char *outputLocal    = NULL;
+    unsigned char *outBytesNative = NULL;
+    unsigned char *KEKNative      = NULL;
+    unsigned int   opType         = (unsigned int)type;
+    unsigned int   inputSize      = 0;
+
+    inputNative = (unsigned char *)((*env)->GetPrimitiveArrayCritical(
+        env, input, &isCopy));
+
+    if (NULL == inputNative) {
+        throwOCKException(env, 0, "Input is NULL from GetPrimitiveArrayCritical!");
+        return retOutBytes;
+    }
+
+    KEKNative =
+        (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, KEK, &isCopy));
+
+    if (NULL == KEKNative) {
+        (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative,
+                                              JNI_ABORT);
+        throwOCKException(env, 0, "KEK is NULL from GetPrimitiveArrayCritical!");
+        return retOutBytes;
+    }
+
+    inputSize = (*env)->GetArrayLength(env, input);
+
+    outputLocal = (unsigned char *)malloc(inputSize + 16);
+    if (outputLocal == NULL) {
+        throwOCKException(env, 0, "malloc failed");
+    } else {
+        const unsigned int keybits = ((*env)->GetArrayLength(env, KEK)) * 8;
+
+        rv = ICC_SP800_38F_KW(ockCtx, inputNative, inputSize, outputLocal,
+                              &outputlen, KEKNative, keybits, opType);
+        if (ICC_NOT_IMPLEMENTED == rv) {
+            throwOCKException(env, rv, "ICC_SP800_38F_KW not_supported");
+        } else if (1 != rv) {
+            throwOCKException(env, rv, "ICC_SP800_38F_KW:ICC_KW_WRAP failed");
+        } else {
+            outBytes = (*env)->NewByteArray(env, outputlen);
+            if (outBytes == NULL) {
+                throwOCKException(env, 0, "NewByteArray failed");
+            } else {
+                outBytesNative =
+                    (unsigned char *)((*env)->GetPrimitiveArrayCritical(
+                        env, outBytes, &isCopy));
+                if (outBytesNative == NULL) {
+                    throwOCKException(env, 0,
+                                      "Output is NULL from GetPrimitiveArrayCritical");
+                } else {
+                    memcpy(outBytesNative, outputLocal, outputlen);
+                    retOutBytes = outBytes;
+                }
+            }
+        }
+    }
+
+    if (outputLocal != NULL) {
+        free(outputLocal);
+        outputLocal = NULL;
+    }
+
+    if (outBytesNative != NULL) {
+        (*env)->ReleasePrimitiveArrayCritical(env, outBytes, outBytesNative, 0);
+    }
+
+    (*env)->ReleasePrimitiveArrayCritical(env, KEK, KEKNative, JNI_ABORT);
+    (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, JNI_ABORT);
+
+    return retOutBytes;
+}

--- a/src/main/native/jgskit.mac.mak
+++ b/src/main/native/jgskit.mac.mak
@@ -35,6 +35,7 @@ OPENJCEPLUS_HEADER_FILES ?= ${TOPDIR}/src/main/native
 JAVACLASSDIR=${BUILDTOP}/classes
 
 OBJS = \
+	${HOSTOUT}/AESKeyWrap.o \
 	${HOSTOUT}/BasicRandom.o \
 	${HOSTOUT}/BuildDate.o \
 	${HOSTOUT}/CCM.o \

--- a/src/main/native/jgskit.mak
+++ b/src/main/native/jgskit.mak
@@ -70,6 +70,7 @@ OPENJCEPLUS_HEADER_FILES ?= ${TOPDIR}/src/main/native
 JAVACLASSDIR=${BUILDTOP}/classes
 
 OBJS = \
+	${HOSTOUT}/AESKeyWrap.o \
 	${HOSTOUT}/BasicRandom.o \
 	${HOSTOUT}/BuildDate.o \
 	${HOSTOUT}/CCM.o \

--- a/src/main/native/jgskit.win64.cygwin.mak
+++ b/src/main/native/jgskit.win64.cygwin.mak
@@ -25,6 +25,7 @@ HOSTOUT = $(BUILDTOP)\host64
 JAVACLASSDIR = $(TOPDIR)\target\classes
 
 OBJS= \
+	AESKeyWrap.obj \
 	BasicRandom.obj \
 	BuildDate.obj \
 	CCM.obj \

--- a/src/main/native/jgskit.win64.mak
+++ b/src/main/native/jgskit.win64.mak
@@ -26,6 +26,7 @@ OPENJCEPLUS_HEADER_FILES ?= $(TOPDIR)/src/main/native
 JAVACLASSDIR = $(TOPDIR)/target/classes
 
 OBJS= \
+	$(HOSTOUT)/AESKeyWrap.obj \
 	$(HOSTOUT)/BasicRandom.obj \
 	$(HOSTOUT)/BuildDate.obj \
 	$(HOSTOUT)/CCM.obj \

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESKeyWrap.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESKeyWrap.java
@@ -1,0 +1,700 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+package ibm.jceplus.junit.base;
+
+import java.security.AlgorithmParameters;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.InvalidParameterException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.util.Arrays;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KeyGenerator;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class BaseTestAESKeyWrap extends BaseTestJunit5Interop {
+    protected SecretKey           key;
+    protected AlgorithmParameters params           = null;
+    protected Cipher              cpA              = null;
+    protected Cipher              cpB              = null;
+    protected boolean             success          = true;
+    protected int                 specifiedKeySize = 0;
+ 
+    @ParameterizedTest
+    @CsvSource({"AES/KW/NoPadding", "AES/KWP/NoPadding", "AES_128/KW/NoPadding",
+        "AES_128/KWP/NoPadding", "AES_192/KW/NoPadding",
+        "AES_192/KWP/NoPadding", "AES_256/KW/NoPadding",
+        "AES_256/KWP/NoPadding", "AESWrap", "AESWrapPad", "AESWrap_128",
+        "AESWrapPad_128", "AESWrap_192", "AESWrapPad_192", "AESWrap_256",
+        "AESWrapPad_256"})
+    public void testAESWrap128Keys(String alg) throws Exception {
+        SecretKey kek            = null;
+        SecretKey keyToBeWrapped = null;
+
+        kek            = createKey("AES", getKeySize(alg), getProviderName());
+        keyToBeWrapped = createKey("AES", 128, getProviderName());
+
+        WrapUnwrapKey(alg, keyToBeWrapped, kek, getProviderName());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"AES/KW/NoPadding", "AES/KWP/NoPadding", "AES_128/KW/NoPadding",
+        "AES_128/KWP/NoPadding", "AES_192/KW/NoPadding",
+        "AES_192/KWP/NoPadding", "AES_256/KW/NoPadding",
+        "AES_256/KWP/NoPadding"})
+    public void testAESWrapWith256WrappedKey(String alg) throws Exception {
+        SecretKey kek            = null;
+        SecretKey keyToBeWrapped = null;
+
+        kek            = createKey("AES", getKeySize(alg), getProviderName());
+        keyToBeWrapped = createKey("AES", 256, getProviderName());
+
+        WrapUnwrapKey(alg, keyToBeWrapped, kek, getProviderName());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"AES/KW/NoPadding", "AES/KWP/NoPadding", "AES_128/KW/NoPadding",
+        "AES_128/KWP/NoPadding", "AES_192/KW/NoPadding",
+        "AES_192/KWP/NoPadding", "AES_256/KW/NoPadding",
+        "AES_256/KWP/NoPadding"})
+    public void testAESWrapInterop(String alg) throws Exception {
+        SecretKey kek            = null;
+        SecretKey keyToBeWrapped = null;
+
+        kek            = createKey("AES", getKeySize(alg), getProviderName());
+        keyToBeWrapped = createKey("AES", 256, getInteropProviderName());
+
+        WrapUnwrapKeyInterop(alg, keyToBeWrapped, kek, getProviderName(),
+            getInteropProviderName());
+
+        kek = createKey("AES", getKeySize(alg), getInteropProviderName());
+        keyToBeWrapped = createKey("AES", 256, getProviderName());
+
+        WrapUnwrapKeyInteropRev(alg, keyToBeWrapped, kek, getProviderName(),
+            getInteropProviderName());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"AES_192/KW/NoPadding", "AES_192/KWP/NoPadding",
+        "AES_256/KW/NoPadding", "AES_256/KWP/NoPadding"})
+    public void testAESWrapFailureKeySize(String alg) throws Exception {
+        SecretKey kek            = null;
+        SecretKey keyToBeWrapped = null;
+
+        kek            = createKey("AES", 128, getProviderName());
+        keyToBeWrapped = createKey("AES", 256, getInteropProviderName());
+
+        try {
+            Cipher cp = null;
+
+            cp = Cipher.getInstance(alg, getProviderName());
+
+            // Encrypt the plain text
+            cp.init(Cipher.WRAP_MODE, kek);
+            cp.wrap(keyToBeWrapped);
+
+            fail("testAESWrapFailureKeySize did no fail as expected.");
+        } catch (InvalidKeyException ie) {
+            assumeTrue(true);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            assumeTrue(false);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"AES_192/KW/NoPadding", "AES_192/KWP/NoPadding",
+        "AES_256/KW/NoPadding", "AES_256/KWP/NoPadding"})
+    public void testAESWrapFailureCiphertext(String alg) throws Exception {
+        SecretKey kek            = null;
+        SecretKey keyToBeWrapped = null;
+
+        kek            = createKey("AES", getKeySize(alg), getProviderName());
+        keyToBeWrapped = createKey("AES", 256, getInteropProviderName());
+
+        try {
+            Cipher cp = null;
+            cp = Cipher.getInstance(alg, getProviderName());
+
+            // Encrypt the plain text
+            cp.init(Cipher.WRAP_MODE, kek);
+            byte[] cipherText = cp.wrap(keyToBeWrapped);
+
+            if (cipherText[2] == (byte)0xFF) {
+                cipherText[2] = (byte) 0x01;
+            } else {
+                cipherText[2] = (byte) 0xFF;
+            }
+
+            cp.init(Cipher.UNWRAP_MODE, kek);
+
+            cp.unwrap(cipherText, "AES", Cipher.SECRET_KEY);
+                
+            fail("testAESWrapFailureCiphertext did no fail as expected.");
+        } catch (InvalidKeyException ie) {
+            assumeTrue(true);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            assumeTrue(false);
+        }
+    }
+ 
+    @Test
+    public void testAESWrapModeFailureWrap() throws Exception {
+        SecretKey kek            = null;
+        SecretKey keyToBeWrapped = null;
+        String    alg            = "AES_192/KW/NoPadding";
+
+        kek            = createKey("AES", getKeySize(alg), getProviderName());
+        keyToBeWrapped = createKey("AES", 256, getInteropProviderName());
+
+        try {
+            Cipher cp = null;
+
+            cp = Cipher.getInstance(alg, getProviderName());
+
+            // Encrypt the plain text
+            cp.init(Cipher.UNWRAP_MODE, kek);
+            cp.wrap(keyToBeWrapped);
+            fail("testAESWrapModeFailureWrap did no fail as expected.");
+        } catch (IllegalStateException ie) {
+            assumeTrue(true);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            assumeTrue(false);
+        }
+    }
+
+    @Test
+    public void testAESWrapModeFailureUnwrap() throws Exception {
+        SecretKey kek            = null;
+        SecretKey keyToBeWrapped = null;
+        String    alg            = "AES_192/KW/NoPadding";
+
+        kek            = createKey("AES", getKeySize(alg), getProviderName());
+        keyToBeWrapped = createKey("AES", 256, getInteropProviderName());
+
+        try {
+            Cipher cp = null;
+
+            cp = Cipher.getInstance(alg, getProviderName());
+
+            // Encrypt the plain text
+            cp.init(Cipher.WRAP_MODE, kek);
+            byte[] cipherText = cp.wrap(keyToBeWrapped);
+            cp.unwrap(cipherText, "AES", Cipher.SECRET_KEY);
+
+            fail("testAESWrapModeFailureUnwrap did no fail as expected.");
+        } catch (IllegalStateException ie) {
+            assumeTrue(true);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            assumeTrue(false);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"AES_192/KW/NoPadding", "AES_192/KWP/NoPadding"})
+    public void testEncDec(String alg) {
+        SecretKey kek      = null;
+        byte[]    DATA_128 = Arrays.copyOf(
+            "1234567890123456789012345678901234".getBytes(), 128);
+        try {
+            kek = createKey("AES", getKeySize(alg), getProviderName());
+
+            Cipher c = null;
+
+            c = Cipher.getInstance(alg, getProviderName());
+            c.init(Cipher.ENCRYPT_MODE, kek);
+
+            byte[] out = c.doFinal(DATA_128, 0, DATA_128.length);
+
+            // encryption outout should always be multiple of 8 and at least
+            // 8-byte longer than input
+            if ((out.length % 8 != 0) || (out.length - DATA_128.length < 8)) {
+                throw new RuntimeException(
+                    "Invalid length of encrypted data: " + out.length);
+            }
+
+            c.init(Cipher.DECRYPT_MODE, kek);
+
+            byte[] in2 = c.doFinal(out);
+
+            assertArrayEquals(DATA_128, in2, "Data do not match!");
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            assumeTrue(false);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"AES_256/KW/NoPadding", "AES_256/KWP/NoPadding"})
+    public void testEncDecLargeData(String alg) {
+        SecretKey kek      = null;
+        byte[]    DATA_128 = Arrays.copyOf(
+            "1234567890123456789012345678901234".getBytes(), 128);
+        try {
+            kek = createKey("AES", getKeySize(alg), getProviderName());
+
+            Cipher c = null;
+
+            c = Cipher.getInstance(alg, getProviderName());
+            c.init(Cipher.ENCRYPT_MODE, kek);
+            byte[] test = new byte[DATA_128.length * 100];
+            int    i    = 0;
+            for (int x = 1; x < 100; x++) {
+                c.update(DATA_128);
+                System.arraycopy(DATA_128, 0, test, i, DATA_128.length);
+                i = i + DATA_128.length;
+            }
+
+            System.arraycopy(DATA_128, 0, test, i, DATA_128.length);
+
+            byte[] out = c.doFinal(DATA_128, 0, DATA_128.length);
+
+            // encryption outout should always be multiple of 8 and at least
+            // 8-byte longer than input
+            if ((out.length % 8 != 0) || (out.length - DATA_128.length < 8)) {
+                throw new RuntimeException(
+                    "Invalid length of encrypted data: " + out.length);
+            }
+
+            c.init(Cipher.DECRYPT_MODE, kek);
+
+            byte[] in2 = c.doFinal(out);
+
+            assertArrayEquals(test, in2, "Data do not match!");
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            assumeTrue(false);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"AES_256/KW/NoPadding", "AES_256/KWP/NoPadding"})
+    public void testEncDecOtherDoFInal(String alg) {
+        SecretKey kek      = null;
+        byte[]    DATA_128 = Arrays.copyOf(
+            "1234567890123456789012345678901234".getBytes(), 128);
+        try {
+            kek = createKey("AES", getKeySize(alg), getProviderName());
+
+            Cipher c = null;
+
+            c = Cipher.getInstance(alg, getProviderName());
+            c.init(Cipher.ENCRYPT_MODE, kek);
+            byte[] test = new byte[DATA_128.length * 2];
+            c.update(DATA_128);
+ 
+            System.arraycopy(DATA_128, 0, test, 0, DATA_128.length);
+            System.arraycopy(DATA_128, 0, test, DATA_128.length, DATA_128.length);
+
+            byte[] out = new byte[c.getOutputSize(test.length)];
+
+            int outlen = c.doFinal(DATA_128, 0, DATA_128.length, out, 0);
+
+            // encryption outout should always be multiple of 8 and at least
+            // 8-byte longer than input
+            if ((out.length % 8 != 0) || (out.length - DATA_128.length < 8)) {
+                throw new RuntimeException(
+                    "Invalid length of encrypted data: " + out.length);
+            }
+
+            c.init(Cipher.DECRYPT_MODE, kek);
+
+            byte[] in2 = c.doFinal(out, 0, outlen);
+
+            assertArrayEquals(test, in2, "Data do not match!");
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            assumeTrue(false);
+        }
+    }
+
+    @Test
+    public void testUninitializedCipherDoFinal() throws Exception {
+        String alg  = "AES_192/KW/NoPadding";
+        byte[] data = new byte[16]; // Some test data
+
+        try {
+            Cipher cp = Cipher.getInstance(alg, getProviderName());
+            // Intentionally not initializing the cipher
+            cp.doFinal(data);
+            fail("testUninitializedCipherDoFinal did not fail as expected.");
+        } catch (IllegalStateException ise) {
+            assumeTrue(true);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            assumeTrue(false);
+        }
+    }
+
+    @Test
+    public void testUninitializedCipherUpdate() throws Exception {
+        String alg  = "AES_192/KW/NoPadding";
+        byte[] data = new byte[16]; // Some test data
+
+        try {
+            Cipher cp = Cipher.getInstance(alg, getProviderName());
+            // Intentionally not initializing the cipher
+            cp.update(data);
+            fail("testUninitializedCipherUpdate did not fail as expected.");
+        } catch (IllegalStateException ise) {
+            assumeTrue(true);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            assumeTrue(false);
+        }
+    }
+    @Test
+    public void testInvalidMode() throws Exception {
+        try {
+            // Using an invalid mode "ABC" instead of "KW" or "KWP"
+            Cipher.getInstance("AES/ABC/NoPadding", getProviderName());
+            fail("testInvalidMode did not fail as expected.");
+        } catch (NoSuchAlgorithmException nsae) {
+            assumeTrue(true);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            assumeTrue(false);
+        }
+    }
+
+    @Test
+    public void testInvalidPadding() throws Exception {
+        try {
+            // Using an invalid padding "PKCS5Padding" instead of "NoPadding"
+            Cipher.getInstance("AES/KW/PKCS5Padding", getProviderName());
+            fail("testInvalidPadding did not fail as expected.");
+        } catch (NoSuchAlgorithmException nspe) {
+            assumeTrue(true);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            assumeTrue(false);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"AES_192/KW/NoPadding", "AES_192/KWP/NoPadding"})
+    public void testInvalidKeyAlgorithm(String alg) throws Exception {
+        try {
+            // Create a key with a different algorithm (e.g., DES)
+            SecretKey wrongKey = createKey("DESede", 168, getProviderName());
+
+            Cipher cp = Cipher.getInstance(alg, getProviderName());
+            cp.init(Cipher.WRAP_MODE, wrongKey);
+
+            fail("testInvalidKeyAlgorithm did not fail as expected.");
+        } catch (InvalidKeyException ike) {
+            assumeTrue(true);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            assumeTrue(false);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"AES_192/KW/NoPadding", "AES_192/KWP/NoPadding"})
+    public void testNullKey(String alg) throws Exception {
+        try {
+            Cipher cp = Cipher.getInstance(alg, getProviderName());
+            cp.init(Cipher.WRAP_MODE, (Key)null);
+
+            fail("testNullKey did not fail as expected.");
+        } catch (InvalidKeyException ike) {
+            assumeTrue(true);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            assumeTrue(false);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"AES_192/KW/NoPadding", "AES_192/KWP/NoPadding"})
+    public void testInvalidKeyEncoding(String alg) throws Exception {
+        try {
+            // Create a custom key that returns null for getEncoded()
+            SecretKey badKey = new SecretKey() {
+                @Override
+                public String getAlgorithm() {
+                    return "AES";
+                }
+
+                @Override
+                public String getFormat() {
+                    return "RAW";
+                }
+
+                @Override
+                public byte[] getEncoded() {
+                    return null; // Return null to trigger the exception
+                }
+            };
+
+            Cipher cp = Cipher.getInstance(alg, getProviderName());
+            cp.init(Cipher.WRAP_MODE, badKey);
+
+            fail("testInvalidKeyEncoding did not fail as expected.");
+        } catch (InvalidKeyException ike) {
+            assumeTrue(true);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            assumeTrue(false);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"AES_192/KW/NoPadding", "AES_192/KWP/NoPadding"})
+    public void testParametersNotAccepted(String alg) throws Exception {
+        try {
+            SecretKey key =
+                createKey("AES", getKeySize(alg), getProviderName());
+
+            // Create some parameter spec
+            javax.crypto.spec.IvParameterSpec ivSpec =
+                new javax.crypto.spec.IvParameterSpec(new byte[16]);
+
+            Cipher cp = Cipher.getInstance(alg, getProviderName());
+            cp.init(Cipher.WRAP_MODE, key, ivSpec);
+
+            fail("testParametersNotAccepted did not fail as expected.");
+        } catch (InvalidAlgorithmParameterException iape) {
+            assumeTrue(true);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            assumeTrue(false);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"AES_192/KW/NoPadding", "AES_192/KWP/NoPadding"})
+    public void testAlgorithmParametersNotAccepted(String alg)
+        throws Exception {
+        try {
+            SecretKey key =
+                createKey("AES", getKeySize(alg), getProviderName());
+
+            // Create some algorithm parameters
+            AlgorithmParameters params =
+                AlgorithmParameters.getInstance("AES", getProviderName());
+            params.init(new javax.crypto.spec.IvParameterSpec(new byte[16]));
+
+            Cipher cp = Cipher.getInstance(alg, getProviderName());
+            cp.init(Cipher.WRAP_MODE, key, params);
+
+            fail(
+                "testAlgorithmParametersNotAccepted did not fail as expected.");
+        } catch (InvalidAlgorithmParameterException iape) {
+            assumeTrue(true);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            assumeTrue(false);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"AES_192/KW/NoPadding", "AES_192/KWP/NoPadding"})
+    public void testIncorrectInputToAPI(String alg) throws Exception {
+        SecretKey key = createKey("AES", getKeySize(alg), getProviderName());
+
+        try {
+            Cipher cp = Cipher.getInstance(alg, getProviderName());
+            cp.init(Cipher.ENCRYPT_MODE, key);
+
+            // Create invalid input parameters
+            byte[] input         = new byte[16];
+            int    invalidOffset = 20; // Offset beyond array length
+
+            cp.doFinal(input, invalidOffset, 8);
+            fail("testIncorrectInputToAPI did not fail as expected.");
+        } catch (IllegalArgumentException ise) {
+            assumeTrue(true);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            assumeTrue(false);
+        }
+    }
+
+    public SecretKey createKey(String alg, int size, String providerName) throws NoSuchAlgorithmException, 
+        NoSuchProviderException {
+        KeyGenerator keyGen = null;
+        try {
+            keyGen = KeyGenerator.getInstance(alg, providerName);
+            keyGen.init(size);
+        } catch (NoSuchAlgorithmException nsae) {
+            throw nsae;
+        } catch (NoSuchProviderException nspe) {
+            throw nspe;
+        }
+        return keyGen.generateKey();
+    }
+
+    public void WrapUnwrapKey(String cipher, SecretKey keyWrapped,
+        SecretKey KEK, String providerName) throws NoSuchAlgorithmException, NoSuchProviderException, 
+        NoSuchPaddingException, InvalidKeyException, IllegalBlockSizeException  {
+        Cipher cp = null;
+        try {
+            cp = Cipher.getInstance(cipher, providerName);
+
+            // Encrypt the plain text
+            cp.init(Cipher.WRAP_MODE, KEK);
+            byte[] cipherText = cp.wrap(keyWrapped);
+
+            cp.init(Cipher.UNWRAP_MODE, KEK);
+
+            Key res = cp.unwrap(cipherText, "AES", Cipher.SECRET_KEY);
+
+            assertArrayEquals(res.getEncoded(), keyWrapped.getEncoded(),
+                "Keys do not match!");
+
+        } catch (Exception ex) {
+            System.out.println("Test exception: " + ex.getMessage());
+            ex.printStackTrace();
+            throw ex;
+        }
+    }
+
+    public void WrapUnwrapKeyInterop(String cipher, SecretKey keyWrapped,
+        SecretKey KEK, String providerName, String providerNameInterop) throws NoSuchAlgorithmException, 
+        NoSuchProviderException, NoSuchPaddingException, InvalidKeyException, IllegalBlockSizeException {
+        Cipher cp         = null;
+        Cipher cpI        = null;
+        Key    res        = null;
+        byte[] cipherText = null;
+
+        try {
+            cp  = Cipher.getInstance(cipher, providerName);
+            cpI = Cipher.getInstance(cipher, providerNameInterop);
+
+            // Encrypt the plain text
+            cp.init(Cipher.WRAP_MODE, KEK);
+            cipherText = cp.wrap(keyWrapped);
+
+            cpI.init(Cipher.UNWRAP_MODE, KEK);
+
+            res = cpI.unwrap(cipherText, "AES", Cipher.SECRET_KEY);
+
+            assertArrayEquals(res.getEncoded(), keyWrapped.getEncoded(),
+                "Keys do not match!");
+
+            cipherText = null;
+            res        = null;
+            // Encrypt the plain text
+            cpI.init(Cipher.WRAP_MODE, KEK);
+            cipherText = cpI.wrap(keyWrapped);
+
+            cp.init(Cipher.UNWRAP_MODE, KEK);
+
+            res = cp.unwrap(cipherText, "AES", Cipher.SECRET_KEY);
+
+            assertArrayEquals(res.getEncoded(), keyWrapped.getEncoded(),
+                "Keys does not match!");
+        } catch (Exception ex) {
+            System.out.println("Test exception: " + ex.getMessage());
+            throw ex;
+        }
+    }
+
+    public void WrapUnwrapKeyInteropRev(String cipher, SecretKey keyWrapped,
+        SecretKey KEK, String providerName, String providerNameInterop) throws NoSuchAlgorithmException, 
+        NoSuchProviderException, NoSuchPaddingException, InvalidKeyException, IllegalBlockSizeException {
+        Cipher cp         = null;
+        Cipher cpI        = null;
+        Key    res        = null;
+        byte[] cipherText = null;
+
+        try {
+            cp  = Cipher.getInstance(cipher, providerNameInterop);
+            cpI = Cipher.getInstance(cipher, providerName);
+
+            // Encrypt the plain text
+            cp.init(Cipher.WRAP_MODE, KEK);
+            cipherText = cp.wrap(keyWrapped);
+
+            cpI.init(Cipher.UNWRAP_MODE, KEK);
+
+            res = cpI.unwrap(cipherText, "AES", Cipher.SECRET_KEY);
+
+            assertArrayEquals(res.getEncoded(), keyWrapped.getEncoded(),
+                "Keys does not match!");
+
+            cipherText = null;
+            res        = null;
+            // Encrypt the plain text
+            cpI.init(Cipher.WRAP_MODE, KEK);
+            cipherText = cpI.wrap(keyWrapped);
+
+            cp.init(Cipher.UNWRAP_MODE, KEK);
+
+            res = cp.unwrap(cipherText, "AES", Cipher.SECRET_KEY);
+
+            assertArrayEquals(res.getEncoded(), keyWrapped.getEncoded(),
+                "Keys does not match!");
+        } catch (Exception ex) {
+            System.out.println("Test exception: " + ex.getMessage());
+            throw ex;
+        }
+    }
+
+    public int getKeySize(String alg) {
+        int size = 128;
+        switch (alg) {
+            case "AES/KW/NoPadding":
+            case "AES/KWP/NoPadding":
+            case "AES_128/KW/NoPadding":
+            case "AES_128/KWP/NoPadding":
+            case "AESWrap":
+            case "AESWrapPad":
+            case "AESWrap_128":
+            case "AESWrapPad_128":
+                break;
+            case "AES_192/KW/NoPadding":
+            case "AES_192/KWP/NoPadding":
+            case "AESWrap_192":
+            case "AESWrapPad_192":
+                size = 192;
+                break;
+            case "AES_256/KW/NoPadding":
+            case "AES_256/KWP/NoPadding":
+            case "AESWrap_256":
+            case "AESWrapPad_256":
+                size = 256;
+                break;
+            default:
+                throw new InvalidParameterException("Invalid key algorithm specified");
+        }
+        return size;
+    }
+}

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAESKeyWrap.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAESKeyWrap.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+package ibm.jceplus.junit.openjceplus;
+
+import ibm.jceplus.junit.base.BaseTestAESKeyWrap;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestAESKeyWrap extends BaseTestAESKeyWrap {
+
+    @BeforeAll
+    public void beforeAll() {
+        Utils.loadProviderTestSuite();
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
+        setInteropProviderName(Utils.PROVIDER_SunJCE);
+    }
+}

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAll.java
@@ -38,6 +38,7 @@ import org.junit.platform.suite.api.Suite;
     TestAESGCMUpdate.class,
     TestAESGCMUpdateInteropBC.class,
     TestAESGCMWithByteBuffer.class,
+    TestAESKeyWrap.class,
     TestAliases.class,
     TestAttributes.class,
     TestByteArrayOutputDelay.class,

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESKeyWrap.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAESKeyWrap.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+package ibm.jceplus.junit.openjceplusfips;
+
+import ibm.jceplus.junit.base.BaseTestAESKeyWrap;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestAESKeyWrap extends BaseTestAESKeyWrap {
+
+    @BeforeAll
+    public void beforeAll() {
+        Utils.loadProviderTestSuite();
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
+        setInteropProviderName(Utils.PROVIDER_SunJCE);
+    }
+}

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAll.java
@@ -35,6 +35,7 @@ import org.junit.platform.suite.api.Suite;
     TestAESGCMSameBuffer.class,
     TestAESGCMUpdate.class,
     TestAESGCMWithByteBuffer.class,
+    TestAESKeyWrap.class,
     TestAliases.class,
     TestAttributes.class,
     TestDeterministic.class,


### PR DESCRIPTION
Needed to add AES Key Wrap based on SP800-38F. The support is for KW and KWP.

Signed-off-by: John Peck [140550562+johnpeck-us-ibm@users.noreply.github.com](mailto:140550562+johnpeck-us-ibm@users.noreply.github.com)