### PR TITLE
Enable PQC algorithms on Mac OS x86 platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,8 +422,6 @@ OpenJCEPlus provider enhances the security of Java applications by providing an 
 
 No keytool or certificate support was added other than what is already in a given Java runtime environment.
 
-The `ML-KEM` algorithm is supported in all OpenJCEPlus environments listed in section [How to Build `OpenJCEPlus` and Java Native Interface Library](#how-to-build-openjceplus-and-java-native-interface-library) except for MacOS on x86.
-
 ### ML-DSA
 
 Quantum-Resistant Module-Lattice-Based Digital Signature Algorithm (`ML-DSA`)
@@ -431,8 +429,6 @@ Quantum-Resistant Module-Lattice-Based Digital Signature Algorithm (`ML-DSA`)
 OpenJCEPlus provider enhances the security of Java applications by providing an implementation of quantum-resistant Module-Lattice-Based Digital Signature Algorithm (`ML-DSA`). Digital signatures are used to detect unauthorized modifications to data and to authenticate the identities of signatories. `ML-DSA` is designed to be secure against future quantum computing attacks and has been standardized by the United States National Institute of Standards and Technology (NIST) in [FIPS 204](https://csrc.nist.gov/pubs/fips/204/final).
 
 No keytool or certificate support was added other than what is already in a given Java runtime environment.
-
-The `ML-DSA` algorithm is supported in all OpenJCEPlus environments listed in section [How to Build `OpenJCEPlus` and Java Native Interface Library](#how-to-build-openjceplus-and-java-native-interface-library) except for MacOS on x86.
 
 ### ECKeyPairGenerator incorrect keysize
 

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
@@ -110,8 +110,6 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
     private void registerAlgorithms(Provider jce) {
 
         String[] aliases = null;
-        String osName = System.getProperty("os.name");
-        String osArch = System.getProperty("os.arch");
         /* =======================================================================
          * Algorithm Parameter engines
          * =======================================================================
@@ -336,39 +334,39 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
         putService(new OpenJCEPlusService(jce, "KeyFactory", "RSAPSS",
                 "com.ibm.crypto.plus.provider.RSAKeyFactory$PSS", aliases));
 
-        //PQC is not working on Mac x86 so not registering these.        
-        if (!(osName.equals("Mac OS X") && osArch.equals("x86_64"))) {
-            // PQC Algorithms
-            aliases = new String[] {"ML_KEM_512", "MLKEM512", "2.16.840.1.101.3.4.4.1"};
+        /* =======================================================================
+         * PQC key factories
+         * =======================================================================
+         */
+        aliases = new String[] {"ML_KEM_512", "MLKEM512", "2.16.840.1.101.3.4.4.1"};
 
-            putService(new OpenJCEPlusService(jce, "KeyFactory", "ML-KEM-512",
-                      "com.ibm.crypto.plus.provider.PQCKeyFactory$MLKEM512", aliases));
-        
-            aliases = new String[] {"ML_KEM_768", "MLKEM768", "2.16.840.1.101.3.4.4.2"};
+        putService(new OpenJCEPlusService(jce, "KeyFactory", "ML-KEM-512",
+                  "com.ibm.crypto.plus.provider.PQCKeyFactory$MLKEM512", aliases));
 
-            putService(new OpenJCEPlusService(jce, "KeyFactory", "ML-KEM-768",
-                   "com.ibm.crypto.plus.provider.PQCKeyFactory$MLKEM768", aliases));
+        aliases = new String[] {"ML_KEM_768", "MLKEM768", "2.16.840.1.101.3.4.4.2"};
+
+        putService(new OpenJCEPlusService(jce, "KeyFactory", "ML-KEM-768",
+               "com.ibm.crypto.plus.provider.PQCKeyFactory$MLKEM768", aliases));
                 
-            aliases = new String[] {"ML_KEM_1024", "MLKEM1024", "2.16.840.1.101.3.4.4.3"};
+        aliases = new String[] {"ML_KEM_1024", "MLKEM1024", "2.16.840.1.101.3.4.4.3"};
 
-            putService(new OpenJCEPlusService(jce, "KeyFactory", "ML-KEM-1024",
-                   "com.ibm.crypto.plus.provider.PQCKeyFactory$MLKEM1024", aliases));
+        putService(new OpenJCEPlusService(jce, "KeyFactory", "ML-KEM-1024",
+               "com.ibm.crypto.plus.provider.PQCKeyFactory$MLKEM1024", aliases));
                         
-            aliases = new String[] {"ML_DSA_44", "MLDSA44", "2.16.840.1.101.3.4.3.17"};
+        aliases = new String[] {"ML_DSA_44", "MLDSA44", "2.16.840.1.101.3.4.3.17"};
 
-            putService(new OpenJCEPlusService(jce, "KeyFactory", "ML-DSA-44",
-                   "com.ibm.crypto.plus.provider.PQCKeyFactory$MLDSA44", aliases));
+        putService(new OpenJCEPlusService(jce, "KeyFactory", "ML-DSA-44",
+               "com.ibm.crypto.plus.provider.PQCKeyFactory$MLDSA44", aliases));
                                
-            aliases = new String[] {"ML_DSA_65", "MLDSA65", "2.16.840.1.101.3.4.3.18"};
+        aliases = new String[] {"ML_DSA_65", "MLDSA65", "2.16.840.1.101.3.4.3.18"};
 
-            putService(new OpenJCEPlusService(jce, "KeyFactory", "ML-DSA-65",
-                   "com.ibm.crypto.plus.provider.PQCKeyFactory$MLDSA65", aliases));
+        putService(new OpenJCEPlusService(jce, "KeyFactory", "ML-DSA-65",
+               "com.ibm.crypto.plus.provider.PQCKeyFactory$MLDSA65", aliases));
                                 
-            aliases = new String[] {"ML_DSA_87", "MLDSA87", "2.16.840.1.101.3.4.3.19"};
+        aliases = new String[] {"ML_DSA_87", "MLDSA87", "2.16.840.1.101.3.4.3.19"};
 
-            putService(new OpenJCEPlusService(jce, "KeyFactory", "ML-DSA-87",
-                   "com.ibm.crypto.plus.provider.PQCKeyFactory$MLDSA87", aliases));
-        }                
+        putService(new OpenJCEPlusService(jce, "KeyFactory", "ML-DSA-87",
+               "com.ibm.crypto.plus.provider.PQCKeyFactory$MLDSA87", aliases));
         
         /* =======================================================================
          * Key Generator engines
@@ -522,40 +520,39 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
         putService(new OpenJCEPlusService(jce, "KeyPairGenerator", "RSAPSS",
                 "com.ibm.crypto.plus.provider.RSAKeyPairGenerator$PSS", aliases));
 
-                
-        //PQC is not working on Mac x86 so not registering these.        
-        if (!(osName.equals("Mac OS X") && osArch.equals("x86_64"))) {
-            // PQC Algorithms
-            aliases = new String[] {"ML_KEM_512", "MLKEM512", "2.16.840.1.101.3.4.4.1"};
+        /* =======================================================================
+         * PQC key pair generators
+         * =======================================================================
+         */
+        aliases = new String[] {"ML_KEM_512", "MLKEM512", "2.16.840.1.101.3.4.4.1"};
 
-            putService(new OpenJCEPlusService(jce, "KeyPairGenerator", "ML-KEM-512",
-                      "com.ibm.crypto.plus.provider.PQCKeyPairGenerator$MLKEM512", aliases));
-        
-            aliases = new String[] {"ML_KEM_768", "MLKEM768", "2.16.840.1.101.3.4.4.2"};
+        putService(new OpenJCEPlusService(jce, "KeyPairGenerator", "ML-KEM-512",
+                  "com.ibm.crypto.plus.provider.PQCKeyPairGenerator$MLKEM512", aliases));
 
-            putService(new OpenJCEPlusService(jce, "KeyPairGenerator", "ML-KEM-768",
-                   "com.ibm.crypto.plus.provider.PQCKeyPairGenerator$MLKEM768", aliases));
-                
-            aliases = new String[] {"ML_KEM_1024", "MLKEM1024", "2.16.840.1.101.3.4.4.3"};
+        aliases = new String[] {"ML_KEM_768", "MLKEM768", "2.16.840.1.101.3.4.4.2"};
 
-            putService(new OpenJCEPlusService(jce, "KeyPairGenerator", "ML-KEM-1024",
-                   "com.ibm.crypto.plus.provider.PQCKeyPairGenerator$MLKEM1024", aliases));
-                        
-            aliases = new String[] {"ML_DSA_44", "MLDSA44", "2.16.840.1.101.3.4.3.17"};
+        putService(new OpenJCEPlusService(jce, "KeyPairGenerator", "ML-KEM-768",
+               "com.ibm.crypto.plus.provider.PQCKeyPairGenerator$MLKEM768", aliases));
 
-            putService(new OpenJCEPlusService(jce, "KeyPairGenerator", "ML-DSA-44",
-                   "com.ibm.crypto.plus.provider.PQCKeyPairGenerator$MLDSA44", aliases));
-                                
-            aliases = new String[] {"ML_DSA_65", "MLDSA65", "2.16.840.1.101.3.4.3.18"};
+        aliases = new String[] {"ML_KEM_1024", "MLKEM1024", "2.16.840.1.101.3.4.4.3"};
 
-            putService(new OpenJCEPlusService(jce, "KeyPairGenerator", "ML-DSA-65",
-                   "com.ibm.crypto.plus.provider.PQCKeyPairGenerator$MLDSA65", aliases));
-                                
-            aliases = new String[] {"ML_DSA_87", "MLDSA87", "2.16.840.1.101.3.4.3.19"};
+        putService(new OpenJCEPlusService(jce, "KeyPairGenerator", "ML-KEM-1024",
+               "com.ibm.crypto.plus.provider.PQCKeyPairGenerator$MLKEM1024", aliases));
 
-            putService(new OpenJCEPlusService(jce, "KeyPairGenerator", "ML-DSA-87",
-                   "com.ibm.crypto.plus.provider.PQCKeyPairGenerator$MLDSA87", aliases)); 
-        }         
+        aliases = new String[] {"ML_DSA_44", "MLDSA44", "2.16.840.1.101.3.4.3.17"};
+
+        putService(new OpenJCEPlusService(jce, "KeyPairGenerator", "ML-DSA-44",
+               "com.ibm.crypto.plus.provider.PQCKeyPairGenerator$MLDSA44", aliases));
+
+        aliases = new String[] {"ML_DSA_65", "MLDSA65", "2.16.840.1.101.3.4.3.18"};
+
+        putService(new OpenJCEPlusService(jce, "KeyPairGenerator", "ML-DSA-65",
+               "com.ibm.crypto.plus.provider.PQCKeyPairGenerator$MLDSA65", aliases));
+
+        aliases = new String[] {"ML_DSA_87", "MLDSA87", "2.16.840.1.101.3.4.3.19"};
+
+        putService(new OpenJCEPlusService(jce, "KeyPairGenerator", "ML-DSA-87",
+               "com.ibm.crypto.plus.provider.PQCKeyPairGenerator$MLDSA87", aliases)); 
 
         /* =======================================================================
          * Message authentication engines
@@ -710,27 +707,24 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
         putService(new OpenJCEPlusService(jce, "MessageDigest", "SHA3-512",
                 "com.ibm.crypto.plus.provider.MessageDigest$SHA3_512", aliases));
 
-        //PQC is not working on Mac x86 so not registering these.        
-        if (!(osName.equals("Mac OS X") && osArch.equals("x86_64"))) {
-            /* =======================================================================
-             * Key Encapsulation Mechanisms
-             * =======================================================================
-             */
-            aliases = new String[] {"ML_KEM_512", "ML-KEM", "MLKEM512", "2.16.840.1.101.3.4.4.1"};
+        /* =======================================================================
+         * PQC key encapsulation mechanisms
+         * =======================================================================
+         */
+        aliases = new String[] {"ML_KEM_512", "ML-KEM", "MLKEM512", "2.16.840.1.101.3.4.4.1"};
 
-            putService(new OpenJCEPlusService(jce, "KEM", "ML-KEM-512",
-                   "com.ibm.crypto.plus.provider.MLKEMImpl$MLKEM512", aliases));
-        
-            aliases = new String[] {"ML_KEM_768", "MLKEM768", "2.16.840.1.101.3.4.4.2"};
+        putService(new OpenJCEPlusService(jce, "KEM", "ML-KEM-512",
+               "com.ibm.crypto.plus.provider.MLKEMImpl$MLKEM512", aliases));
 
-            putService(new OpenJCEPlusService(jce, "KEM", "ML-KEM-768",
-                   "com.ibm.crypto.plus.provider.MLKEMImpl$MLKEM768", aliases));
-                
-            aliases = new String[] {"ML_KEM_1024", "MLKEM1024", "2.16.840.1.101.3.4.4.3"};
+        aliases = new String[] {"ML_KEM_768", "MLKEM768", "2.16.840.1.101.3.4.4.2"};
 
-            putService(new OpenJCEPlusService(jce, "KEM", "ML-KEM-1024",
-                   "com.ibm.crypto.plus.provider.MLKEMImpl$MLKEM1024", aliases));
-        }        
+        putService(new OpenJCEPlusService(jce, "KEM", "ML-KEM-768",
+               "com.ibm.crypto.plus.provider.MLKEMImpl$MLKEM768", aliases));
+
+        aliases = new String[] {"ML_KEM_1024", "MLKEM1024", "2.16.840.1.101.3.4.4.3"};
+
+        putService(new OpenJCEPlusService(jce, "KEM", "ML-KEM-1024",
+               "com.ibm.crypto.plus.provider.MLKEMImpl$MLKEM1024", aliases));
 
         /* =======================================================================
          * Secret key factories
@@ -964,26 +958,25 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
         aliases = new String[] {"OID.1.3.101.113", "1.3.101.113"};
         putService(new OpenJCEPlusService(jce, "Signature", "Ed448",
                 "com.ibm.crypto.plus.provider.EdDSASignature$Ed448", aliases));
-        
-                
-        //PQC is not working on Mac x86 so not registering these.        
-        if (!(osName.equals("Mac OS X") && osArch.equals("x86_64"))) {
-            // PQC Algorithms        
-            aliases = new String[] {"ML_DSA_44", "MLDSA44", "2.16.840.1.101.3.4.3.17"};
 
-            putService(new OpenJCEPlusService(jce, "Signature", "ML-DSA-44",
-                   "com.ibm.crypto.plus.provider.PQCSignatureImpl$MLDSA44", aliases));
-                                
-            aliases = new String[] {"ML_DSA_65", "MLDSA65", "2.16.840.1.101.3.4.3.18"};
+        /* =======================================================================
+         * PQC signatures
+         * =======================================================================
+         */
+        aliases = new String[] {"ML_DSA_44", "MLDSA44", "2.16.840.1.101.3.4.3.17"};
 
-            putService(new OpenJCEPlusService(jce, "Signature", "ML-DSA-65",
-                   "com.ibm.crypto.plus.provider.PQCSignatureImpl$MLDSA65", aliases));
-                                
-            aliases = new String[] {"ML_DSA_87", "MLDSA87", "2.16.840.1.101.3.4.3.19"};
+        putService(new OpenJCEPlusService(jce, "Signature", "ML-DSA-44",
+               "com.ibm.crypto.plus.provider.PQCSignatureImpl$MLDSA44", aliases));
 
-            putService(new OpenJCEPlusService(jce, "Signature", "ML-DSA-87",
-                   "com.ibm.crypto.plus.provider.PQCSignatureImpl$MLDSA87", aliases));
-        }                  
+        aliases = new String[] {"ML_DSA_65", "MLDSA65", "2.16.840.1.101.3.4.3.18"};
+
+        putService(new OpenJCEPlusService(jce, "Signature", "ML-DSA-65",
+               "com.ibm.crypto.plus.provider.PQCSignatureImpl$MLDSA65", aliases));
+
+        aliases = new String[] {"ML_DSA_87", "MLDSA87", "2.16.840.1.101.3.4.3.19"};
+
+        putService(new OpenJCEPlusService(jce, "Signature", "ML-DSA-87",
+               "com.ibm.crypto.plus.provider.PQCSignatureImpl$MLDSA87", aliases));
     }
 
     private static class OpenJCEPlusService extends Service {

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKEM.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKEM.java
@@ -12,13 +12,10 @@ import ibm.jceplus.junit.base.BaseTestKEM;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
-import org.junit.jupiter.api.condition.OS;
 
 @TestInstance(Lifecycle.PER_CLASS)
-@DisabledOnOs(value = OS.MAC, architectures = "x86_64")
 @EnabledForJreRange(min = JRE.JAVA_17)
 public class TestPQCKEM extends BaseTestKEM {
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKEMMultiThread.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKEMMultiThread.java
@@ -12,13 +12,10 @@ import ibm.jceplus.junit.base.BaseTestPQCKEMMultiThread ;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
-import org.junit.jupiter.api.condition.OS;
 
 @TestInstance(Lifecycle.PER_CLASS)
-@DisabledOnOs(value = OS.MAC, architectures = "x86_64")
 @EnabledForJreRange(min = JRE.JAVA_17)
 public class TestPQCKEMMultiThread extends BaseTestPQCKEMMultiThread  {
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKeyInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKeyInteropBC.java
@@ -12,13 +12,10 @@ import ibm.jceplus.junit.base.BaseTestPQCKeyInterop;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
-import org.junit.jupiter.api.condition.OS;
 
 @TestInstance(Lifecycle.PER_CLASS)
-@DisabledOnOs(value = OS.MAC, architectures = "x86_64")
 @EnabledForJreRange(min = JRE.JAVA_17)
 public class TestPQCKeyInteropBC extends BaseTestPQCKeyInterop {
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKeyInteropOracle.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKeyInteropOracle.java
@@ -12,13 +12,10 @@ import ibm.jceplus.junit.base.BaseTestPQCKeyInterop;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
-import org.junit.jupiter.api.condition.OS;
 
 @TestInstance(Lifecycle.PER_CLASS)
-@DisabledOnOs(value = OS.MAC, architectures = "x86_64")
 @EnabledForJreRange(min = JRE.JAVA_24)
 public class TestPQCKeyInteropOracle extends BaseTestPQCKeyInterop {
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKeys.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKeys.java
@@ -12,13 +12,10 @@ import ibm.jceplus.junit.base.BaseTestPQCKeys;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
-import org.junit.jupiter.api.condition.OS;
 
 @TestInstance(Lifecycle.PER_CLASS)
-@DisabledOnOs(value = OS.MAC, architectures = "x86_64")
 @EnabledForJreRange(min = JRE.JAVA_17)
 public class TestPQCKeys extends BaseTestPQCKeys {
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKeystore.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKeystore.java
@@ -12,13 +12,10 @@ import ibm.jceplus.junit.base.BaseTestPQCKeystore;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
-import org.junit.jupiter.api.condition.OS;
 
 @TestInstance(Lifecycle.PER_CLASS)
-@DisabledOnOs(value = OS.MAC, architectures = "x86_64")
 @EnabledForJreRange(min = JRE.JAVA_17)
 public class TestPQCKeystore extends BaseTestPQCKeystore {
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCSignatureWithAliases.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCSignatureWithAliases.java
@@ -12,13 +12,10 @@ import ibm.jceplus.junit.base.BaseTestPQCSignatureWithAliases;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
-import org.junit.jupiter.api.condition.OS;
 
 @TestInstance(Lifecycle.PER_CLASS)
-@DisabledOnOs(value = OS.MAC, architectures = "x86_64")
 @EnabledForJreRange(min = JRE.JAVA_17)
 public class TestPQCSignatureWithAliases extends BaseTestPQCSignatureWithAliases {
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCSignatures.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCSignatures.java
@@ -12,13 +12,10 @@ import ibm.jceplus.junit.base.BaseTestPQCSignature;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
-import org.junit.jupiter.api.condition.OS;
 
 @TestInstance(Lifecycle.PER_CLASS)
-@DisabledOnOs(value = OS.MAC, architectures = "x86_64")
 @EnabledForJreRange(min = JRE.JAVA_17)
 public class TestPQCSignatures extends BaseTestPQCSignature {
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestPQCKEM.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestPQCKEM.java
@@ -13,13 +13,10 @@ import ibm.jceplus.junit.openjceplus.Utils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
-import org.junit.jupiter.api.condition.OS;
 
 @TestInstance(Lifecycle.PER_CLASS)
-@DisabledOnOs(value = OS.MAC, architectures = "x86_64")
 @EnabledForJreRange(min = JRE.JAVA_17)
 public class TestPQCKEM extends BaseTestKEM {
 

--- a/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestPQCSignatures.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/multithread/TestPQCSignatures.java
@@ -13,13 +13,10 @@ import ibm.jceplus.junit.openjceplus.Utils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
-import org.junit.jupiter.api.condition.OS;
 
 @TestInstance(Lifecycle.PER_CLASS)
-@DisabledOnOs(value = OS.MAC, architectures = "x86_64")
 @EnabledForJreRange(min = JRE.JAVA_17)
 public class TestPQCSignatures extends BaseTestPQCSignature {
 


### PR DESCRIPTION
With the update to OCKC `8.9.14` the PQC algorithms are now available on Mac OS x86. This update simply enables the various algorithms and tests which were previously disabled.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>
