### PR TITLE
Always store human readable alg name in PQC keys

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/PQCPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCPrivateKey.java
@@ -43,7 +43,7 @@ final class PQCPrivateKey extends PKCS8Key {
             throws InvalidKeyException {
    
         this.algid = new AlgorithmId(PQCAlgorithmId.getOID(algName));
-        this.name = algName;
+        this.name = PQCKnownOIDs.findMatch(this.algid.getName()).stdName();
         this.provider = provider;
         byte[] key = null;
         DerValue pkOct = null;
@@ -97,7 +97,7 @@ final class PQCPrivateKey extends PKCS8Key {
                 }
             }
 
-            this.name = pqcKey.getAlgorithm();
+            this.name = PQCKnownOIDs.findMatch(pqcKey.getAlgorithm()).stdName();
             this.algid = new AlgorithmId(PQCAlgorithmId.getOID(name));
         } catch (Exception exception) {
             throw provider.providerException("Failure in PQCPrivateKey" + exception.getMessage(), exception);

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCPublicKey.java
@@ -39,7 +39,7 @@ final class PQCPublicKey extends X509Key
             throws InvalidKeyException {
         this.algid = new AlgorithmId(PQCAlgorithmId.getOID(algName));
         this.provider = provider;
-        this.name = algName;
+        this.name = PQCKnownOIDs.findMatch(this.algid.getName()).stdName();
 
         setKey(new BitArray(rawKey.length * 8, rawKey));
         try {
@@ -61,9 +61,9 @@ final class PQCPublicKey extends X509Key
         try {
             this.provider = provider;
             byte[] rawKey = pqcKey.getPublicKeyBytes();
-            this.name = pqcKey.getAlgorithm();
+            this.algid = new AlgorithmId(PQCAlgorithmId.getOID(pqcKey.getAlgorithm()));
 
-            this.algid = new AlgorithmId(PQCAlgorithmId.getOID(name));
+            this.name = PQCKnownOIDs.findMatch(this.algid.getName()).stdName();
 
             //OCKC puts the BITSTRING on the key. Need to remove it.
             setKey(new BitArray((rawKey.length - 5)*8, rawKey, 5));
@@ -80,7 +80,7 @@ final class PQCPublicKey extends X509Key
         try {
             decode(encoded);
 
-            name = this.algid.toString();
+            this.name = PQCKnownOIDs.findMatch(this.algid.getName()).stdName();
             DerOutputStream tmp = new DerOutputStream();
             tmp.putUnalignedBitString(getKey());
             byte[] b = tmp.toByteArray();

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCSignatureImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCSignatureImpl.java
@@ -114,7 +114,7 @@ abstract class PQCSignatureImpl extends SignatureSpi {
         }
         //Validate that the alg of the key matchs the alg specified on creation of this object
         if (this.alg != null && !((keyPublic.getAlgorithm()).equalsIgnoreCase(this.alg))) {
-            throw new InvalidKeyException("Key must be of algorithm " + this.alg);
+            throw new InvalidKeyException("Expected algorithm " + this.alg + ", but got " + keyPublic.getAlgorithm());
         }
         try {
             this.signature.initialize(keyPublic.getPQCKey());

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPQCSignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPQCSignature.java
@@ -8,13 +8,17 @@
 
 package ibm.jceplus.junit.base;
 
+import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 public class BaseTestPQCSignature extends BaseTestJunit5Signature {
-
 
     static final byte[] origMsg = "this is the original message to be signed".getBytes();
 
@@ -22,17 +26,27 @@ public class BaseTestPQCSignature extends BaseTestJunit5Signature {
     @CsvSource({"ML_DSA_44","ML-DSA-65","ML_DSA_87"})
     public void testPQCKeySignature(String Algorithm) throws Exception {
 
-        if (getProviderName().equals("OpenJCEPlusFIPS")) {
-            //FIPS does not supported
-            return;
-        }
+        KeyPair keyPair = generateKeyPair(Algorithm);
+        doSignVerify(Algorithm, origMsg, keyPair.getPrivate(), keyPair.getPublic());
+    }
 
-        try { 
-            KeyPair keyPair = generateKeyPair(Algorithm);
-            doSignVerify(Algorithm, origMsg, keyPair.getPrivate(), keyPair.getPublic());
-        } catch (Exception e) {
-            throw new Exception(e.getCause() +" - "+Algorithm, e);
-        }
+    @ParameterizedTest
+    @CsvSource({"ML_DSA_44","ML-DSA-65","ML_DSA_87"})
+    public void testPQCKeySignatureEncodings(String Algorithm) throws Exception {
+
+        KeyPair keyPair = generateKeyPair(Algorithm);
+
+        PrivateKey privateKey = keyPair.getPrivate();
+        PublicKey publicKey = keyPair.getPublic();
+
+        byte[] publicKeyBytes = publicKey.getEncoded();
+        byte[] privateKeyBytes = privateKey.getEncoded();
+
+        KeyFactory keyFactory = KeyFactory.getInstance(Algorithm, getProviderName());
+        X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(publicKeyBytes);
+        PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(privateKeyBytes);
+
+        doSignVerify(Algorithm, origMsg, keyFactory.generatePrivate(privateKeySpec), keyFactory.generatePublic(publicKeySpec));
     }
 
     protected KeyPair generateKeyPair(String Algorithm) throws Exception {


### PR DESCRIPTION
The algorithm name at times stores the OID instead of the human readable name when running on releases other then Java 25. This update uses our internal maps to always convert the OID to the human readable name within the PQC key objects.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/815

Fixes [#814](https://github.com/IBM/OpenJCEPlus/issues/814)

Signed-off-by: Jason Katonica <katonica@us.ibm.com>