### PR TITLE
Assign parent Jenkins node to be none

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -646,7 +646,7 @@ pipeline {
             Overall build timeout (HOURS)')
     }
 
-    agent any
+    agent none
     stages {
         stage('Build And Test OpenJCEPlus') {
             steps {


### PR DESCRIPTION
Fixes #763

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/767

Signed-off-by: Jason Katonica <katonica@us.ibm.com>