### PR TITLE
Check NoWhitespaceAfter and NoWhitespaceBefore

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -11,26 +11,28 @@
 -->
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
-    <module name="TreeWalker">
-        <property name="fileExtensions" value="java"/>
-        <module name="UnusedImports"/>
-        <module name="AvoidStarImport"/>
-        <module name="RedundantImport"/>
-        <module name="StringLiteralEquality"/>
-        <module name="GenericWhitespace"/>
-        <module name="Indentation">
-            <property name="caseIndent" value="4"/>
-            <property name="arrayInitIndent" value="8"/>
-        </module>
-        <module name="UnusedLocalVariable"/>
-        <module name="EmptyBlock"/>
-        <module name="ImportOrder"/>
-        <module name="StringLiteralEquality"/>
-    </module>
+    <module name="FileTabCharacter"/>
     <module name="NewlineAtEndOfFile"/>
     <module name="RegexpHeader">
         <property name="fileExtensions" value="java"/>
         <property name="header" value="^\W.*\n^.*Copyright IBM Corp\. \d\d\d\d\n^\W.*\n^\W.*. This code is free software; you can redistribute it and/or modify it\n^\W.*. under the terms provided by IBM in the LICENSE file that accompanied\n^\W.*. this code, including the &quot;Classpath&quot; Exception described therein."/>
     </module>
-    <module name="FileTabCharacter"/>
+    <module name="TreeWalker">
+        <property name="fileExtensions" value="java"/>
+        <module name="AvoidStarImport"/>
+        <module name="EmptyBlock"/>
+        <module name="GenericWhitespace"/>
+        <module name="ImportOrder"/>
+        <module name="Indentation">
+            <property name="arrayInitIndent" value="8"/>
+            <property name="caseIndent" value="4"/>
+        </module>
+        <module name="NoWhitespaceAfter"/>
+        <module name="NoWhitespaceBefore"/>
+        <module name="RedundantImport"/>
+        <module name="StringLiteralEquality"/>
+        <module name="StringLiteralEquality"/>
+        <module name="UnusedImports"/>
+        <module name="UnusedLocalVariable"/>
+    </module>
 </module>

--- a/src/main/java/com/ibm/crypto/plus/provider/AESKeyWrapCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKeyWrapCipher.java
@@ -40,11 +40,11 @@ abstract class AESKeyWrapCipher extends CipherSpi {
     private int bufSize = 0;
     private int opmode = 0;
     private boolean setPadding = false;
-    static final byte[] ICV1 = { 
+    static final byte[] ICV1 = {
         (byte) 0xA6, (byte) 0xA6, (byte) 0xA6, (byte) 0xA6,
         (byte) 0xA6, (byte) 0xA6, (byte) 0xA6, (byte) 0xA6
     };
-    static final byte[] ICV2 = { 
+    static final byte[] ICV2 = {
         (byte) 0xA6, (byte) 0x59, (byte) 0x59, (byte) 0xA6
     };
 
@@ -159,7 +159,7 @@ abstract class AESKeyWrapCipher extends CipherSpi {
 
     @Override
     protected byte[] engineGetIV() {
-        byte [] iv = ICV2;
+        byte[] iv = ICV2;
         if (!setPadding) {
             iv = ICV1;
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAKeyPairGenerator.java
@@ -118,8 +118,6 @@ abstract class EdDSAKeyPairGenerator extends KeyPairGeneratorSpi {
         }
     }
 
-    ;
-
     public static final class Ed448 extends EdDSAKeyPairGenerator {
         public Ed448(OpenJCEPlusProvider provider) {
             super(provider, "Ed448");
@@ -131,6 +129,4 @@ abstract class EdDSAKeyPairGenerator extends KeyPairGeneratorSpi {
             super(provider);
         }
     }
-
-    ;
 }

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCKeyFactory.java
@@ -179,14 +179,14 @@ class PQCKeyFactory extends KeyFactorySpi {
         String keyAlg = key.getAlgorithm();
         if (keyAlg == null) {
             throw new InvalidKeyException("Algorithm associate with key is null.");
-        } else if (! (key.getAlgorithm().equalsIgnoreCase(this.algName) || 
+        } else if (!(key.getAlgorithm().equalsIgnoreCase(this.algName) || 
             (PQCKnownOIDs.findMatch(key.getAlgorithm()).stdName().equalsIgnoreCase(this.algName)))) {
             throw new InvalidKeyException("Expected a " + this.algName + " key, but got " + keyAlg);
         }
 
     }
 
-    private boolean checkEncoded(byte [] key, boolean pub) {
+    private boolean checkEncoded(byte[] key, boolean pub) {
         try {
             //Check and see if this is an encoded OctetString
             if ( (!pub && key[0] == 0x04) || (pub && key[0] == 0x03)) {

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCKeyPairGenerator.java
@@ -54,10 +54,10 @@ abstract class PQCKeyPairGenerator extends KeyPairGeneratorSpi {
         try {
             //System.out.println("Generating KeyPair for " + mlkemAlg);
             PQCKey mlkemKey = PQCKey.generateKeyPair(provider.getOCKContext(), mlkemAlg);
-            byte [] privKeyBytes = mlkemKey.getPrivateKeyBytes();
+            byte[] privKeyBytes = mlkemKey.getPrivateKeyBytes();
             PQCPrivateKey privKey = new PQCPrivateKey(provider, PQCKey.createPrivateKey(provider.getOCKContext(), 
                                                                mlkemAlg, privKeyBytes));
-            byte [] pubKeyBytes = mlkemKey.getPublicKeyBytes();
+            byte[] pubKeyBytes = mlkemKey.getPublicKeyBytes();
             PQCPublicKey pubKey = new PQCPublicKey(provider, PQCKey.createPublicKey(provider.getOCKContext(), 
                                                                mlkemAlg, pubKeyBytes));        
             return new KeyPair(pubKey, privKey);

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCPrivateKey.java
@@ -45,7 +45,7 @@ final class PQCPrivateKey extends PKCS8Key {
         this.algid = new AlgorithmId(PQCAlgorithmId.getOID(algName));
         this.name = algName;
         this.provider = provider;
-        byte [] key = null;
+        byte[] key = null;
         DerValue pkOct = null;
         
         //Check to determine if the key bytes already have the Octet tag.
@@ -155,7 +155,7 @@ final class PQCPrivateKey extends PKCS8Key {
         *        ...
         *      }
         */
-        byte [] encodedKey = null;
+        byte[] encodedKey = null;
         try {
             int V1 = 0;
             DerOutputStream tmp = new DerOutputStream();
@@ -211,7 +211,7 @@ final class PQCPrivateKey extends PKCS8Key {
         }
     }
 
-    private boolean OctectStringEncoded(byte [] key) {
+    private boolean OctectStringEncoded(byte[] key) {
         try {
             //Check and see if this is an encoded OctetString
             if (key[0] == 0x04) {

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCPublicKey.java
@@ -46,7 +46,7 @@ final class PQCPublicKey extends X509Key
             // OCKC needs the key with a BitArray encoding to process it as raw.
             DerOutputStream tmp = new DerOutputStream();
             tmp.putUnalignedBitString(getKey());
-            byte [] b = tmp.toByteArray();
+            byte[] b = tmp.toByteArray();
             tmp.close();
 
             this.pqcKey = PQCKey.createPublicKey(provider.getOCKContext(), algName, b);
@@ -83,7 +83,7 @@ final class PQCPublicKey extends X509Key
             name = this.algid.toString();
             DerOutputStream tmp = new DerOutputStream();
             tmp.putUnalignedBitString(getKey());
-            byte [] b = tmp.toByteArray();
+            byte[] b = tmp.toByteArray();
             tmp.close();
             
             this.pqcKey = PQCKey.createPublicKey(provider.getOCKContext(), name, b);
@@ -114,7 +114,7 @@ final class PQCPublicKey extends X509Key
     @Override
     public byte[] getEncoded() {
         checkDestroyed();
-        byte [] encodedKey = null;
+        byte[] encodedKey = null;
         try {
 
             DerOutputStream out = new DerOutputStream();

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCSignatureImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCSignatureImpl.java
@@ -137,7 +137,7 @@ abstract class PQCSignatureImpl extends SignatureSpi {
         try {
             byte[] dataBytes = message.toByteArray();
             message.reset();
-            byte [] sign = this.signature.sign(dataBytes);
+            byte[] sign = this.signature.sign(dataBytes);
             return sign;
         } catch (Exception e) {
             SignatureException signatureException = new SignatureException("Could not sign data");

--- a/src/main/java/com/ibm/crypto/plus/provider/PSSParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PSSParameters.java
@@ -715,7 +715,7 @@ public final class PSSParameters extends AlgorithmParametersSpi {
                                                             this.maskGenAlgorithm.getName(),
                                                             this.mgfParameterSpec,
                                                             this.saltLength,
-                                                            this.trailerField)) ;
+                                                            this.trailerField));
         } else {
             throw new InvalidParameterSpecException("Inappropriate parameter Specification");
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
@@ -270,21 +270,15 @@ abstract class XDHKeyAgreement extends KeyAgreementSpi {
         }
     }
 
-    ;
-
     public static final class X448 extends XDHKeyAgreement {
         public X448(OpenJCEPlusProvider provider) {
             super(provider, "X448");
         }
     }
 
-    ;
-
     public static final class XDH extends XDHKeyAgreement {
         public XDH(OpenJCEPlusProvider provider) {
             super(provider);
         }
     }
-
-    ;
 }

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/AESKeyWrap.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/AESKeyWrap.java
@@ -13,10 +13,10 @@ import java.util.Arrays;
 public final class AESKeyWrap {
 
     private OCKContext ockContext;
-    private byte [] key = null;
+    private byte[] key = null;
     private boolean padding = false;
 
-    public AESKeyWrap(OCKContext ockContext, byte [] key, boolean padding)
+    public AESKeyWrap(OCKContext ockContext, byte[] key, boolean padding)
             throws OCKException {
         if (ockContext == null || key == null) {
             throw new OCKException("Invalid input data");
@@ -26,12 +26,12 @@ public final class AESKeyWrap {
         this.padding = padding;
     }
 
-    public byte [] wrap(byte [] data, int start, int length) throws OCKException {
+    public byte[] wrap(byte[] data, int start, int length) throws OCKException {
         if (data == null || start < 0 || data.length < start || data.length < (length + start)) {
             throw new OCKException("Invalid input data");
         }
-        byte [] output = null;
-        byte [] inData = Arrays.copyOfRange(data, start, length);
+        byte[] output = null;
+        byte[] inData = Arrays.copyOfRange(data, start, length);
         
         int type = 1; //wrap
         if (padding) {
@@ -49,12 +49,12 @@ public final class AESKeyWrap {
         return output;    
     }
 
-    public byte [] unwrap(byte [] data, int start, int length) throws OCKException {
+    public byte[] unwrap(byte[] data, int start, int length) throws OCKException {
         if (data == null || start < 0 || length < start || data.length < (length - start)) {
             throw new OCKException("Invalid input data");
         }
-        byte [] output = null;
-        byte [] inData = Arrays.copyOfRange(data, start, length);
+        byte[] output = null;
+        byte[] inData = Arrays.copyOfRange(data, start, length);
         int type = 0;
 
         if (padding) {

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
@@ -367,7 +367,7 @@ final class NativeInterface {
     static public native void CIPHER_delete(long ockContextId, long ockCipherId)
             throws OCKException;
             
-    static public native byte[] CIPHER_KeyWraporUnwrap(long ockContextId, byte[] key, byte [] KEK, int type)
+    static public native byte[] CIPHER_KeyWraporUnwrap(long ockContextId, byte[] key, byte[] KEK, int type)
             throws OCKException;
 
     static public native int z_kmc_native(byte[] input, int inputOffset, byte[] output,

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/PQCSignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/PQCSignature.java
@@ -52,7 +52,7 @@ public final class PQCSignature {
         //OCKDebug.Msg (debPrefix, methodName,  "this.key=" + key);
     }
 
-    public synchronized byte[] sign(byte [] data) throws OCKException {
+    public synchronized byte[] sign(byte[] data) throws OCKException {
 
         if (!this.initialized) {
             throw new IllegalStateException("Signature not initialized");

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESInterop.java
@@ -291,7 +291,7 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
         byte[] fullBlock = "0123456789ABCDEF".getBytes();
         byte[] incompleteBlock = "0123456789ABCDEF012".getBytes();
         byte[] multipleFullBlocks = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF".getBytes();
-        String[] algorithms = { /* "AES/CFB8/PKCS5Padding"*, */ "AES/CFB8/NoPadding",
+        String[] algorithms = {/* "AES/CFB8/PKCS5Padding"*, */ "AES/CFB8/NoPadding",
                 "AES/CBC/PKCS5Padding", "AES/CBC/NoPadding"};
 
         for (int i = 0; i < algorithms.length; i++) {
@@ -360,7 +360,7 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
         byte[] fullBlock = "0123456789ABCDEF".getBytes();
         byte[] incompleteBlock = "0123456789ABCDEF012".getBytes();
         byte[] multipleFullBlocks = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF".getBytes();
-        String[] algorithms = { /* "AES/CFB8/PKCS5Padding", */ "AES/CFB8/NoPadding",
+        String[] algorithms = {/* "AES/CFB8/PKCS5Padding", */ "AES/CFB8/NoPadding",
                 "AES/CBC/PKCS5Padding", "AES/CBC/NoPadding"};
         for (int i = 0; i < algorithms.length; i++) {
             doTestAESWithUpdateForEncryptionButOnlyFinalForDecryption(algorithms[i], fullBlock,
@@ -432,7 +432,7 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
         byte[] fullBlock = "0123456789ABCDEF".getBytes();
         byte[] incompleteBlock = "0123456789ABCDEF012".getBytes();
         byte[] multipleFullBlocks = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF".getBytes();
-        String[] algorithms = { /* "AES/CFB8/PKCS5Padding", */ "AES/CFB8/NoPadding",
+        String[] algorithms = {/* "AES/CFB8/PKCS5Padding", */ "AES/CFB8/NoPadding",
                 "AES/CBC/PKCS5Padding", "AES/CBC/NoPadding"};
         for (int i = 0; i < algorithms.length; i++) {
             doTestAESWithUpdateEncryptionAndDecryption(algorithms[i], fullBlock, "OpenJCEPlus",

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeys.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeys.java
@@ -144,8 +144,8 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
             default:
                 return;
         }
-        byte [] privKey = HexFormat.of().parseHex(privBytes);
-        byte [] pubKey = HexFormat.of().parseHex(pubBytes);
+        byte[] privKey = HexFormat.of().parseHex(privBytes);
+        byte[] pubKey = HexFormat.of().parseHex(pubBytes);
 
         pqcKeyFactory = KeyFactory.getInstance(Algorithm, getProviderName());
         
@@ -156,16 +156,16 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
         PrivateKey privateKey = pqcKeyFactory.generatePrivate(privSpec);
 
         //Need to extract just the key material from the key to do the compare
-        byte [] newPubKey = parsePub(publicKey.getEncoded());
-        byte [] newPrivKey = parsePriv(privateKey.getEncoded());
+        byte[] newPubKey = parsePub(publicKey.getEncoded());
+        byte[] newPrivKey = parsePriv(privateKey.getEncoded());
 
         assertArrayEquals(newPubKey, pubKey, "Public key does not match generated public key - "+Algorithm);
         assertArrayEquals(newPrivKey, privKey, "Private key does not match generated public key - "+Algorithm);
 
     }
 
-    byte [] parsePub(byte[] key) throws InvalidKeyException{
-        byte [] keyMaterial = null;
+    byte[] parsePub(byte[] key) throws InvalidKeyException{
+        byte[] keyMaterial = null;
 
         try {
             DerValue val = new DerValue(key);
@@ -184,8 +184,8 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
         return keyMaterial;
     }
 
-    byte [] parsePriv(byte[] key) throws InvalidKeyException {
-        byte [] keyMaterial = null;
+    byte[] parsePriv(byte[] key) throws InvalidKeyException {
+        byte[] keyMaterial = null;
         try {
             DerValue val = new DerValue(key);
             if (val.tag != DerValue.tag_Sequence) {
@@ -199,7 +199,7 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
             AlgorithmId algid = AlgorithmId.parse (val.data.getDerValue ());
             algid.encode();
 
-            byte [] tmp = val.data.getOctetString();
+            byte[] tmp = val.data.getOctetString();
 
             DerValue next;
             if (val.data.available() == 0) {

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKEMMultiThread.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestPQCKEMMultiThread.java
@@ -8,7 +8,7 @@
 
 package ibm.jceplus.junit.openjceplus;
 
-import ibm.jceplus.junit.base.BaseTestPQCKEMMultiThread ;
+import ibm.jceplus.junit.base.BaseTestPQCKEMMultiThread;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;


### PR DESCRIPTION
This update adds new rules for token whitespace before and after a given token. This will provide more consistency in the source.

Checkstyle rules were also put into alphabetical order.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/787

Signed-off-by: Jason Katonica <katonica@us.ibm.com>