### PR TITLE
Add JMH performance benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@
 # Allow tracked changes for configuration file used by the
 # clang-format tool for formatting C code.
 !.clang-format
+
+# Igore JMH lock file
+jmh.lock

--- a/JenkinsfilePerformance
+++ b/JenkinsfilePerformance
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2024, 2025
+ * Copyright IBM Corp. 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -23,9 +23,8 @@ import groovy.transform.Field;
 @Field JAVA_RELEASE
 @Field OCK_RELEASE
 @Field OCK_FULL_URL
-@Field EXECUTE_TESTS
-@Field SPECIFIC_TEST
 @Field PARALLEL_ITERATIONS
+@Field BENCHMARK
 @Field ADDITIONAL_NODE_LABELS
 @Field OVERRIDE_NODE_LABELS
 @Field ADDITIONAL_ENVARS
@@ -93,34 +92,6 @@ def getPlatforms() {
 }
 
 /*
- * Get the appropriate test flag.
- *
- * The user might have requested that test are not
- * run or asked for a specific test to
- * be executed.
- *
- * Even if that's not the case, in some
- * platforms the OpenJCEPlusFIPS provider is not
- * available and thus the FIPS-related tests should
- * not be executed.
- */
-def getTestFlag(hardware, software) {
-    // User requested that tests not be executed.
-    if (EXECUTE_TESTS == "false") {
-        return " -DskipTests"
-    }
-
-    // User requested execution of a specific test.
-    if (SPECIFIC_TEST) {
-        return " -Dtest=${SPECIFIC_TEST}"
-    }
-
-    // Run all tests. Some platforms will naturally run in developer mode.
-    echo "All tests (both FIPS and non-FIPS) can be run in ${hardware}_${software}"
-    return "";
-}
-
-/*
  * Creates the upload specification and triggers the process
  * of uploading the compressed file to Artifactory.
  *
@@ -131,7 +102,7 @@ def archive(platform, iteration) {
     
     // Create compressed file containing build.
     def ending = ".tar.gz"
-    def filename = "openjceplus-$iteration-$platform$ending"
+    def filename = "openjceplus-performance-$iteration-$platform$ending"
     dir("openjceplus/OpenJCEPlus") {
         tar archive: false, compress: true, defaultExcludes: false, dir: '', exclude: '', file: "$filename", glob: '', overwrite: false
     }
@@ -199,7 +170,7 @@ def run(platform) {
     return {
         def excludeNode = []
         def iteration = 0
-        retry(3) {
+        retry(0) {
             // Specific labels are selected based on platform.
             def nodeTags = "hw.arch.${node_hardware}&&sw.os.${node_software}"
             // Nodes where a failed attempt was made are excluded.
@@ -207,16 +178,19 @@ def run(platform) {
 
             // Some OSes have some further specific requirements.
             if (software == "aix") {
-                // Java 25 requires C++17.1 runtime. Otherwise crashes occur.
-                nodeTags += "&&sw.tool.c++runtime.17_1"
+                // For now only one default AIX performance machine.
+                nodeTags += "&&wp25-005-aix73tl03sp01-1.cc9.pok.ibm.com"
+            } else if ((hardware == "ppc64le") && (software == "linux")) {
+                // For now only one ppcle64 linux performance machine.
+                nodeTags += "&&wp25-005-rhel96-5.cc9.pok.ibm.com"
+            } else if ((hardware == "x86-64") && (software == "linux")) {
+                // For now only one x86 linux performance machine.
+                nodeTags += "&&ub-cascadelake-2s32c-01.rtp.raleigh.ibm.com"
+            } else {
+                nodeTags += "&&ci.role.test"
+                // Exclude machines that are FIPS140-2 configured.
+                nodeTags += "&&!ci.role.test.fips"
             }
-
-            // Machines tagged as ci.role.test are expected to have
-            // software to compile, build, and test OpenJCEPlus.
-            nodeTags += "&&ci.role.test"
-
-            // Exclude machines that are FIPS140-2 configured.
-            nodeTags += "&&!ci.role.test.fips"
 
             // Add additional labels specified by user.
             nodeTags += (ADDITIONAL_NODE_LABELS) ? "&&" + ADDITIONAL_NODE_LABELS : ""
@@ -233,14 +207,20 @@ def run(platform) {
                     externalLibrary = load("./utils.groovy")
                 }
                 try {
+                    def isBuildable = externalLibrary.isBuildable(hardware, software)
+                    if (!isBuildable) {
+                        return {
+                            echo "OpenJCEPlus is not supported on $hardware and $software"
+                        }
+                    }
+
                     externalLibrary.getJava(hardware, software)
                     echo "Java fetched"
                     externalLibrary.getBinaries(hardware, software)
                     echo "Binaries fetched"
                     externalLibrary.getMaven()
                     echo "Maven fetched"
-                    def command = "install"
-                    command += getTestFlag(hardware, software)
+                    def command = "clean install -DskipTests -Djmh.benchmark.skip=false -Djmh.benchmark=" + BENCHMARK
                     externalLibrary.runOpenJCEPlus(command, software)
                     echo "OpenJCEPlus built"
                 } finally {
@@ -282,11 +262,11 @@ pipeline {
             """
         )
         booleanParam(name: 'ppc64_aix', defaultValue: false, description: '\
-            Build for ppc64_aix platform')
+            Build for ppc64_aix platform ( Real hardware available )')
         booleanParam(name: 'x86_64_linux', defaultValue: false, description: '\
-            Build for x86-64_linux platform')
+            Build for x86-64_linux platform ( Real hardware available )')
         booleanParam(name: 'ppc64le_linux', defaultValue: false, description: '\
-            Build for ppc64le_linux platform')
+            Build for ppc64le_linux platform ( Real hardware available )')
         booleanParam(name: 's390x_linux', defaultValue: false, description: '\
             Build for s390x_linux platform')
         booleanParam(name: 'x86_64_windows', defaultValue: false, description: '\
@@ -349,13 +329,39 @@ pipeline {
                 font-style: italic;
             """
         )
-        booleanParam(name: 'EXECUTE_TESTS', defaultValue: true, description:'\
-            Execute tests during the build')
-        string(name: 'SPECIFIC_TEST', defaultValue: '', description: '\
-            Set this to only execute a specific test, instead of the whole test suite.<br> \
-            Keep in mind that EXECUTE_TESTS has to be set too for this to work.')
         string(name: 'PARALLEL_ITERATIONS', defaultValue: '', description: '\
             Number of iterations to run all stages for each of the specified platforms. The iterations will run in parallel.')
+        choice(name: 'BENCHMARK', choices: ['ibm.jceplus.jmh.RunAll', \
+                                            'ibm.jceplus.jmh.AESCipherBenchmark', \
+                                            'ibm.jceplus.jmh.AESKeyGeneratorBenchmark', \
+                                            'ibm.jceplus.jmh.AESWrapBenchmark', \
+                                            'ibm.jceplus.jmh.ChaCha20CipherBenchmark', \
+                                            'ibm.jceplus.jmh.ChaCha20KeyGeneratorBenchmark', \
+                                            'ibm.jceplus.jmh.ChaCha20Poly1305CipherBenchmark', \
+                                            'ibm.jceplus.jmh.DESedeCipherBenchmark', \
+                                            'ibm.jceplus.jmh.DESedeKeyGeneratorBenchmark', \
+                                            'ibm.jceplus.jmh.DHKeyExchangeBenchmark', \
+                                            'ibm.jceplus.jmh.DHKeyGeneratorBenchmark', \
+                                            'ibm.jceplus.jmh.DSAKeyGeneratorBenchmark', \
+                                            'ibm.jceplus.jmh.DSASignatureBenchmark', \
+                                            'ibm.jceplus.jmh.ECDHKeyExchangeBenchmark', \
+                                            'ibm.jceplus.jmh.ECKeyGeneratorBenchmark', \
+                                            'ibm.jceplus.jmh.EdKeyGeneratorBenchmark', \
+                                            'ibm.jceplus.jmh.HmacBenchmark', \
+                                            'ibm.jceplus.jmh.HMACKeyGeneratorBenchmark', \
+                                            'ibm.jceplus.jmh.MessageDigestBenchmark', \
+                                            'ibm.jceplus.jmh.MessageDigestInstanceBenchmark', \
+                                            'ibm.jceplus.jmh.MLDSABenchmark', \
+                                            'ibm.jceplus.jmh.MLKEMBenchmark', \
+                                            'ibm.jceplus.jmh.PBKDF2Benchmark', \
+                                            'ibm.jceplus.jmh.RandomBenchmark', \
+                                            'ibm.jceplus.jmh.RSAKeyGeneratorBenchmark', \
+                                            'ibm.jceplus.jmh.RSASignatureBenchmark', \
+                                            'ibm.jceplus.jmh.X448KeyExchangeBenchmark', \
+                                            'ibm.jceplus.jmh.X25519KeyExchangeBenchmark', \
+                                            'ibm.jceplus.jmh.XDHKeyExchangeBenchmark', \
+                                            'ibm.jceplus.jmh.XDHKeyGeneratorBenchmark'], description: '\
+            Specify the performance benchmark you would like to run.')
         separator(name: "ExtendedOptions", sectionHeader: "Extended Options",
             separatorStyle: "border-width: 0",
             sectionHeaderStyle: """
@@ -381,13 +387,13 @@ pipeline {
             Specify them in comma-separated pairs of name and value (e.g. ENVAR1=value1, ENVAR2=value2, ...).<br><br> \
             Beware of what you add as it might be overriding existing environment variables.<br> \
             NOTE: those will be added to all selected platforms.')
-        string(name: 'TIMEOUT_TIME', defaultValue: '6', description: '\
+        string(name: 'TIMEOUT_TIME', defaultValue: '48', description: '\
             Overall build timeout (HOURS)')
     }
 
     agent none
     stages {
-        stage('Build And Test OpenJCEPlus') {
+        stage('Build And Performance Test') {
             steps {
                 timestamps {
                     script {
@@ -408,9 +414,8 @@ pipeline {
                         JAVA_RELEASE="${params.JAVA_RELEASE}"
                         OCK_RELEASE="${params.OCK_RELEASE}"
                         OCK_FULL_URL="${params.OCK_FULL_URL}"
-                        EXECUTE_TESTS="${params.EXECUTE_TESTS}"
-                        SPECIFIC_TEST="${params.SPECIFIC_TEST}"
                         PARALLEL_ITERATIONS="${params.PARALLEL_ITERATIONS}"
+                        BENCHMARK="${params.BENCHMARK}"
                         ADDITIONAL_NODE_LABELS="${params.ADDITIONAL_NODE_LABELS}"
                         OVERRIDE_NODE_LABELS="${params.OVERRIDE_NODE_LABELS}"
                         ADDITIONAL_ENVARS="${params.ADDITIONAL_ENVARS}"

--- a/README.md
+++ b/README.md
@@ -184,6 +184,22 @@ export GSKIT_HOME="$PROJECT_HOME/OCK/jgsk_sdk"
 mvn '-Dock.library.path=$PROJECT_HOME/OCK/' test -Dtest=TestClassname
 ```
 
+### Run performance tests
+
+The OpenJCEPlus project includes JMH performance tests that exercise various algorithms included. They can be executed as follows:
+
+To run a single test for example the `SHA256Benchmark`:
+
+```console
+mvn -Dock.library.path=$PROJECT_HOME/OCK/jgsk_crypto clean install -DskipTests -Djmh.benchmark.skip=false -Djmh.benchmark=ibm.jceplus.jmh.SHA256Benchmark
+```
+
+To run all performance tests:
+
+```console
+mvn -Dock.library.path=$PROJECT_HOME/OCK/jgsk_crypto clean install -DskipTests -Djmh.benchmark.skip=false
+```
+
 ## OpenJCEPlus and OpenJCEPlusFIPS Provider SDK Installation
 
 1. There are two ways to configure and make use of the OpenJCEPlus and OpenJCEPlusFIPS providers:

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyyMMdd</maven.build.timestamp.format>
+        <jmh.benchmark>ibm.jceplus.jmh.RunAll</jmh.benchmark>
+        <jmh.benchmark.skip>true</jmh.benchmark.skip>
     </properties>
         <profiles>
           <profile>
@@ -66,6 +68,7 @@
                 <plugin>
                   <groupId>org.codehaus.mojo</groupId>
                   <artifactId>exec-maven-plugin</artifactId>
+                  <version>3.5.0</version>
                   <executions>
                     <execution>
                       <id>Execute Native Library Build Script</id>
@@ -263,6 +266,64 @@
                     </includes>
                   </configuration>
                 </plugin>
+                <plugin>
+                  <artifactId>maven-antrun-plugin</artifactId>
+                  <version>3.1.0</version>
+                  <executions>
+                      <execution>
+                          <phase>generate-sources</phase>
+                          <configuration>
+                              <target>
+                                  <mkdir dir="${project.build.directory}/jmh-results"/>
+                              </target>
+                          </configuration>
+                          <goals>
+                              <goal>run</goal>
+                          </goals>
+                      </execution>
+                  </executions>
+                </plugin>
+                <plugin>
+                  <groupId>org.codehaus.mojo</groupId>
+                  <artifactId>exec-maven-plugin</artifactId>
+                  <version>3.5.0</version>
+                  <executions>
+                      <execution>
+                        <id>Execute Performance Tests</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                          <includeProjectDependencies>true</includeProjectDependencies>
+                          <includePluginDependencies>true</includePluginDependencies>
+                          <additionalClasspathElements>
+                            <additionalClasspathElement>${project.build.directory}${file.separator}test-classes</additionalClasspathElement>
+                          </additionalClasspathElements>
+                          <systemProperties>
+                            <systemProperty>
+                              <key>jmh.project.dir</key>
+                              <value>${project.basedir}</value>
+                            </systemProperty>
+                            <systemProperty>
+                              <key>ock.library.path</key>
+                              <value>${ock.library.path}</value>
+                            </systemProperty>
+                            <systemProperty>
+                              <key>jgskit.library.path</key>
+                              <value>${build.target.jgskitlib.dir}</value>
+                            </systemProperty>
+                            <systemProperty>
+                              <key>java.io.tmpdir</key>
+                              <value>.</value>
+                            </systemProperty>
+                          </systemProperties>
+                          <mainClass>${jmh.benchmark}</mainClass>
+                          <skip>${jmh.benchmark.skip}</skip>
+                        </configuration>
+                      </execution>
+                  </executions>
+                </plugin>
               </plugins>
             </build>
           </profile>
@@ -373,11 +434,10 @@
                     <inputEncoding>${style.encoding}</inputEncoding>
                     <consoleOutput>true</consoleOutput>
                     <failsOnError>true</failsOnError>
-                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <excludes>**/module-info.java</excludes>
                     <sourceDirectories>
-                        <sourceDirectory>src</sourceDirectory>
-                        <sourceDirectory>src/native</sourceDirectory>
+                        <sourceDirectory>src/test</sourceDirectory>
+                        <sourceDirectory>src/main</sourceDirectory>
                     </sourceDirectories>
                 </configuration>
                 <executions>
@@ -448,6 +508,13 @@
                         <arg>--add-exports </arg>
                         <arg>java.base/jdk.internal.logger=ALL-UNNAMED</arg>
                     </compilerArgs>
+                    <annotationProcessorPaths>
+                      <path>
+                          <groupId>org.openjdk.jmh</groupId>
+                          <artifactId>jmh-generator-annprocess</artifactId>
+                          <version>1.37</version>
+                      </path>
+                    </annotationProcessorPaths>
                     <fork>true</fork>
                     <debug>true</debug>
                 </configuration>
@@ -748,11 +815,26 @@
           <groupId>org.bouncycastle</groupId>
           <artifactId>bcprov-ext-jdk18on</artifactId>
           <version>1.78.1</version>
-      </dependency>
+        </dependency>
         <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
             <version>0.8.13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.37</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.37</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>3.1.0</version>
         </dependency>
     </dependencies>
     <groupId>crypto</groupId>

--- a/src/test/java/ibm/jceplus/jmh/AESCipherBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/AESCipherBenchmark.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.util.concurrent.TimeUnit;
+import javax.crypto.Cipher;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class AESCipherBenchmark extends CipherBase {
+
+    @Param({"AES/ECB/PKCS5Padding", "AES/CBC/PKCS5Padding", "AES/CFB/PKCS5Padding",
+            "AES/OFB/PKCS5Padding", "AES/CTR/NoPadding", "AES/GCM/NoPadding"})
+    private String transformation;
+
+    @Param({"256"})
+    private int keySize;
+
+    @Param({"1024", "32768"})
+    private int payloadSize;
+
+    @Param({"OpenJCEPlus", "SunJCE"})
+    private String provider;
+
+    @Setup
+    public void setup() throws Exception {
+        super.setup(keySize, transformation, payloadSize, provider);
+    }
+
+    @Setup(Level.Invocation)
+    public void setupInvocation() throws Exception {
+        if (iv != null) {
+            encryptCipher.init(Cipher.ENCRYPT_MODE, secretKey, iv);
+            decryptCipher.init(Cipher.DECRYPT_MODE, secretKey, iv);
+        } else if (gcmParm != null) {
+            encryptCipher.init(Cipher.ENCRYPT_MODE, secretKey);
+            decryptCipher.init(Cipher.DECRYPT_MODE, secretKey, gcmParm);
+        } else {
+            encryptCipher.init(Cipher.ENCRYPT_MODE, secretKey);
+            decryptCipher.init(Cipher.DECRYPT_MODE, secretKey);
+        }
+    }
+
+    @Benchmark
+    public byte[] benchmarkEncryption() throws Exception {
+        return encryptCipher.doFinal(plaintext);
+    }
+
+    @Benchmark
+    public byte[] benchmarkDecryption() throws Exception {
+        return decryptCipher.doFinal(ciphertext);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = AESCipherBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/AESKeyGeneratorBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/AESKeyGeneratorBenchmark.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.util.concurrent.TimeUnit;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class AESKeyGeneratorBenchmark extends JMHBase {
+
+    @Param({"OpenJCEPlus", "SunJCE"})
+    private String provider;
+
+    private KeyGenerator aesKeyGenerator128 = null;
+    private KeyGenerator aesKeyGenerator192 = null;
+    private KeyGenerator aesKeyGenerator256 = null;
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        aesKeyGenerator128 = KeyGenerator.getInstance("AES", provider);
+        aesKeyGenerator128.init(128);
+        aesKeyGenerator192 = KeyGenerator.getInstance("AES", provider);
+        aesKeyGenerator192.init(192);
+        aesKeyGenerator256 = KeyGenerator.getInstance("AES", provider);
+        aesKeyGenerator256.init(256);
+    }
+
+    @Benchmark
+    public SecretKey aes128KeyGeneration() throws Exception {
+        return aesKeyGenerator128.generateKey();
+    }
+
+    @Benchmark
+    public SecretKey aes192KeyGeneration() throws Exception {
+        return aesKeyGenerator192.generateKey();
+    }
+
+    @Benchmark
+    public SecretKey aes256KeyGeneration() throws Exception {
+        return aesKeyGenerator256.generateKey();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = AESKeyGeneratorBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/AESWrapBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/AESWrapBenchmark.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.Key;
+import java.util.concurrent.TimeUnit;
+import javax.crypto.Cipher;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class AESWrapBenchmark extends CipherBase {
+
+    @Param({"AESWrap", "AESWrapPad"})
+    private String transformation;
+
+    @Param({"128", "192", "256"})
+    private int keySize;
+
+    @Param({"OpenJCEPlus", "SunJCE"})
+    private String provider;
+
+    private byte[] wrappedKey;
+
+    @Setup
+    public void setup() throws Exception {
+        super.setup(keySize, transformation, 0, provider);
+        encryptCipher.init(Cipher.WRAP_MODE, secretKey);
+        decryptCipher.init(Cipher.UNWRAP_MODE, secretKey);
+        wrappedKey = encryptCipher.wrap(secretKey);
+    }
+
+    @Benchmark
+    public byte[] benchmarkAESWrap() throws Exception {
+        return encryptCipher.wrap(secretKey);
+    }
+
+    @Benchmark
+    public Key benchmarkAESUnwrap() throws Exception {
+        return decryptCipher.unwrap(wrappedKey, "AES", Cipher.SECRET_KEY);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = AESWrapBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/ChaCha20CipherBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/ChaCha20CipherBenchmark.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.util.concurrent.TimeUnit;
+import javax.crypto.Cipher;
+import javax.crypto.spec.ChaCha20ParameterSpec;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class ChaCha20CipherBenchmark extends CipherBase {
+
+    @Param({"ChaCha20/None/NoPadding"})
+    private String transformation;
+
+    @Param({"1024", "32768"})
+    private int payloadSize;
+
+    @Param({"OpenJCEPlus", "SunJCE"})
+    private String provider;
+
+    @Setup
+    public void setup() throws Exception {
+        super.setup(256, transformation, payloadSize, provider);
+        decryptCipher.init(Cipher.DECRYPT_MODE, secretKey, chacha20Spec);
+    }
+
+    @Benchmark
+    public byte[] benchmarkEncryption() throws Exception {
+        byte[] ivBytes = new byte[getIVSize("ChaCha20", "None")];
+        random.nextBytes(ivBytes);
+        ChaCha20ParameterSpec newChaCha20Spec = new ChaCha20ParameterSpec(ivBytes, 1);
+        encryptCipher.init(Cipher.ENCRYPT_MODE, secretKey, newChaCha20Spec);
+        return encryptCipher.doFinal(plaintext);
+    }
+
+    @Benchmark
+    public byte[] benchmarkDecryption() throws Exception {
+        return decryptCipher.doFinal(ciphertext);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = ChaCha20CipherBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/ChaCha20KeyGeneratorBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/ChaCha20KeyGeneratorBenchmark.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.util.concurrent.TimeUnit;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class ChaCha20KeyGeneratorBenchmark extends JMHBase {
+
+    @Param({"OpenJCEPlus", "SunJCE"})
+    private String provider;
+
+    private KeyGenerator chaCha20KeyGenerator = null;
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        chaCha20KeyGenerator = KeyGenerator.getInstance("ChaCha20", provider);
+    }
+
+    @Benchmark
+    public SecretKey chaCha20KeyGeneration() throws Exception {
+        return chaCha20KeyGenerator.generateKey();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = ChaCha20KeyGeneratorBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/ChaCha20Poly1305CipherBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/ChaCha20Poly1305CipherBenchmark.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.util.concurrent.TimeUnit;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class ChaCha20Poly1305CipherBenchmark extends CipherBase {
+
+    @Param({"ChaCha20-Poly1305/None/NoPadding"})
+    private String transformation;
+
+    @Param({"1024", "32768"})
+    private int payloadSize;
+
+    @Param({"OpenJCEPlus", "SunJCE"})
+    private String provider;
+
+    @Setup
+    public void setup() throws Exception {
+        super.setup(256, transformation, payloadSize, provider);
+        decryptCipher.init(Cipher.DECRYPT_MODE, secretKey, iv);
+    }
+
+    @Benchmark
+    public byte[] benchmarkEncryption() throws Exception {
+        byte[] ivBytes = new byte[getIVSize("ChaCha20", "None")];
+        random.nextBytes(ivBytes);
+        iv = new IvParameterSpec(ivBytes);
+        encryptCipher.init(Cipher.ENCRYPT_MODE, secretKey, iv);
+        return encryptCipher.doFinal(plaintext);
+    }
+
+    @Benchmark
+    public byte[] benchmarkDecryption() throws Exception {
+        return decryptCipher.doFinal(ciphertext);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = ChaCha20Poly1305CipherBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/CipherBase.java
+++ b/src/test/java/ibm/jceplus/jmh/CipherBase.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.SecureRandom;
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.ChaCha20ParameterSpec;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+
+abstract public class CipherBase extends JMHBase {
+
+    protected byte[] plaintext = null;
+    protected SecretKey secretKey = null;
+    protected IvParameterSpec iv = null;
+    protected GCMParameterSpec gcmParm = null;
+    ChaCha20ParameterSpec chacha20Spec = null;
+    protected Cipher encryptCipher = null;
+    protected Cipher decryptCipher = null;
+    protected byte[] ciphertext = null;
+    protected SecureRandom random = new SecureRandom();
+
+    /**
+     * Sets a cipher test up for execution.
+     * @param keySize The size of the key.
+     * @param transformation The transformation.
+     * @param payloadSize The payload to preallocate with random data. This value may be 0 in which we will not use a payload such as AESWraping.
+     * @param provider The provider to use for both key generation and the transformation itself.
+     * @throws Exception
+     */
+    public void setup(int keySize, String transformation, int payloadSize, String provider)
+            throws Exception {
+        insertProvider(provider);
+        String splitTransformation[] = transformation.split("/");
+
+        String algorithm = splitTransformation[0];
+
+        String mode = null;
+        if (splitTransformation.length > 1) {
+            mode = splitTransformation[1];
+        }
+
+        encryptCipher = Cipher.getInstance(transformation, provider);
+        decryptCipher = Cipher.getInstance(transformation, provider);
+
+        plaintext = new byte[payloadSize];
+        random.nextBytes(plaintext);
+
+        KeyGenerator keyGen = null;
+        if (algorithm.equals("ChaCha20-Poly1305")) {
+            keyGen = KeyGenerator.getInstance("ChaCha20", provider);
+        } else if (algorithm.startsWith("AESWrap")) {
+            keyGen = KeyGenerator.getInstance("AES", provider);
+        } else {
+            keyGen = KeyGenerator.getInstance(algorithm, provider);
+        }
+        keyGen.init(keySize);
+        secretKey = keyGen.generateKey();
+
+        iv = null;
+        gcmParm = null;
+        if (ivRequired(mode)) {
+            byte[] ivBytes = new byte[getIVSize(algorithm, mode)];
+            random.nextBytes(ivBytes);
+            if (mode.equals("GCM")) {
+                int tagLength = 128;
+                gcmParm = new GCMParameterSpec(tagLength, ivBytes);
+                encryptCipher.init(Cipher.ENCRYPT_MODE, secretKey, gcmParm);
+            } else if (algorithm.equals("ChaCha20")) {
+                chacha20Spec = new ChaCha20ParameterSpec(ivBytes, 1);
+                encryptCipher.init(Cipher.ENCRYPT_MODE, secretKey, chacha20Spec);
+            } else {
+                iv = new IvParameterSpec(ivBytes);
+                encryptCipher.init(Cipher.ENCRYPT_MODE, secretKey, iv);
+            }
+        } else {
+            encryptCipher.init(Cipher.ENCRYPT_MODE, secretKey);
+        }
+
+        if (plaintext.length > 0) {
+            ciphertext = encryptCipher.doFinal(plaintext);
+        }
+    }
+
+    protected int getIVSize(String algorithm, String mode) {
+        if ("AES".equals(algorithm)) {
+            return "GCM".equals(mode) ? 12 : 16;
+        } else if ("DESede".equals(algorithm)) {
+            return 8;
+        } else if (algorithm.startsWith("ChaCha20")) {
+            return 12;
+        }
+        return 16;
+    }
+
+    private boolean ivRequired(String mode) {
+        return "CBC".equals(mode) || "CFB".equals(mode) || "CTR".equals(mode) || "GCM".equals(mode)
+                || "None".equals(mode) || // ChaCha20 specific
+                "OFB".equals(mode);
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/DESedeCipherBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/DESedeCipherBenchmark.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.util.concurrent.TimeUnit;
+import javax.crypto.Cipher;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class DESedeCipherBenchmark extends CipherBase {
+
+    @Param({"DESede/ECB/PKCS5Padding", "DESede/CBC/PKCS5Padding"})
+    private String transformation;
+
+    @Param({"1024", "32768"})
+    private int payloadSize;
+
+    @Param({"OpenJCEPlus", "SunJCE"})
+    private String provider;
+
+    @Setup
+    public void setup() throws Exception {
+        super.setup(168, transformation, payloadSize, provider);
+    }
+
+    @Setup(Level.Invocation)
+    public void setupInvocation() throws Exception {
+        if (iv != null) {
+            encryptCipher.init(Cipher.ENCRYPT_MODE, secretKey, iv);
+            decryptCipher.init(Cipher.DECRYPT_MODE, secretKey, iv);
+        } else {
+            encryptCipher.init(Cipher.ENCRYPT_MODE, secretKey);
+            decryptCipher.init(Cipher.DECRYPT_MODE, secretKey);
+        }
+    }
+
+    @Benchmark
+    public byte[] benchmarkEncryption() throws Exception {
+        return encryptCipher.doFinal(plaintext);
+    }
+
+    @Benchmark
+    public byte[] benchmarkDecryption() throws Exception {
+        return decryptCipher.doFinal(ciphertext);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = DESedeCipherBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/DESedeKeyGeneratorBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/DESedeKeyGeneratorBenchmark.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.util.concurrent.TimeUnit;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class DESedeKeyGeneratorBenchmark extends JMHBase {
+
+    @Param({"OpenJCEPlus", "SunJCE"})
+    private String provider;
+
+    private KeyGenerator desedeKeyGenerator = null;
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        desedeKeyGenerator = KeyGenerator.getInstance("DESede", provider);
+    }
+
+    @Benchmark
+    public SecretKey desedeKeyGeneration() throws Exception {
+        return desedeKeyGenerator.generateKey();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = DESedeKeyGeneratorBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/DHKeyExchangeBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/DHKeyExchangeBenchmark.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.concurrent.TimeUnit;
+import javax.crypto.KeyAgreement;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class DHKeyExchangeBenchmark extends JMHBase {
+
+    @Param({"OpenJCEPlus", "SunJCE"})
+    private String provider;
+
+    @Param({"1024", "4096"})
+    private int keySize;
+
+    private KeyPairGenerator dhKeyPairGenerator;
+    private KeyAgreement dhKeyAgreement;
+    private KeyPair bobDHKeyPair;
+    private KeyPair aliceDHKeyPair;
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        dhKeyPairGenerator = KeyPairGenerator.getInstance("DH", provider);
+        dhKeyPairGenerator.initialize(keySize);
+
+        dhKeyAgreement = KeyAgreement.getInstance("DH", provider);
+
+        bobDHKeyPair = dhKeyPairGenerator.generateKeyPair();
+        aliceDHKeyPair = dhKeyPairGenerator.generateKeyPair();
+
+        dhKeyAgreement.init(bobDHKeyPair.getPrivate());
+    }
+
+    @Benchmark
+    public byte[] dhKeyExchange() throws Exception {
+        dhKeyAgreement.doPhase(aliceDHKeyPair.getPublic(), true);
+        return dhKeyAgreement.generateSecret();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = DHKeyExchangeBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/DHKeyGeneratorBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/DHKeyGeneratorBenchmark.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class DHKeyGeneratorBenchmark extends JMHBase {
+
+    @Param({"OpenJCEPlus", "SunJCE"})
+    private String provider;
+
+    private KeyPairGenerator dhKeyPairGenerator1024 = null;
+    private KeyPairGenerator dhKeyPairGenerator2048 = null;
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        dhKeyPairGenerator1024 = KeyPairGenerator.getInstance("DH", provider);
+        dhKeyPairGenerator1024.initialize(1024);
+        dhKeyPairGenerator2048 = KeyPairGenerator.getInstance("DH", provider);
+        dhKeyPairGenerator2048.initialize(2048);
+    }
+
+    @Benchmark
+    public KeyPair dh1024KeyGeneration() throws Exception {
+        return dhKeyPairGenerator1024.generateKeyPair();
+    }
+
+    @Benchmark
+    public KeyPair dh2048KeyGeneration() throws Exception {
+        return dhKeyPairGenerator2048.generateKeyPair();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = DHKeyGeneratorBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/DSAKeyGeneratorBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/DSAKeyGeneratorBenchmark.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class DSAKeyGeneratorBenchmark extends JMHBase {
+
+    @Param({"OpenJCEPlus", "SUN"})
+    private String provider;
+
+    private KeyPairGenerator dsaKeyPairGenerator1024 = null;
+    private KeyPairGenerator dsaKeyPairGenerator2048 = null;
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        dsaKeyPairGenerator1024 = KeyPairGenerator.getInstance("DSA", provider);
+        dsaKeyPairGenerator1024.initialize(1024);
+        dsaKeyPairGenerator2048 = KeyPairGenerator.getInstance("DSA", provider);
+        dsaKeyPairGenerator2048.initialize(2048);
+    }
+
+    @Benchmark
+    public KeyPair dsa1024KeyGeneration() throws Exception {
+        return dsaKeyPairGenerator1024.generateKeyPair();
+    }
+
+    @Benchmark
+    public KeyPair dsa2048KeyGeneration() throws Exception {
+        return dsaKeyPairGenerator2048.generateKeyPair();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = DSAKeyGeneratorBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/DSASignatureBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/DSASignatureBenchmark.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.security.Signature;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class DSASignatureBenchmark extends JMHBase {
+
+    @Param({"2048", "32768"})
+    private int payloadSize;
+
+    @Param({"OpenJCEPlus", "SUN"})
+    private String provider;
+
+    @Param({"2048"})
+    private int keySize;
+
+    private KeyPairGenerator dsaKeyPairGenerator;
+    private Signature dsaSha1SignatureInstance;
+    private Signature dsaSha224SignatureInstance;
+    private Signature dsaSha256SignatureInstance;
+    private Signature dsaSha1VerifierInstance;
+    private Signature dsaSha224VerifierInstance;
+    private Signature dsaSha256VerifierInstance;
+    private KeyPair dsaKeyPair;
+    private byte[] dsaSha1signature;
+    private byte[] dsaSha224signature;
+    private byte[] dsaSha256signature;
+    private byte[] payload;
+    private SecureRandom random = new SecureRandom();
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        dsaKeyPairGenerator = KeyPairGenerator.getInstance("DSA", provider);
+        dsaKeyPairGenerator.initialize(keySize);
+
+        dsaSha1SignatureInstance = Signature.getInstance("SHA1withDSA", provider);
+        dsaSha224SignatureInstance = Signature.getInstance("SHA224withDSA", provider);
+        dsaSha256SignatureInstance = Signature.getInstance("SHA256withDSA", provider);
+
+        dsaSha1VerifierInstance = Signature.getInstance("SHA1withDSA", provider);
+        dsaSha224VerifierInstance = Signature.getInstance("SHA224withDSA", provider);
+        dsaSha256VerifierInstance = Signature.getInstance("SHA256withDSA", provider);
+
+        dsaKeyPair = dsaKeyPairGenerator.generateKeyPair();
+
+        dsaSha1SignatureInstance.initSign(dsaKeyPair.getPrivate());
+        dsaSha224SignatureInstance.initSign(dsaKeyPair.getPrivate());
+        dsaSha256SignatureInstance.initSign(dsaKeyPair.getPrivate());
+
+        payload = new byte[payloadSize];
+        random.nextBytes(payload);
+
+        dsaSha1SignatureInstance.update(payload);
+        dsaSha224SignatureInstance.update(payload);
+        dsaSha256SignatureInstance.update(payload);
+
+        dsaSha1signature = dsaSha1SignatureInstance.sign();
+        dsaSha224signature = dsaSha224SignatureInstance.sign();
+        dsaSha256signature = dsaSha256SignatureInstance.sign();
+    }
+
+    @Benchmark
+    public byte[] dsaSha1Sign() throws Exception {
+        dsaSha1SignatureInstance.initSign(dsaKeyPair.getPrivate());
+        dsaSha1SignatureInstance.update(payload);
+        return dsaSha1SignatureInstance.sign();
+    }
+
+    @Benchmark
+    public byte[] dsaSha224Sign() throws Exception {
+        dsaSha224SignatureInstance.initSign(dsaKeyPair.getPrivate());
+        dsaSha224SignatureInstance.update(payload);
+        return dsaSha224SignatureInstance.sign();
+    }
+
+    @Benchmark
+    public byte[] dsaSha256Sign() throws Exception {
+        dsaSha256SignatureInstance.initSign(dsaKeyPair.getPrivate());
+        dsaSha256SignatureInstance.update(payload);
+        return dsaSha256SignatureInstance.sign();
+    }
+
+    @Benchmark
+    public boolean dsaSha1Verify() throws Exception {
+        dsaSha1VerifierInstance.initVerify(dsaKeyPair.getPublic());
+        dsaSha1VerifierInstance.update(payload);
+        return dsaSha1VerifierInstance.verify(dsaSha1signature);
+    }
+
+    @Benchmark
+    public boolean dsaSha224Verify() throws Exception {
+        dsaSha224VerifierInstance.initVerify(dsaKeyPair.getPublic());
+        dsaSha224VerifierInstance.update(payload);
+        return dsaSha224VerifierInstance.verify(dsaSha224signature);
+    }
+
+    @Benchmark
+    public boolean dsaSha256Verify() throws Exception {
+        dsaSha256VerifierInstance.initVerify(dsaKeyPair.getPublic());
+        dsaSha256VerifierInstance.update(payload);
+        return dsaSha256VerifierInstance.verify(dsaSha256signature);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = DSASignatureBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/ECDHKeyExchangeBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/ECDHKeyExchangeBenchmark.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.spec.ECGenParameterSpec;
+import java.util.concurrent.TimeUnit;
+import javax.crypto.KeyAgreement;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class ECDHKeyExchangeBenchmark extends JMHBase {
+
+    @Param({"OpenJCEPlus", "SunEC"})
+    private String provider;
+
+    @Param({"secp256r1", "secp384r1", "secp521r1"})
+    private String curveName;
+
+    private KeyPairGenerator ecKeyPairGenerator;
+    private KeyAgreement ecdhKeyAgreement;
+    private KeyPair bobECKeyPair;
+    private KeyPair aliceECKeyPair;
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        ecKeyPairGenerator = KeyPairGenerator.getInstance("EC", provider);
+        ECGenParameterSpec ecSpec = new ECGenParameterSpec(curveName);
+        ecKeyPairGenerator.initialize(ecSpec);
+
+        ecdhKeyAgreement = KeyAgreement.getInstance("ECDH", provider);
+
+        bobECKeyPair = ecKeyPairGenerator.generateKeyPair();
+        aliceECKeyPair = ecKeyPairGenerator.generateKeyPair();
+
+        ecdhKeyAgreement.init(bobECKeyPair.getPrivate());
+    }
+
+    @Benchmark
+    public byte[] ecdhKeyExchange() throws Exception {
+        ecdhKeyAgreement.doPhase(aliceECKeyPair.getPublic(), true);
+        return ecdhKeyAgreement.generateSecret();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = ECDHKeyExchangeBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/ECKeyGeneratorBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/ECKeyGeneratorBenchmark.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.spec.ECGenParameterSpec;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class ECKeyGeneratorBenchmark extends JMHBase {
+
+    @Param({"OpenJCEPlus", "SunEC"})
+    private String provider;
+
+    private KeyPairGenerator ecKeyPairGeneratorP256 = null;
+    private KeyPairGenerator ecKeyPairGeneratorP384 = null;
+    private KeyPairGenerator ecKeyPairGeneratorP521 = null;
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        ecKeyPairGeneratorP256 = KeyPairGenerator.getInstance("EC", provider);
+        ecKeyPairGeneratorP256.initialize(new ECGenParameterSpec("secp256r1"));
+        ecKeyPairGeneratorP384 = KeyPairGenerator.getInstance("EC", provider);
+        ecKeyPairGeneratorP384.initialize(new ECGenParameterSpec("secp384r1"));
+        ecKeyPairGeneratorP521 = KeyPairGenerator.getInstance("EC", provider);
+        ecKeyPairGeneratorP521.initialize(new ECGenParameterSpec("secp521r1"));
+    }
+
+    @Benchmark
+    public KeyPair ecP256KeyGeneration() throws Exception {
+        return ecKeyPairGeneratorP256.generateKeyPair();
+    }
+
+    @Benchmark
+    public KeyPair ecP384KeyGeneration() throws Exception {
+        return ecKeyPairGeneratorP384.generateKeyPair();
+    }
+
+    @Benchmark
+    public KeyPair ecP521KeyGeneration() throws Exception {
+        return ecKeyPairGeneratorP521.generateKeyPair();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = ECKeyGeneratorBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/EdKeyGeneratorBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/EdKeyGeneratorBenchmark.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class EdKeyGeneratorBenchmark extends JMHBase {
+
+    @Param({"OpenJCEPlus", "SunEC"})
+    private String provider;
+
+    private KeyPairGenerator ed25519KeyPairGenerator = null;
+    private KeyPairGenerator ed448KeyPairGenerator = null;
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        ed25519KeyPairGenerator = KeyPairGenerator.getInstance("Ed25519", provider);
+        ed448KeyPairGenerator = KeyPairGenerator.getInstance("Ed448", provider);
+    }
+
+    @Benchmark
+    public KeyPair ed25519KeyGeneration() throws Exception {
+        return ed25519KeyPairGenerator.generateKeyPair();
+    }
+
+    @Benchmark
+    public KeyPair ed448KeyGeneration() throws Exception {
+        return ed448KeyPairGenerator.generateKeyPair();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = EdKeyGeneratorBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/HMACKeyGeneratorBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/HMACKeyGeneratorBenchmark.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.util.concurrent.TimeUnit;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class HMACKeyGeneratorBenchmark extends JMHBase {
+
+    @Param({"OpenJCEPlus", "SunJCE"})
+    private String provider;
+
+    private KeyGenerator hmacSha1KeyGenerator = null;
+    private KeyGenerator hmacSha256KeyGenerator = null;
+    private KeyGenerator hmacSha384KeyGenerator = null;
+    private KeyGenerator hmacSha512KeyGenerator = null;
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        hmacSha1KeyGenerator = KeyGenerator.getInstance("HmacSHA1", provider);
+        hmacSha256KeyGenerator = KeyGenerator.getInstance("HmacSHA256", provider);
+        hmacSha384KeyGenerator = KeyGenerator.getInstance("HmacSHA384", provider);
+        hmacSha512KeyGenerator = KeyGenerator.getInstance("HmacSHA512", provider);
+    }
+
+    @Benchmark
+    public SecretKey hmacSha1KeyGeneration() throws Exception {
+        return hmacSha1KeyGenerator.generateKey();
+    }
+
+    @Benchmark
+    public SecretKey hmacSha256KeyGeneration() throws Exception {
+        return hmacSha256KeyGenerator.generateKey();
+    }
+
+    @Benchmark
+    public SecretKey hmacSha384KeyGeneration() throws Exception {
+        return hmacSha384KeyGenerator.generateKey();
+    }
+
+    @Benchmark
+    public SecretKey hmacSha512KeyGeneration() throws Exception {
+        return hmacSha512KeyGenerator.generateKey();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = HMACKeyGeneratorBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/HmacBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/HmacBenchmark.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+import javax.crypto.KeyGenerator;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class HmacBenchmark extends JMHBase {
+
+    @Param({"HMACSHA1", "HMACSHA256", "HMACSHA512"})
+    private String transformation;
+
+    @Param({"16", "2048", "32768"})
+    private int payloadSize;
+
+    @Param({"OpenJCEPlus", "SunJCE"})
+    private String provider;
+
+    private Mac mac;
+    private byte[] payload;
+    private SecretKeySpec secretKey;
+    protected SecureRandom random = new SecureRandom();
+
+    @Setup(Level.Trial)
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        KeyGenerator kg = KeyGenerator.getInstance("AES");
+        kg.init(256);
+        SecretKey key = kg.generateKey();
+        secretKey = new SecretKeySpec(key.getEncoded(), transformation);
+
+        mac = Mac.getInstance(transformation, provider);
+        mac.init(secretKey);
+
+        payload = new byte[payloadSize];
+        random.nextBytes(payload);
+    }
+
+    @Benchmark
+    public byte[] hmacSingleShot() {
+        return mac.doFinal(payload);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = HmacBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/JMHBase.java
+++ b/src/test/java/ibm/jceplus/jmh/JMHBase.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+package ibm.jceplus.jmh;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.Provider;
+import org.openjdk.jmh.profile.ClassloaderProfiler;
+import org.openjdk.jmh.profile.CompilerProfiler;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.profile.StackProfiler;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+abstract public class JMHBase {
+
+    static Options optionsBuild(String regexClassName, String logFileRoot) {
+        // This is necessary to pass various classpath values to the forked JVM we are about to create.
+        URLClassLoader classLoader = (URLClassLoader) RunAll.class.getClassLoader();
+        StringBuilder classpath = new StringBuilder();
+        for (URL url : classLoader.getURLs()) {
+            classpath.append(url.getPath()).append(File.pathSeparator);
+        }
+        System.setProperty("java.class.path", classpath.toString());
+
+        // Get properties needed to build options.
+        String projectHomeDir = System.getProperty("jmh.project.dir");
+        String ockLibraryPath = System.getProperty("ock.library.path");
+        String jgskitLibraryPath = System.getProperty("jgskit.library.path");
+        String osName = System.getProperty("os.name").toLowerCase();
+        System.out.println("Home dir: " + projectHomeDir);
+        System.out.println("JGSkit Library Path: " + jgskitLibraryPath);
+        System.out.println("Regex of classes to run: " + regexClassName);
+        System.out.println("OS Name: " + osName);
+
+        OptionsBuilder optionsBuilder = new OptionsBuilder();
+        optionsBuilder.include(regexClassName);
+        optionsBuilder.resultFormat(org.openjdk.jmh.results.format.ResultFormatType.JSON);
+        optionsBuilder.result(projectHomeDir + "/target/jmh-results/" + logFileRoot + ".json");
+        optionsBuilder.addProfiler(StackProfiler.class);
+        optionsBuilder.addProfiler(GCProfiler.class);
+        optionsBuilder.addProfiler(ClassloaderProfiler.class);
+        optionsBuilder.addProfiler(CompilerProfiler.class);
+        optionsBuilder.jvmArgsAppend("-Xms1G", "-Xmx1G", "--patch-module",
+                "openjceplus=" + projectHomeDir + "/target/classes",
+                "--add-exports=java.base/sun.security.util=ALL-UNNAMED",
+                "--add-exports=java.base/sun.security.pkcs=ALL-UNNAMED",
+                "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",
+                "-Dock.library.path=" + ockLibraryPath,
+                "-Djgskit.library.path=" + jgskitLibraryPath);
+        optionsBuilder.forks(1);
+        optionsBuilder.output(projectHomeDir + "/target/jmh-results/" + logFileRoot + ".txt");
+
+        //TODO Most Jenkins systems dont seem to work with this. Must be admin.
+        /*
+        if (osName.contains("linux")) {
+            optionsBuilder.addProfiler(LinuxPerfProfiler.class);
+            optionsBuilder.addProfiler(LinuxPerfNormProfiler.class);
+            optionsBuilder.addProfiler(LinuxPerfAsmProfiler.class);
+        } else if (osName.contains("windows")) {
+            optionsBuilder.addProfiler(WinPerfAsmProfiler.class);
+        }
+        */
+
+        //Add these conditionally based on os and arch:
+        //.addProfiler(DTraceAsmProfiler.class)
+        return optionsBuilder.build();
+    }
+
+    protected void insertProvider(String provider) throws Exception {
+        if (provider.equalsIgnoreCase("OpenJCEPlus")) {
+            Provider myProvider = java.security.Security.getProvider("OpenJCEPlus");
+            if (myProvider == null) {
+                myProvider = (Provider) Class.forName("com.ibm.crypto.plus.provider.OpenJCEPlus")
+                        .getDeclaredConstructor().newInstance();
+            }
+            java.security.Security.insertProviderAt(myProvider, 1);
+        } else if (provider.equalsIgnoreCase("BC")) {
+            Provider myProvider = java.security.Security.getProvider("BC");
+            if (myProvider == null) {
+                myProvider = (Provider) Class
+                        .forName("org.bouncycastle.jce.provider.BouncyCastleProvider")
+                        .getDeclaredConstructor().newInstance();
+            }
+            java.security.Security.insertProviderAt(myProvider, 1);
+        }
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/MLDSABenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/MLDSABenchmark.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.security.Signature;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class MLDSABenchmark extends JMHBase {
+
+    @Param({"64", "1024", "8192", "32768"})
+    private int payloadSize;
+
+    @Param({"OpenJCEPlus", "SUN"})
+    private String provider;
+
+    private KeyPairGenerator mldsa44KeyPairGenerator;
+    private KeyPairGenerator mldsa65KeyPairGenerator;
+    private KeyPairGenerator mldsa87KeyPairGenerator;
+    private Signature mldsa44SignatureInstance;
+    private Signature mldsa65SignatureInstance;
+    private Signature mldsa87SignatureInstance;
+    private Signature mldsa44VerifierInstance;
+    private Signature mldsa65VerifierInstance;
+    private Signature mldsa87VerifierInstance;
+    private KeyPair mldsa44keyPair;
+    private KeyPair mldsa65keyPair;
+    private KeyPair mldsa87keyPair;
+    private byte[] mldsa44signature;
+    private byte[] mldsa65signature;
+    private byte[] mldsa87signature;
+    private byte[] payload;
+    private SecureRandom random = new SecureRandom();
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        mldsa44KeyPairGenerator = KeyPairGenerator.getInstance("ML-DSA-44", provider);
+        mldsa65KeyPairGenerator = KeyPairGenerator.getInstance("ML-DSA-65", provider);
+        mldsa87KeyPairGenerator = KeyPairGenerator.getInstance("ML-DSA-87", provider);
+
+        mldsa44SignatureInstance = Signature.getInstance("ML-DSA-44", provider);
+        mldsa65SignatureInstance = Signature.getInstance("ML-DSA-65", provider);
+        mldsa87SignatureInstance = Signature.getInstance("ML-DSA-87", provider);
+
+        mldsa44VerifierInstance = Signature.getInstance("ML-DSA-44", provider);
+        mldsa65VerifierInstance = Signature.getInstance("ML-DSA-65", provider);
+        mldsa87VerifierInstance = Signature.getInstance("ML-DSA-87", provider);
+
+        mldsa44keyPair = mldsa44KeyPairGenerator.generateKeyPair();
+        mldsa65keyPair = mldsa65KeyPairGenerator.generateKeyPair();
+        mldsa87keyPair = mldsa87KeyPairGenerator.generateKeyPair();
+
+        mldsa44SignatureInstance.initSign(mldsa44keyPair.getPrivate());
+        mldsa65SignatureInstance.initSign(mldsa65keyPair.getPrivate());
+        mldsa87SignatureInstance.initSign(mldsa87keyPair.getPrivate());
+
+        payload = new byte[payloadSize];
+        random.nextBytes(payload);
+
+        mldsa44SignatureInstance.update(payload);
+        mldsa65SignatureInstance.update(payload);
+        mldsa87SignatureInstance.update(payload);
+
+        mldsa44signature = mldsa44SignatureInstance.sign();
+        mldsa65signature = mldsa65SignatureInstance.sign();
+        mldsa87signature = mldsa87SignatureInstance.sign();
+    }
+
+    @Benchmark
+    public KeyPair mldsa44KeyGeneration() throws Exception {
+        return mldsa44KeyPairGenerator.generateKeyPair();
+    }
+
+    @Benchmark
+    public KeyPair mldsa65KeyGeneration() throws Exception {
+        return mldsa65KeyPairGenerator.generateKeyPair();
+    }
+
+    @Benchmark
+    public KeyPair mldsa87KeyGeneration() throws Exception {
+        return mldsa87KeyPairGenerator.generateKeyPair();
+    }
+
+    @Benchmark
+    public byte[] mldsa44Sign() throws Exception {
+        mldsa44SignatureInstance.initSign(mldsa44keyPair.getPrivate());
+        mldsa44SignatureInstance.update(payload);
+        return mldsa44SignatureInstance.sign();
+    }
+
+    @Benchmark
+    public byte[] mldsa65Sign() throws Exception {
+        mldsa65SignatureInstance.initSign(mldsa65keyPair.getPrivate());
+        mldsa65SignatureInstance.update(payload);
+        return mldsa65SignatureInstance.sign();
+    }
+
+    @Benchmark
+    public byte[] mldsa87Sign() throws Exception {
+        mldsa87SignatureInstance.initSign(mldsa87keyPair.getPrivate());
+        mldsa87SignatureInstance.update(payload);
+        return mldsa87SignatureInstance.sign();
+    }
+
+    @Benchmark
+    public boolean mldsa44Verify() throws Exception {
+        mldsa44VerifierInstance.initVerify(mldsa44keyPair.getPublic());
+        mldsa44VerifierInstance.update(payload);
+        return mldsa44VerifierInstance.verify(mldsa44signature);
+    }
+
+    @Benchmark
+    public boolean mldsa65Verify() throws Exception {
+        mldsa65VerifierInstance.initVerify(mldsa65keyPair.getPublic());
+        mldsa65VerifierInstance.update(payload);
+        return mldsa65VerifierInstance.verify(mldsa65signature);
+    }
+
+    @Benchmark
+    public boolean mldsa87Verify() throws Exception {
+        mldsa87VerifierInstance.initVerify(mldsa87keyPair.getPublic());
+        mldsa87VerifierInstance.update(payload);
+        return mldsa87VerifierInstance.verify(mldsa87signature);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = MLDSABenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/MLKEMBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/MLKEMBenchmark.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.concurrent.TimeUnit;
+import javax.crypto.KEM;
+import javax.crypto.SecretKey;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class MLKEMBenchmark extends JMHBase {
+
+    @Param({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+    private String transformation;
+
+    @Param({"OpenJCEPlus", "SunJCE"})
+    private String provider;
+
+    private KEM myKEM;
+    private KeyPair keyPair;
+    private KeyPairGenerator keyPairGen;
+    private KEM.Encapsulator encapsulator;
+    private KEM.Encapsulated encapsulated;
+    private KEM.Decapsulator decapsulator;
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        myKEM = KEM.getInstance(transformation, provider);
+        keyPairGen = KeyPairGenerator.getInstance(transformation, provider);
+        keyPair = keyPairGen.generateKeyPair();
+        keyPair.getPublic();
+        keyPair.getPrivate();
+        encapsulator = myKEM.newEncapsulator(keyPair.getPublic());
+        encapsulated = encapsulator.encapsulate(0, 31, "AES");
+        decapsulator = myKEM.newDecapsulator(keyPair.getPrivate());
+    }
+
+    @Benchmark
+    public SecretKey encapsulation() throws Exception {
+        encapsulated = encapsulator.encapsulate(0, 31, "AES");
+        return encapsulated.key();
+    }
+
+    @Benchmark
+    public SecretKey decapsulation() throws Exception {
+        return decapsulator.decapsulate(encapsulated.encapsulation(), 0, 31, "AES");
+    }
+
+    @Benchmark
+    public SecretKey encapsulationAndDecapsulation() throws Exception {
+        encapsulated = encapsulator.encapsulate(0, 31, "AES");
+        return decapsulator.decapsulate(encapsulated.encapsulation(), 0, 31, "AES");
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = MLKEMBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/MessageDigestBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/MessageDigestBenchmark.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class MessageDigestBenchmark extends JMHBase {
+
+    @Param({"16", "2048", "32768"})
+    private int payloadSize;
+
+    @Param({"OpenJCEPlus", "SUN"})
+    private String provider;
+
+    private MessageDigest messageDigestSHA512;
+    private MessageDigest messageDigestSHA512_224;
+    private MessageDigest messageDigestSHA512_256;
+    private MessageDigest messageDigestSHA256;
+    private MessageDigest messageDigestMD5;
+    private MessageDigest messageDigestSHA1;
+    private byte[] payload;
+    protected SecureRandom random = new SecureRandom();
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        payload = new byte[payloadSize];
+        random.nextBytes(payload);
+        messageDigestSHA512 = MessageDigest.getInstance("SHA-512", provider);
+        messageDigestSHA512_224 = MessageDigest.getInstance("SHA512/224", provider);
+        messageDigestSHA512_256 = MessageDigest.getInstance("SHA512/256", provider);
+        messageDigestSHA256 = MessageDigest.getInstance("SHA-256", provider);
+        messageDigestMD5 = MessageDigest.getInstance("MD5", provider);
+        messageDigestSHA1 = MessageDigest.getInstance("SHA1", provider);
+    }
+
+    @Benchmark
+    public byte[] sha512UpdateDigest() {
+        messageDigestSHA512.update(payload);
+        return messageDigestSHA512.digest();
+    }
+
+    @Benchmark
+    public byte[] sha512_224UpdateDigest() {
+        messageDigestSHA512_224.update(payload);
+        return messageDigestSHA512_224.digest();
+    }
+
+    @Benchmark
+    public byte[] sha512_256UpdateDigest() {
+        messageDigestSHA512_256.update(payload);
+        return messageDigestSHA512_256.digest();
+    }
+
+    @Benchmark
+    public byte[] sha256UpdateDigest() {
+        messageDigestSHA256.update(payload);
+        return messageDigestSHA256.digest();
+    }
+
+    @Benchmark
+    public byte[] md5UpdateDigest() {
+        messageDigestMD5.update(payload);
+        return messageDigestMD5.digest();
+    }
+
+    @Benchmark
+    public byte[] sha1UpdateDigest() {
+        messageDigestSHA1.update(payload);
+        return messageDigestSHA1.digest();
+    }
+
+    @Benchmark
+    public byte[] sha512SingleShotDigest() {
+        return messageDigestSHA512.digest(payload);
+    }
+
+    @Benchmark
+    public byte[] sha256SingleShotDigest() {
+        return messageDigestSHA256.digest(payload);
+    }
+
+    @Benchmark
+    public byte[] md5SingleShotDigest() {
+        return messageDigestMD5.digest(payload);
+    }
+
+    @Benchmark
+    public byte[] sha1SingleShotDigest() {
+        return messageDigestSHA1.digest(payload);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = MessageDigestBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/MessageDigestInstanceBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/MessageDigestInstanceBenchmark.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class MessageDigestInstanceBenchmark extends JMHBase {
+
+    @Param({"1"})
+    private int payloadSize;
+
+    @Param({"OpenJCEPlus", "SUN"})
+    private String provider;
+
+    private MessageDigest messageDigestSHA512;
+    private MessageDigest messageDigestSHA256;
+    private MessageDigest messageDigestMD5;
+    private MessageDigest messageDigestSHA1;
+    private byte[] payload;
+    protected SecureRandom random = new SecureRandom();
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+        payload = new byte[payloadSize];
+        random.nextBytes(payload);
+    }
+
+    @Benchmark
+    public byte[] sha512Instance() throws Exception {
+        messageDigestSHA512 = MessageDigest.getInstance("SHA-512", provider);
+        return messageDigestSHA512.digest(payload);
+    }
+
+    @Benchmark
+    public byte[] sha256Instance() throws Exception {
+        messageDigestSHA256 = MessageDigest.getInstance("SHA-256", provider);
+        return messageDigestSHA256.digest(payload);
+    }
+
+    @Benchmark
+    public byte[] md5Instance() throws Exception {
+        messageDigestMD5 = MessageDigest.getInstance("MD5", provider);
+        return messageDigestMD5.digest(payload);
+    }
+
+    @Benchmark
+    public byte[] sha1Instance() throws Exception {
+        messageDigestSHA1 = MessageDigest.getInstance("SHA1", provider);
+        return messageDigestSHA1.digest(payload);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = MessageDigestInstanceBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/PBKDF2Benchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/PBKDF2Benchmark.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.util.concurrent.TimeUnit;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class PBKDF2Benchmark extends JMHBase {
+    private SecretKeyFactory pbkdf2Sha1Factory;
+    private SecretKeyFactory pbkdf2Sha256Factory;
+    private SecretKeyFactory pbkdf2Sha512Factory;
+    private char[] password;
+    private byte[] salt = new byte[16];
+    private SecureRandom random = new SecureRandom();
+
+    @Param({"OpenJCEPlus", "SunJCE"})
+    private String provider;
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        pbkdf2Sha1Factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1", provider);
+        pbkdf2Sha256Factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256", provider);
+        pbkdf2Sha512Factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA512", provider);
+        password = "lazydogjumpedoverthemoon".toCharArray();
+        random.nextBytes(salt);
+    }
+
+    @Benchmark
+    public byte[] pbkdf2Sha11000Iter() throws InvalidKeySpecException {
+        return pbkdf2Sha1Factory.generateSecret(new PBEKeySpec(password, salt, 1000, 256))
+                .getEncoded();
+    }
+
+    @Benchmark
+    public byte[] pbkdf2Sha1300000Iter() throws InvalidKeySpecException {
+        return pbkdf2Sha1Factory.generateSecret(new PBEKeySpec(password, salt, 300000, 256))
+                .getEncoded();
+    }
+
+    @Benchmark
+    public byte[] pbkdf2Sha2561000Iter() throws InvalidKeySpecException {
+        return pbkdf2Sha256Factory.generateSecret(new PBEKeySpec(password, salt, 1000, 256))
+                .getEncoded();
+    }
+
+    @Benchmark
+    public byte[] pbkdf2Sha256300000Iter() throws InvalidKeySpecException {
+        return pbkdf2Sha256Factory.generateSecret(new PBEKeySpec(password, salt, 300000, 256))
+                .getEncoded();
+    }
+
+    @Benchmark
+    public byte[] pbkdf2Sha5121000Iter() throws InvalidKeySpecException {
+        return pbkdf2Sha512Factory.generateSecret(new PBEKeySpec(password, salt, 1000, 256))
+                .getEncoded();
+    }
+
+    @Benchmark
+    public byte[] pbkdf2Sha512300000Iter() throws InvalidKeySpecException {
+        return pbkdf2Sha512Factory.generateSecret(new PBEKeySpec(password, salt, 300000, 256))
+                .getEncoded();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = PBKDF2Benchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/RSAKeyGeneratorBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/RSAKeyGeneratorBenchmark.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class RSAKeyGeneratorBenchmark extends JMHBase {
+
+    @Param({"OpenJCEPlus", "SunRsaSign"})
+    private String provider;
+
+    private KeyPairGenerator rsaKeyPairGenerator1024 = null;
+    private KeyPairGenerator rsaKeyPairGenerator2048 = null;
+    private KeyPairGenerator rsaKeyPairGenerator4096 = null;
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        rsaKeyPairGenerator1024 = KeyPairGenerator.getInstance("RSA", provider);
+        rsaKeyPairGenerator1024.initialize(1024);
+        rsaKeyPairGenerator2048 = KeyPairGenerator.getInstance("RSA", provider);
+        rsaKeyPairGenerator2048.initialize(2048);
+        rsaKeyPairGenerator4096 = KeyPairGenerator.getInstance("RSA", provider);
+        rsaKeyPairGenerator4096.initialize(4096);
+    }
+
+    @Benchmark
+    public KeyPair rsa1024KeyGeneration() throws Exception {
+        return rsaKeyPairGenerator1024.generateKeyPair();
+    }
+
+    @Benchmark
+    public KeyPair rsa2048KeyGeneration() throws Exception {
+        return rsaKeyPairGenerator2048.generateKeyPair();
+    }
+
+    @Benchmark
+    public KeyPair rsa4096KeyGeneration() throws Exception {
+        return rsaKeyPairGenerator4096.generateKeyPair();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = RSAKeyGeneratorBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/RSASignatureBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/RSASignatureBenchmark.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.security.Signature;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class RSASignatureBenchmark extends JMHBase {
+
+    @Param({"2048", "32768"})
+    private int payloadSize;
+
+    @Param({"OpenJCEPlus", "SunRsaSign"})
+    private String provider;
+
+    @Param({"2048", "4096"})
+    private int keySize;
+
+    private KeyPairGenerator rsaKeyPairGenerator;
+    private Signature rsaSha256SignatureInstance;
+    private Signature rsaSha384SignatureInstance;
+    private Signature rsaSha512SignatureInstance;
+    private Signature rsaSha256VerifierInstance;
+    private Signature rsaSha384VerifierInstance;
+    private Signature rsaSha512VerifierInstance;
+    private KeyPair rsaKeyPair;
+    private byte[] rsaSha256signature;
+    private byte[] rsaSha384signature;
+    private byte[] rsaSha512signature;
+    private byte[] payload;
+    private SecureRandom random = new SecureRandom();
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        rsaKeyPairGenerator = KeyPairGenerator.getInstance("RSA", provider);
+        rsaKeyPairGenerator.initialize(keySize);
+
+        rsaSha256SignatureInstance = Signature.getInstance("SHA256withRSA", provider);
+        rsaSha384SignatureInstance = Signature.getInstance("SHA384withRSA", provider);
+        rsaSha512SignatureInstance = Signature.getInstance("SHA512withRSA", provider);
+
+        rsaSha256VerifierInstance = Signature.getInstance("SHA256withRSA", provider);
+        rsaSha384VerifierInstance = Signature.getInstance("SHA384withRSA", provider);
+        rsaSha512VerifierInstance = Signature.getInstance("SHA512withRSA", provider);
+
+        rsaKeyPair = rsaKeyPairGenerator.generateKeyPair();
+
+        rsaSha256SignatureInstance.initSign(rsaKeyPair.getPrivate());
+        rsaSha384SignatureInstance.initSign(rsaKeyPair.getPrivate());
+        rsaSha512SignatureInstance.initSign(rsaKeyPair.getPrivate());
+
+        payload = new byte[payloadSize];
+        random.nextBytes(payload);
+
+        rsaSha256SignatureInstance.update(payload);
+        rsaSha384SignatureInstance.update(payload);
+        rsaSha512SignatureInstance.update(payload);
+
+        rsaSha256signature = rsaSha256SignatureInstance.sign();
+        rsaSha384signature = rsaSha384SignatureInstance.sign();
+        rsaSha512signature = rsaSha512SignatureInstance.sign();
+    }
+
+    @Benchmark
+    public byte[] rsaSha256Sign() throws Exception {
+        rsaSha256SignatureInstance.initSign(rsaKeyPair.getPrivate());
+        rsaSha256SignatureInstance.update(payload);
+        return rsaSha256SignatureInstance.sign();
+    }
+
+    @Benchmark
+    public byte[] rsaSha384Sign() throws Exception {
+        rsaSha384SignatureInstance.initSign(rsaKeyPair.getPrivate());
+        rsaSha384SignatureInstance.update(payload);
+        return rsaSha384SignatureInstance.sign();
+    }
+
+    @Benchmark
+    public byte[] rsaSha512Sign() throws Exception {
+        rsaSha512SignatureInstance.initSign(rsaKeyPair.getPrivate());
+        rsaSha512SignatureInstance.update(payload);
+        return rsaSha512SignatureInstance.sign();
+    }
+
+    @Benchmark
+    public boolean rsaSha256Verify() throws Exception {
+        rsaSha256VerifierInstance.initVerify(rsaKeyPair.getPublic());
+        rsaSha256VerifierInstance.update(payload);
+        return rsaSha256VerifierInstance.verify(rsaSha256signature);
+    }
+
+    @Benchmark
+    public boolean rsaSha384Verify() throws Exception {
+        rsaSha384VerifierInstance.initVerify(rsaKeyPair.getPublic());
+        rsaSha384VerifierInstance.update(payload);
+        return rsaSha384VerifierInstance.verify(rsaSha384signature);
+    }
+
+    @Benchmark
+    public boolean rsaSha512Verify() throws Exception {
+        rsaSha512VerifierInstance.initVerify(rsaKeyPair.getPublic());
+        rsaSha512VerifierInstance.update(payload);
+        return rsaSha512VerifierInstance.verify(rsaSha512signature);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = RSASignatureBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/RandomBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/RandomBenchmark.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class RandomBenchmark extends JMHBase {
+
+    @Param({"16", "2048", "32768"})
+    private int payloadSize;
+
+    private byte[] payload;
+
+    private SecureRandom randomOpenJCEPlusSHA256DRBG;
+    private SecureRandom randomOpenJCEPlusSHA512DRBG;
+    private SecureRandom randomSUNSHA1PRNG;
+    private SecureRandom randomSUNDRBG;
+    private SecureRandom random = new SecureRandom();
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider("OpenJCEPlus");
+        randomOpenJCEPlusSHA256DRBG = SecureRandom.getInstance("SHA256DRBG", "OpenJCEPlus");
+        randomOpenJCEPlusSHA512DRBG = SecureRandom.getInstance("SHA512DRBG", "OpenJCEPlus");
+        randomSUNSHA1PRNG = SecureRandom.getInstance("SHA1PRNG", "SUN");
+        randomSUNDRBG = SecureRandom.getInstance("DRBG", "SUN");
+        payload = new byte[payloadSize];
+        random.nextBytes(payload);
+    }
+
+    @Benchmark
+    public byte[] runOpenJCEPlusSHA256DRBG() {
+        randomOpenJCEPlusSHA256DRBG.nextBytes(payload);
+        return payload;
+    }
+
+    @Benchmark
+    public byte[] runOpenJCEPlusSHA512DRBG() {
+        randomOpenJCEPlusSHA512DRBG.nextBytes(payload);
+        return payload;
+    }
+
+    @Benchmark
+    public byte[] runSUNSHA1PRNG() {
+        randomSUNSHA1PRNG.nextBytes(payload);
+        return payload;
+    }
+
+    @Benchmark
+    public byte[] runSUNDRBG() {
+        randomSUNDRBG.nextBytes(payload);
+        return payload;
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = RandomBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/RunAll.java
+++ b/src/test/java/ibm/jceplus/jmh/RunAll.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+public class RunAll extends JMHBase {
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = optionsBuild("Benchmark", // Run all classes that have the word "Benchmark" in their name.
+                RunAll.class.getSimpleName());
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/X25519KeyExchangeBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/X25519KeyExchangeBenchmark.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.concurrent.TimeUnit;
+import javax.crypto.KeyAgreement;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class X25519KeyExchangeBenchmark extends JMHBase {
+
+    @Param({"OpenJCEPlus", "SunEC"})
+    private String provider;
+
+    private KeyPairGenerator x25519KeyPairGenerator;
+    private KeyAgreement x25519KeyAgreement;
+    private KeyPair bobX25519KeyPair;
+    private KeyPair aliceX25519KeyPair;
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        x25519KeyPairGenerator = KeyPairGenerator.getInstance("X25519", provider);
+        x25519KeyAgreement = KeyAgreement.getInstance("X25519", provider);
+
+        bobX25519KeyPair = x25519KeyPairGenerator.generateKeyPair();
+        aliceX25519KeyPair = x25519KeyPairGenerator.generateKeyPair();
+
+        x25519KeyAgreement.init(bobX25519KeyPair.getPrivate());
+    }
+
+    @Benchmark
+    public byte[] x25519KeyExchange() throws Exception {
+        x25519KeyAgreement.doPhase(aliceX25519KeyPair.getPublic(), true);
+        return x25519KeyAgreement.generateSecret();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = X25519KeyExchangeBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/X448KeyExchangeBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/X448KeyExchangeBenchmark.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.concurrent.TimeUnit;
+import javax.crypto.KeyAgreement;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class X448KeyExchangeBenchmark extends JMHBase {
+
+    @Param({"OpenJCEPlus", "SunEC"})
+    private String provider;
+
+    private KeyPairGenerator x448KeyPairGenerator;
+    private KeyAgreement x448KeyAgreement;
+    private KeyPair bobX448KeyPair;
+    private KeyPair aliceX448KeyPair;
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        x448KeyPairGenerator = KeyPairGenerator.getInstance("X448", provider);
+        x448KeyAgreement = KeyAgreement.getInstance("X448", provider);
+
+        bobX448KeyPair = x448KeyPairGenerator.generateKeyPair();
+        aliceX448KeyPair = x448KeyPairGenerator.generateKeyPair();
+
+        x448KeyAgreement.init(bobX448KeyPair.getPrivate());
+    }
+
+    @Benchmark
+    public byte[] x448KeyExchange() throws Exception {
+        x448KeyAgreement.doPhase(aliceX448KeyPair.getPublic(), true);
+        return x448KeyAgreement.generateSecret();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = X448KeyExchangeBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/XDHKeyExchangeBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/XDHKeyExchangeBenchmark.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.spec.NamedParameterSpec;
+import java.util.concurrent.TimeUnit;
+import javax.crypto.KeyAgreement;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class XDHKeyExchangeBenchmark extends JMHBase {
+
+    @Param({"OpenJCEPlus", "SunEC"})
+    private String provider;
+
+    @Param({"X25519", "X448"})
+    private String curveName;
+
+    private KeyPairGenerator xdhKeyPairGenerator;
+    private KeyAgreement xdhKeyAgreement;
+    private KeyPair bobKeyPair;
+    private KeyPair aliceKeyPair;
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        xdhKeyPairGenerator = KeyPairGenerator.getInstance("XDH", provider);
+        NamedParameterSpec namedSpec = new NamedParameterSpec(curveName);
+        xdhKeyPairGenerator.initialize(namedSpec);
+
+        xdhKeyAgreement = KeyAgreement.getInstance("XDH", provider);
+
+        bobKeyPair = xdhKeyPairGenerator.generateKeyPair();
+        aliceKeyPair = xdhKeyPairGenerator.generateKeyPair();
+
+        xdhKeyAgreement.init(bobKeyPair.getPrivate());
+    }
+
+    @Benchmark
+    public byte[] xdhKeyExchange() throws Exception {
+        xdhKeyAgreement.doPhase(aliceKeyPair.getPublic(), true);
+        return xdhKeyAgreement.generateSecret();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = XDHKeyExchangeBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/XDHKeyGeneratorBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/XDHKeyGeneratorBenchmark.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class XDHKeyGeneratorBenchmark extends JMHBase {
+
+    @Param({"OpenJCEPlus", "SunEC"})
+    private String provider;
+
+    private KeyPairGenerator x25519KeyPairGenerator = null;
+    private KeyPairGenerator x448KeyPairGenerator = null;
+
+    @Setup
+    public void setup() throws Exception {
+        insertProvider(provider);
+
+        x25519KeyPairGenerator = KeyPairGenerator.getInstance("X25519", provider);
+        x448KeyPairGenerator = KeyPairGenerator.getInstance("X448", provider);
+    }
+
+    @Benchmark
+    public KeyPair x25519KeyGeneration() throws Exception {
+        return x25519KeyPairGenerator.generateKeyPair();
+    }
+
+    @Benchmark
+    public KeyPair x448KeyGeneration() throws Exception {
+        return x448KeyPairGenerator.generateKeyPair();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = XDHKeyGeneratorBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/utils.groovy
+++ b/utils.groovy
@@ -1,0 +1,265 @@
+/*
+ * Checks whether OpenJCEPlus is buildable on this platform.
+ *
+ * @return  Whether OpenJCEPlus is buildable on the platform
+ */
+def isBuildable(hardware, software) {
+    return ((software == "aix")
+        || ((software == "linux") && ((hardware == "x86-64")
+                                   || (hardware == "ppc64le")
+                                   || (hardware == "s390x")
+                                   || (hardware == "aarch64")))
+        || ((software == "mac") && ((hardware == "aarch64")
+                                 || (hardware == "x86-64")))
+        || ((software == "windows") && (hardware == "x86-64")))
+
+}
+
+/*
+ * Get the proper representation of the platform for OCK.
+ *
+ * @return  The proper representation of the platform for OCK
+ */
+def getOCKTarget(hardware, software) {
+    def target = ""
+
+    /*
+     * Based on the specific hardware and software, pick the
+     * appropriate option to use when getting OCK binaries to
+     * set up the environment for the build.
+     */
+    if (software == "aix") {
+        target = "aix64_ppc"
+    } else if (software == "linux") {
+        if (hardware == "x86-64") {
+            target = "linux64_x86"
+        } else if (hardware == "ppc64le") {
+            target = "linux64_ppcle"
+        } else if (hardware == "s390x") {
+            target = "linux64_s390"
+        } else if (hardware == "aarch64") {
+            target = "linux64_arm"
+        }
+    } else if (software == "mac") {
+        if (hardware == "aarch64") {
+            target = "osx64_arm"
+        } else if (hardware == "x86-64") {
+            target = "osx64_x86"
+        }
+    } else if (software == "windows") {
+        if (hardware == "x86-64") {
+            target = "win64_x86"
+        }
+    }
+
+    return target
+}
+
+/*
+ * Figure out the proper URL, get the OCK binaries,
+ * extract them and copy the files to the required
+ * locations.
+ */
+def getBinaries(hardware, software) {
+    if (OCK_RELEASE == "") {
+        OCK_RELEASE = "20250823_8.9.14"
+    }
+    def target = getOCKTarget(hardware, software)
+    def gskit_bin = "https://na.artifactory.swg-devops.com/artifactory/sec-gskit-javasec-generic-local/gskit8/$OCK_RELEASE/$target/jgsk_crypto.tar"
+    def gskit_sdk_bin = "https://na.artifactory.swg-devops.com/artifactory/sec-gskit-javasec-generic-local/gskit8/$OCK_RELEASE/$target/jgsk_crypto_sdk.tar"
+    
+    // If user has specified OCK_FULL_URL, override default location.
+    def ockUrl = OCK_FULL_URL
+    if (ockUrl != "") {
+        gskit_bin = "${ockUrl}/jgsk_crypto.tar"
+        gskit_sdk_bin = "${ockUrl}/jgsk_crypto_sdk.tar"
+    }
+    dir("openjceplus/OCK") {
+        withCredentials([usernamePassword(credentialsId: '7c1c2c28-650f-49e0-afd1-ca6b60479546', passwordVariable: 'GSKIT_PASSWORD', usernameVariable: 'GSKIT_USERNAME')]) {
+            sh "curl -u $GSKIT_USERNAME:$GSKIT_PASSWORD $gskit_bin > jgsk_crypto.tar"
+            sh "curl -u $GSKIT_USERNAME:$GSKIT_PASSWORD $gskit_sdk_bin > jgsk_crypto_sdk.tar"
+        }
+        untar file: 'jgsk_crypto.tar'
+        untar file: 'jgsk_crypto_sdk.tar'
+
+        def jgsk8Lib = 'libjgsk8iccs_64.so'
+        if (target.contains('osx')) {
+            jgsk8Lib = 'libjgsk8iccs.dylib'
+        } else if (target.contains('win')) {
+            jgsk8Lib = 'jgsk8iccs_64.dll'
+        }
+        fileOperations([fileCopyOperation(includes: jgsk8Lib, targetLocation: 'jgsk_sdk/lib64')])
+
+        // Additional copy is required
+        if (target.contains('aix')) {
+            fileOperations([fileCopyOperation(includes: jgsk8Lib, targetLocation: 'jgsk_sdk')])
+        }
+    }
+}
+
+/*
+ * Figure out the proper URL, get the Semeru JDK,
+ * extract it and rename the containing folder to
+ * be used later on.
+ */
+def getJava(hardware, software) {
+    def extension = "tar.gz"
+    if (software == "windows") {
+        extension = "zip"
+    }
+
+    if (hardware == "x86-64") {
+        hardware = "x64"
+    }
+
+    def java_link = ""
+    if (JAVA_RELEASE == "") {
+        java_link = "https://api.adoptopenjdk.net/v3/binary/latest/${JAVA_VERSION}/ga/${software}/${hardware}/jdk/openj9/normal/ibm?project=jdk"
+    } else {
+        def java_release_link = JAVA_RELEASE.replace("+", "%2B")
+        java_link = "https://api.adoptopenjdk.net/v3/binary/version/${java_release_link}/${software}/${hardware}/jdk/openj9/normal/ibm?project=jdk"
+    }
+
+    dir("java") {
+        sh "curl -LJkO ${java_link}"
+        def java_file = sh (
+            script: 'ls | grep \'tar\\|zip\'',
+            returnStdout: true
+        ).trim()
+
+       if (software == "windows") {
+            unzip zipFile: "$java_file"
+        } else {
+            untar file: "$java_file"
+        }
+        sh "rm $java_file"
+
+        def java_folder = sh (
+            script: "ls | grep \'jdk-${JAVA_VERSION}\'",
+            returnStdout: true
+        ).trim()
+        fileOperations([folderRenameOperation(destination: 'jdk', source: "$java_folder")])
+
+        // AIX always loads the bundled version of native libraries. We delete them to
+        // ensure that the one provided by the user is utilized.
+        if (software == "aix") {
+            fileOperations([fileDeleteOperation(excludes: '', includes: 'jdk/lib/libjgsk8iccs_64.so'),
+                            fileDeleteOperation(excludes: '', includes: 'jdk/lib/libjgskit.so'),
+                            folderDeleteOperation('jdk/lib/C'),
+                            folderDeleteOperation('jdk/lib/N')])
+        }
+    }
+}
+
+/*
+ * Get the Maven tool and extract it.
+ */
+def getMaven() {
+    sh "curl -kLO https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.tar.gz"
+    untar file: "apache-maven-3.9.10-bin.tar.gz"
+}
+
+/*
+ * Export the appropriate environment variables
+ * and run the requested maven commands.
+ */
+def runOpenJCEPlus(command, software) {
+    dir("openjceplus/OpenJCEPlus") {
+        def additional_exports = ""
+        if (software == "aix") {
+            additional_exports = "export LIBPATH=$WORKSPACE/openjceplus/OCK/:$WORKSPACE/openjceplus/OCK/jgsk_sdk;"
+        }
+
+        def additional_envars = ADDITIONAL_ENVARS
+        if (additional_envars != "") {
+            for (envar in additional_envars.split(",")) {
+                additional_exports += " export ${envar.trim()};"
+            }
+            
+        }
+
+        def java_home = "export JAVA_HOME=$WORKSPACE/java/jdk;"
+        def gskit_home = "export GSKIT_HOME=$WORKSPACE/openjceplus/OCK/jgsk_sdk;"
+        def environment = "export PATH=$WORKSPACE/apache-maven-3.9.10/bin:\$PATH;"
+        def ock_path = "$WORKSPACE/openjceplus/OCK/"
+        if (software == "windows") {
+            ock_path = "$WORKSPACE\\openjceplus\\OCK\\"
+            bat """
+               dir "c:\\Program Files\\Microsoft Visual Studio\\2022\\Professional\\VC\\Auxiliary\\Build\\vcvarsall.bat"
+               call "c:\\Program Files\\Microsoft Visual Studio\\2022\\Professional\\VC\\Auxiliary\\Build\\vcvarsall.bat" x86_amd64
+               set "JAVA_HOME=$WORKSPACE\\java\\jdk"
+               set "PATH=$WORKSPACE\\apache-maven-3.9.10\\bin;%JAVA_HOME%;%PATH%"
+               set "GSKIT_HOME=$WORKSPACE\\openjceplus\\OCK\\jgsk_sdk"
+               echo PATH: %PATH%
+               echo GSKIT_HOME: %GSKIT_HOME%
+               echo JAVA_HOME: %JAVA_HOME%
+               echo mvn -Dock.library.path=${ock_path} --batch-mode ${command}
+               $WORKSPACE\\apache-maven-3.9.10\\bin\\mvn -Dock.library.path=${ock_path} --batch-mode ${command}
+               """
+        } else if (software == "mac") {
+            java_home = "export JAVA_HOME=$WORKSPACE/java/jdk/Contents/Home;"
+        }
+
+        if (software != "windows") {
+            sh "${java_home} ${gskit_home} ${additional_exports} ${environment} mvn '-Dock.library.path=${ock_path}' --batch-mode ${command}"
+        }
+    }
+}
+
+/*
+ * Upload the compressed build into Artifactory.
+ *
+ * @param uploadSpec    This is the struct containing the upload specification
+ * @return              The URL of the server used to upload
+ */
+def upload_artifactory(uploadSpec) {
+    echo "Uploading to artifactory..."
+    // Specify the Artifactory server to be used.
+    def server = Artifactory.server 'na-public.artifactory.swg-devops'
+    // Set connection timeout to 10 mins to avoid timeout on slow platforms.
+    server.connection.timeout = 600
+
+    // Create build info for this pipeline.
+    def buildInfo = Artifactory.newBuildInfo()
+    buildInfo.retention maxBuilds: 30, maxDays: 60, deleteBuildArtifacts: true
+    buildInfo.env.capture = true
+    buildInfo.name = "sys-rt/" + buildInfo.name
+
+    // Upload to Artifactory and retry  if errors occur
+    def ret = false
+    retry(3) {
+        if (ret) {
+            sleep time: 300, unit: 'SECONDS'
+        } else {
+            ret = true
+        }
+        server.upload spec: uploadSpec, buildInfo: buildInfo
+        server.publishBuildInfo buildInfo
+    }
+
+    return server.getUrl()
+}
+
+/* 
+ * Returns a formatted directory name based upon a branch name.
+ */
+def getSanitizedBranchName() {
+    SANITIZED_BRANCH_NAME=sh(
+        script: "echo $env.GIT_BRANCH | tr -c '[:alpha:][:digit:][.]' '-' | tr -d '\r\n' | sed 's/.\$//'",
+        returnStdout: true
+    ).trim()
+    return SANITIZED_BRANCH_NAME
+}
+
+return [
+    getPlatforms: this.&getPlatforms,
+    isBuildable: this.&isBuildable,
+    getOCKTarget: this.&getOCKTarget,
+    getBinaries: this.&getBinaries,
+    getJava: this.&getJava,
+    getMaven: this.&getMaven,
+    cloneOpenJCEPlus: this.&cloneOpenJCEPlus,
+    runOpenJCEPlus: this.&runOpenJCEPlus,
+    upload_artifactory: this.&upload_artifactory,
+    getSanitizedBranchName: this.&getSanitizedBranchName,
+]


### PR DESCRIPTION
JMH performance updates are added to aid in comparing the SDK we are running with vs what is being delivered in OpenJCEPlus provider.

A new Jenkins performce pipeline is provided to ensure that we have the capability when desired to performance test a given update present in a PR.

A new common groovy library was created for logic that is common between the existing Jenkins pipeline that runs the builds and tests and the new performance specific Jenkins pipeline.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/671

Signed-off-by: Jason Katonica <katonica@us.ibm.com>
