### PR TITLE
Check NoWhitespaceAfter and NoWhitespaceBefore

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -11,26 +11,28 @@
 -->
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
-    <module name="TreeWalker">
-        <property name="fileExtensions" value="java"/>
-        <module name="UnusedImports"/>
-        <module name="AvoidStarImport"/>
-        <module name="RedundantImport"/>
-        <module name="StringLiteralEquality"/>
-        <module name="GenericWhitespace"/>
-        <module name="Indentation">
-            <property name="caseIndent" value="4"/>
-            <property name="arrayInitIndent" value="8"/>
-        </module>
-        <module name="UnusedLocalVariable"/>
-        <module name="EmptyBlock"/>
-        <module name="ImportOrder"/>
-        <module name="StringLiteralEquality"/>
-    </module>
+    <module name="FileTabCharacter"/>
     <module name="NewlineAtEndOfFile"/>
     <module name="RegexpHeader">
         <property name="fileExtensions" value="java"/>
         <property name="header" value="^\W.*\n^.*Copyright IBM Corp\. \d\d\d\d\n^\W.*\n^\W.*. This code is free software; you can redistribute it and/or modify it\n^\W.*. under the terms provided by IBM in the LICENSE file that accompanied\n^\W.*. this code, including the &quot;Classpath&quot; Exception described therein."/>
     </module>
-    <module name="FileTabCharacter"/>
+    <module name="TreeWalker">
+        <property name="fileExtensions" value="java"/>
+        <module name="AvoidStarImport"/>
+        <module name="EmptyBlock"/>
+        <module name="GenericWhitespace"/>
+        <module name="ImportOrder"/>
+        <module name="Indentation">
+            <property name="arrayInitIndent" value="8"/>
+            <property name="caseIndent" value="4"/>
+        </module>
+        <module name="NoWhitespaceAfter"/>
+        <module name="NoWhitespaceBefore"/>
+        <module name="RedundantImport"/>
+        <module name="StringLiteralEquality"/>
+        <module name="StringLiteralEquality"/>
+        <module name="UnusedImports"/>
+        <module name="UnusedLocalVariable"/>
+    </module>
 </module>

--- a/src/main/java/com/ibm/crypto/plus/provider/AESKeyWrapCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKeyWrapCipher.java
@@ -40,11 +40,11 @@ abstract class AESKeyWrapCipher extends CipherSpi {
     private int bufSize = 0;
     private int opmode = 0;
     private boolean setPadding = false;
-    static final byte[] ICV1 = { 
+    static final byte[] ICV1 = {
         (byte) 0xA6, (byte) 0xA6, (byte) 0xA6, (byte) 0xA6,
         (byte) 0xA6, (byte) 0xA6, (byte) 0xA6, (byte) 0xA6
     };
-    static final byte[] ICV2 = { 
+    static final byte[] ICV2 = {
         (byte) 0xA6, (byte) 0x59, (byte) 0x59, (byte) 0xA6
     };
 
@@ -159,7 +159,7 @@ abstract class AESKeyWrapCipher extends CipherSpi {
 
     @Override
     protected byte[] engineGetIV() {
-        byte [] iv = ICV2;
+        byte[] iv = ICV2;
         if (!setPadding) {
             iv = ICV1;
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/PSSParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PSSParameters.java
@@ -715,7 +715,7 @@ public final class PSSParameters extends AlgorithmParametersSpi {
                                                             this.maskGenAlgorithm.getName(),
                                                             this.mgfParameterSpec,
                                                             this.saltLength,
-                                                            this.trailerField)) ;
+                                                            this.trailerField));
         } else {
             throw new InvalidParameterSpecException("Inappropriate parameter Specification");
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
@@ -268,21 +268,15 @@ abstract class XDHKeyAgreement extends KeyAgreementSpi {
         }
     }
 
-    ;
-
     public static final class X448 extends XDHKeyAgreement {
         public X448(OpenJCEPlusProvider provider) {
             super(provider, "X448");
         }
     }
 
-    ;
-
     public static final class XDH extends XDHKeyAgreement {
         public XDH(OpenJCEPlusProvider provider) {
             super(provider);
         }
     }
-
-    ;
 }

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/AESKeyWrap.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/AESKeyWrap.java
@@ -13,10 +13,10 @@ import java.util.Arrays;
 public final class AESKeyWrap {
 
     private OCKContext ockContext;
-    private byte [] key = null;
+    private byte[] key = null;
     private boolean padding = false;
 
-    public AESKeyWrap(OCKContext ockContext, byte [] key, boolean padding)
+    public AESKeyWrap(OCKContext ockContext, byte[] key, boolean padding)
             throws OCKException {
         if (ockContext == null || key == null) {
             throw new OCKException("Invalid input data");
@@ -26,12 +26,12 @@ public final class AESKeyWrap {
         this.padding = padding;
     }
 
-    public byte [] wrap(byte [] data, int start, int length) throws OCKException {
+    public byte[] wrap(byte[] data, int start, int length) throws OCKException {
         if (data == null || start < 0 || data.length < start || data.length < (length + start)) {
             throw new OCKException("Invalid input data");
         }
-        byte [] output = null;
-        byte [] inData = Arrays.copyOfRange(data, start, length);
+        byte[] output = null;
+        byte[] inData = Arrays.copyOfRange(data, start, length);
         
         int type = 1; //wrap
         if (padding) {
@@ -49,12 +49,12 @@ public final class AESKeyWrap {
         return output;    
     }
 
-    public byte [] unwrap(byte [] data, int start, int length) throws OCKException {
+    public byte[] unwrap(byte[] data, int start, int length) throws OCKException {
         if (data == null || start < 0 || length < start || data.length < (length - start)) {
             throw new OCKException("Invalid input data");
         }
-        byte [] output = null;
-        byte [] inData = Arrays.copyOfRange(data, start, length);
+        byte[] output = null;
+        byte[] inData = Arrays.copyOfRange(data, start, length);
         int type = 0;
 
         if (padding) {

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
@@ -376,7 +376,7 @@ final class NativeInterface {
     static public native void CIPHER_delete(long ockContextId, long ockCipherId)
             throws OCKException;
             
-    static public native byte[] CIPHER_KeyWraporUnwrap(long ockContextId, byte[] key, byte [] KEK, int type)
+    static public native byte[] CIPHER_KeyWraporUnwrap(long ockContextId, byte[] key, byte[] KEK, int type)
             throws OCKException;
 
     static public native int z_kmc_native(byte[] input, int inputOffset, byte[] output,

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESInterop.java
@@ -291,7 +291,7 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
         byte[] fullBlock = "0123456789ABCDEF".getBytes();
         byte[] incompleteBlock = "0123456789ABCDEF012".getBytes();
         byte[] multipleFullBlocks = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF".getBytes();
-        String[] algorithms = { /* "AES/CFB8/PKCS5Padding"*, */ "AES/CFB8/NoPadding",
+        String[] algorithms = {/* "AES/CFB8/PKCS5Padding"*, */ "AES/CFB8/NoPadding",
                 "AES/CBC/PKCS5Padding", "AES/CBC/NoPadding"};
 
         for (int i = 0; i < algorithms.length; i++) {
@@ -360,7 +360,7 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
         byte[] fullBlock = "0123456789ABCDEF".getBytes();
         byte[] incompleteBlock = "0123456789ABCDEF012".getBytes();
         byte[] multipleFullBlocks = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF".getBytes();
-        String[] algorithms = { /* "AES/CFB8/PKCS5Padding", */ "AES/CFB8/NoPadding",
+        String[] algorithms = {/* "AES/CFB8/PKCS5Padding", */ "AES/CFB8/NoPadding",
                 "AES/CBC/PKCS5Padding", "AES/CBC/NoPadding"};
         for (int i = 0; i < algorithms.length; i++) {
             doTestAESWithUpdateForEncryptionButOnlyFinalForDecryption(algorithms[i], fullBlock,
@@ -432,7 +432,7 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
         byte[] fullBlock = "0123456789ABCDEF".getBytes();
         byte[] incompleteBlock = "0123456789ABCDEF012".getBytes();
         byte[] multipleFullBlocks = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF".getBytes();
-        String[] algorithms = { /* "AES/CFB8/PKCS5Padding", */ "AES/CFB8/NoPadding",
+        String[] algorithms = {/* "AES/CFB8/PKCS5Padding", */ "AES/CFB8/NoPadding",
                 "AES/CBC/PKCS5Padding", "AES/CBC/NoPadding"};
         for (int i = 0; i < algorithms.length; i++) {
             doTestAESWithUpdateEncryptionAndDecryption(algorithms[i], fullBlock, "OpenJCEPlus",


### PR DESCRIPTION
This update adds new rules for token whitespace before and after a given token. This will provide more consistency in the source.

Checkstyle rules were also put into alphabetical order.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/787

Signed-off-by: Jason Katonica <katonica@us.ibm.com>

