### PR TITLE
Make use of API to fetch Java 25

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Temurin JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '25-ea'
+          java-version: '25.0.0+36.0.LTS'
           distribution: 'temurin'
           architecture: 'x64'
       # Uncomment to capture all files in the runner for debugging purposes.          

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,44 +181,41 @@ def getBinaries(hardware, software) {
  */
 def getJava(hardware, software) {
     def extension = "tar.gz"
+    if (software == "windows") {
+        extension = "zip"
+    }
 
     if (hardware == "x86-64") {
         hardware = "x64"
     }
 
     def java_link = ""
-
     if (JAVA_RELEASE == "") {
-            if (software == "windows") {
-                java_link = "https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/openjceplusworkaround060225/OpenJ9-JDKnext-x86-64_windows-20250531-000422.tar.gz"
-            } else if ((software == "linux") && (hardware == "aarch64")) {
-                java_link = "https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/openjceplusworkaround060225/OpenJ9-JDKnext-aarch64_linux-20250531-035208.tar.gz"
-            } else if ((software == "linux") && (hardware == "ppc64le")) {
-                java_link = "https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/openjceplusworkaround060225/OpenJ9-JDKnext-ppc64le_linux-20250531-032314.tar.gz"
-            } else if ((software == "linux") && (hardware == "x64")) {
-                java_link = "https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/openjceplusworkaround060225/OpenJ9-JDKnext-x86-64_linux-20250531-032515.tar.gz"
-            } else if ((software == "linux") && (hardware == "s390x")) {
-                java_link = "https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/openjceplusworkaround060225/OpenJ9-JDKnext-s390x_linux-20250531-031249.tar.gz"
-            } else if ((software == "mac") && (hardware == "aarch64")) {
-                java_link = "https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/openjceplusworkaround060225/OpenJ9-JDKnext-aarch64_mac-20250531-132316.tar.gz"
-            } else if ((software == "mac") && (hardware == "x64")) {
-                java_link = "https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/openjceplusworkaround060225/OpenJ9-JDKnext-x86-64_mac-20250531-005554.tar.gz"
-            } else if (software == "aix") {
-                java_link = "https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/openjceplusworkaround060225/OpenJ9-JDKnext-ppc64_aix-20250531-041857.tar.gz"
-            } else {
-                echo "No Java SDK downloaded!!!"
-            }
-        }
-
+        java_link = "https://api.adoptopenjdk.net/v3/binary/latest/${JAVA_VERSION}/ga/${software}/${hardware}/jdk/openj9/normal/ibm?project=jdk"
+    } else {
+        def java_release_link = JAVA_RELEASE.replace("+", "%2B")
+        java_link = "https://api.adoptopenjdk.net/v3/binary/version/${java_release_link}/${software}/${hardware}/jdk/openj9/normal/ibm?project=jdk"
+    }
+    
     dir("java") {
-        sh "curl -u $GSKIT_USERNAME:$GSKIT_PASSWORD ${java_link} > java.tar.gz"
+        sh "curl -LJkO ${java_link}"
         def java_file = sh (
             script: 'ls | grep \'tar\\|zip\'',
             returnStdout: true
         ).trim()
 
-        untar file: "$java_file"
+        if (software == "windows") {
+            unzip zipFile: "$java_file"
+        } else {
+            untar file: "$java_file"
+        }
         sh "rm $java_file"
+
+        def java_folder = sh (
+            script: "ls | grep \'jdk-${JAVA_VERSION}\'",
+            returnStdout: true
+        ).trim()
+        fileOperations([folderRenameOperation(destination: 'jdk', source: "$java_folder")])
 
         // AIX always loads the bundled version of native libraries. We delete them to
         // ensure that the one provided by the user is utilized.
@@ -321,7 +318,7 @@ def runOpenJCEPlus(command, software) {
                $WORKSPACE\\apache-maven-3.9.10\\bin\\mvn -Dock.library.path=${ock_path} --batch-mode ${command}
                """
         } else if (software == "mac") {
-            java_home = "export JAVA_HOME=$WORKSPACE/java/jdk;"
+            java_home = "export JAVA_HOME=$WORKSPACE/java/jdk/Contents/Home;"
         }
 
         if (software != "windows") {
@@ -469,7 +466,7 @@ def run(platform) {
 
             // Some OSes have some further specific requirements.
             if (software == "aix") {
-                // Issue with updating the tooling. C++17.1
+                // Java 25 requires C++17.1 runtime. Otherwise crashes occur.
                 nodeTags += "&&sw.tool.c++runtime.17_1"
             }
 
@@ -490,9 +487,7 @@ def run(platform) {
 
             node("$nodeTags") {
                 try {
-                    withCredentials([usernamePassword(credentialsId: '7c1c2c28-650f-49e0-afd1-ca6b60479546', passwordVariable: 'GSKIT_PASSWORD', usernameVariable: 'GSKIT_USERNAME')]) {
-                        getJava(hardware, software)
-                    }
+                    getJava(hardware, software)
                     echo "Java fetched"
                     getBinaries(hardware, software)
                     echo "Binaries fetched"


### PR DESCRIPTION
Releases of Java 25 are now available and this update will make use
of the latest Java 25 ga build.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>