### PR TITLE
Fix KEM to follow the SPI and the Java Docs

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/MLKEMImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/MLKEMImpl.java
@@ -26,7 +26,7 @@ import javax.crypto.spec.SecretKeySpec;
 public class MLKEMImpl implements KEMSpi {
     OpenJCEPlusProvider provider;
     String alg;
-
+    static int SECRETSIZE  = 32;
     public MLKEMImpl(OpenJCEPlusProvider provider, String alg) {
         this.provider = provider;
         this.alg = alg;
@@ -72,7 +72,7 @@ public class MLKEMImpl implements KEMSpi {
     class MLKEMEncapsulator implements KEMSpi.EncapsulatorSpi {
 
         PublicKey publicKey;
-        int size = 0;
+        int size = SECRETSIZE;
 
         /*
          * spec - The AlgorithmParameterSpec is not used and should be null. 
@@ -88,9 +88,9 @@ public class MLKEMImpl implements KEMSpi {
         public KEM.Encapsulated engineEncapsulate(int from, int to, String algorithm) {
             int encapLen = getEncapsulationLength();
             byte[] encapsulation = new byte[encapLen];
-            byte[] secret = new byte[32]; //This is always 32 bytes
+            byte[] secret = new byte[SECRETSIZE];
 
-            if (from < 0 || to > 31 || ((to - from) < 0) ) {
+            if (from < 0 || to > SECRETSIZE || ((to - from) < 0) || (from >= SECRETSIZE)){
                 throw new IndexOutOfBoundsException();
             }
             if (algorithm == null) {
@@ -142,7 +142,7 @@ public class MLKEMImpl implements KEMSpi {
      */
     class MLKEMDecapsulator implements KEMSpi.DecapsulatorSpi {
         PrivateKey privateKey;
-        int size = 0;
+        int size = SECRETSIZE;
 
         MLKEMDecapsulator(PrivateKey privateKey, AlgorithmParameterSpec spec) {
             this.privateKey = privateKey;
@@ -153,7 +153,7 @@ public class MLKEMImpl implements KEMSpi {
                 throws DecapsulateException {
             byte[] secret;
 
-            if (from < 0 || to > 31 || ((to - from) < 0) ) {
+            if (from < 0 || to > SECRETSIZE || ((to - from) < 0) || (from >= SECRETSIZE)){
                 throw new IndexOutOfBoundsException();
             }
             if (algorithm == null || cipherText == null) {


### PR DESCRIPTION
Fix KEM to follow the SPI and the Java Docs

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/798

Signed-off-by: John Peck <[140550562+johnpeck-us-ibm@users.noreply.github.com](mailto:140550562+johnpeck-us-ibm@users.noreply.github.com)>
