### PR TITLE
Support PBKDF2WithHmacSHA512/224 and PBKDF2WithHmacSHA512/256

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,8 @@ SecretKeyFactory            | PBKDF2WithHmacSHA224       |X                |X   
 SecretKeyFactory            | PBKDF2WithHmacSHA256       |X                |X             |              |
 SecretKeyFactory            | PBKDF2WithHmacSHA384       |X                |X             |              |
 SecretKeyFactory            | PBKDF2WithHmacSHA512       |X                |X             |              |
+SecretKeyFactory            | PBKDF2WithHmacSHA512/224   |                 |X             |              |
+SecretKeyFactory            | PBKDF2WithHmacSHA512/256   |                 |X             |              |
 SecureRandom                | SHA256DRBG                 |X                |X             |              |
 SecureRandom                | SHA512DRBG                 |X                |X             |              |
 Signature                   | Ed25519                    |                 |X             |              |

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
@@ -50,6 +50,7 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
             + "                                       , HmacSHA3-224, HmacSHA3-256, HmacSHA3-384, HmacSHA3-512\n"
             + "Message digest                     : MD5, SHA-1, SHA-224, SHA-256, SHA-384, SHA-512, SHA-512/224, SHA-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512\n"
             + "Secret key factory                 : AES, ChaCha20, DESede, PBKDF2WithHmacSHA1, PBKDF2WithHmacSHA224, PBKDF2WithHmacSHA256, PBKDF2WithHmacSHA384, PBKDF2WithHmacSHA512\n"
+            + "                                       PBKDF2WithHmacSHA512/224, PBKDF2WithHmacSHA512/256\n"
             + "Secure random                      : HASHDRBG, SHA256DRBG, SHA512DRBG\n"
             + "Signature algorithms               : NONEwithDSA, SHA1withDSA, SHA224withDSA, SHA256withDSA,\n"
             + "                                       SHA3-224withDSA, SHA3-256withDSA, SHA3-384withDSA, SHA3-512withDSA,\n"
@@ -764,6 +765,20 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
                                      "SecretKeyFactory",
                                      "PBKDF2WithHmacSHA512",
                                      "com.ibm.crypto.plus.provider.PBKDF2Core$HmacSHA512",
+                                     aliases));
+        
+        aliases = null;
+        putService(new OpenJCEPlusService(jce,
+                                     "SecretKeyFactory",
+                                     "PBKDF2WithHmacSHA512/224",
+                                     "com.ibm.crypto.plus.provider.PBKDF2Core$HmacSHA512_224",
+                                     aliases));
+        
+        aliases = null;
+        putService(new OpenJCEPlusService(jce,
+                                     "SecretKeyFactory",
+                                     "PBKDF2WithHmacSHA512/256",
+                                     "com.ibm.crypto.plus.provider.PBKDF2Core$HmacSHA512_256",
                                      aliases));
 
         aliases = new String[] {"TripleDES", "3DES"};

--- a/src/main/java/com/ibm/crypto/plus/provider/PBKDF2Core.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PBKDF2Core.java
@@ -174,4 +174,16 @@ abstract class PBKDF2Core extends SecretKeyFactorySpi {
             super(provider, "HmacSHA512");
         }
     }
+
+    public static final class HmacSHA512_224 extends PBKDF2Core {
+        public HmacSHA512_224(OpenJCEPlusProvider provider) {
+            super(provider, "HmacSHA512/224");
+        }
+    }
+
+    public static final class HmacSHA512_256 extends PBKDF2Core {
+        public HmacSHA512_256(OpenJCEPlusProvider provider) {
+            super(provider, "HmacSHA512/256");
+        }
+    }
 }

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/PBKDF.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/PBKDF.java
@@ -29,13 +29,16 @@ public final class PBKDF {
     public static byte[] PBKDF2derive(OCKContext ockContext, String algorithmName,
             final byte[] password, byte[] salt, int iterations, int keyLength) throws OCKException {
 
-        if ((!algorithmName.equalsIgnoreCase("HmacSHA512"))
+        if ((!algorithmName.equalsIgnoreCase("HmacSHA512/224"))
+                && (!algorithmName.equalsIgnoreCase("HmacSHA512/256"))
+                && (!algorithmName.equalsIgnoreCase("HmacSHA512"))
                 && (!algorithmName.equalsIgnoreCase("HmacSHA384"))
                 && (!algorithmName.equalsIgnoreCase("HmacSHA256"))
                 && (!algorithmName.equalsIgnoreCase("HmacSHA224"))
                 && (!algorithmName.equalsIgnoreCase("HmacSHA1"))) {
             throw new OCKException("Algorithm name not recognized: " + algorithmName);
         }
+        algorithmName = algorithmName.replace("/", "-");
         String algorithmHashName = algorithmName.substring(4).toUpperCase();
 
         if (keyLength <= 0) {

--- a/src/test/java/ibm/jceplus/jmh/PBKDF2Benchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/PBKDF2Benchmark.java
@@ -36,6 +36,8 @@ public class PBKDF2Benchmark extends JMHBase {
     private SecretKeyFactory pbkdf2Sha1Factory;
     private SecretKeyFactory pbkdf2Sha256Factory;
     private SecretKeyFactory pbkdf2Sha512Factory;
+    private SecretKeyFactory pbkdf2Sha512_224Factory;
+    private SecretKeyFactory pbkdf2Sha512_256Factory;
     private char[] password;
     private byte[] salt = new byte[16];
     private SecureRandom random = new SecureRandom();
@@ -50,6 +52,8 @@ public class PBKDF2Benchmark extends JMHBase {
         pbkdf2Sha1Factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1", provider);
         pbkdf2Sha256Factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256", provider);
         pbkdf2Sha512Factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA512", provider);
+        pbkdf2Sha512_224Factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA512/224", provider);
+        pbkdf2Sha512_256Factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA512/256", provider);
         password = "lazydogjumpedoverthemoon".toCharArray();
         random.nextBytes(salt);
     }
@@ -87,6 +91,30 @@ public class PBKDF2Benchmark extends JMHBase {
     @Benchmark
     public byte[] pbkdf2Sha512300000Iter() throws InvalidKeySpecException {
         return pbkdf2Sha512Factory.generateSecret(new PBEKeySpec(password, salt, 300000, 256))
+                .getEncoded();
+    }
+
+    @Benchmark
+    public byte[] pbkdf2Sha512_2241000Iter() throws InvalidKeySpecException {
+        return pbkdf2Sha512_224Factory.generateSecret(new PBEKeySpec(password, salt, 1000, 256))
+                .getEncoded();
+    }
+
+    @Benchmark
+    public byte[] pbkdf2Sha512_224300000Iter() throws InvalidKeySpecException {
+        return pbkdf2Sha512_224Factory.generateSecret(new PBEKeySpec(password, salt, 300000, 256))
+                .getEncoded();
+    }
+
+    @Benchmark
+    public byte[] pbkdf2Sha512_2561000Iter() throws InvalidKeySpecException {
+        return pbkdf2Sha512_256Factory.generateSecret(new PBEKeySpec(password, salt, 1000, 256))
+                .getEncoded();
+    }
+
+    @Benchmark
+    public byte[] pbkdf2Sha512_256300000Iter() throws InvalidKeySpecException {
+        return pbkdf2Sha512_256Factory.generateSecret(new PBEKeySpec(password, salt, 300000, 256))
                 .getEncoded();
     }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPBKDF2Interop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPBKDF2Interop.java
@@ -50,7 +50,7 @@ public class BaseTestPBKDF2Interop extends BaseTestJunit5Interop {
      */
     @ParameterizedTest
     @CsvSource({"PBKDF2WithHmacSHA1", "PBKDF2WithHmacSHA224", "PBKDF2WithHmacSHA256",
-            "PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512"})
+            "PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512", "PBKDF2WithHmacSHA512/224", "PBKDF2WithHmacSHA512/256"})
     public void testGetAlgorithm(String algorithm) throws Exception {
 
         if ((!isSupportedByOpenJCEPlusFIPS(algorithm))
@@ -74,7 +74,7 @@ public class BaseTestPBKDF2Interop extends BaseTestJunit5Interop {
      */
     @ParameterizedTest
     @CsvSource({"PBKDF2WithHmacSHA1", "PBKDF2WithHmacSHA224", "PBKDF2WithHmacSHA256",
-            "PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512"})
+            "PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512", "PBKDF2WithHmacSHA512/224", "PBKDF2WithHmacSHA512/256"})
     public void testGetEncoding(String algorithm) throws Exception {
 
         if ((!isSupportedByOpenJCEPlusFIPS(algorithm))
@@ -98,7 +98,7 @@ public class BaseTestPBKDF2Interop extends BaseTestJunit5Interop {
      */
     @ParameterizedTest
     @CsvSource({"PBKDF2WithHmacSHA1", "PBKDF2WithHmacSHA224", "PBKDF2WithHmacSHA256",
-            "PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512"})
+            "PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512", "PBKDF2WithHmacSHA512/224", "PBKDF2WithHmacSHA512/256"})
     public void testTranslate(String algorithm) throws Exception {
 
         if ((!isSupportedByOpenJCEPlusFIPS(algorithm))
@@ -130,7 +130,7 @@ public class BaseTestPBKDF2Interop extends BaseTestJunit5Interop {
      */
     @ParameterizedTest
     @CsvSource({"PBKDF2WithHmacSHA1", "PBKDF2WithHmacSHA224", "PBKDF2WithHmacSHA256",
-            "PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512"})
+            "PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512", "PBKDF2WithHmacSHA512/224", "PBKDF2WithHmacSHA512/256"})
     public void testKeySpec(String algorithm) throws Exception {
 
         if ((!isSupportedByOpenJCEPlusFIPS(algorithm))
@@ -161,7 +161,7 @@ public class BaseTestPBKDF2Interop extends BaseTestJunit5Interop {
      */
     @ParameterizedTest
     @CsvSource({"PBKDF2WithHmacSHA1", "PBKDF2WithHmacSHA224", "PBKDF2WithHmacSHA256",
-            "PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512"})
+            "PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512", "PBKDF2WithHmacSHA512/224", "PBKDF2WithHmacSHA512/256"})
     public void testHashCode(String algorithm) throws Exception {
 
         if ((!isSupportedByOpenJCEPlusFIPS(algorithm))
@@ -183,7 +183,7 @@ public class BaseTestPBKDF2Interop extends BaseTestJunit5Interop {
      */
     @ParameterizedTest
     @CsvSource({"PBKDF2WithHmacSHA1", "PBKDF2WithHmacSHA224", "PBKDF2WithHmacSHA256",
-            "PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512"})
+            "PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512", "PBKDF2WithHmacSHA512/224", "PBKDF2WithHmacSHA512/256"})
     public void testEquality(String algorithm) throws Exception {
 
         if ((!isSupportedByOpenJCEPlusFIPS(algorithm))
@@ -210,7 +210,7 @@ public class BaseTestPBKDF2Interop extends BaseTestJunit5Interop {
      */
     @ParameterizedTest
     @CsvSource({"PBKDF2WithHmacSHA1", "PBKDF2WithHmacSHA224", "PBKDF2WithHmacSHA256",
-            "PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512"})
+            "PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512", "PBKDF2WithHmacSHA512/224", "PBKDF2WithHmacSHA512/256"})
     public void testGetFormat(String algorithm) throws Exception {
 
         if ((!isSupportedByOpenJCEPlusFIPS(algorithm))


### PR DESCRIPTION
This update adds support for both PBKDF2WithHmacSHA512/224 and PBKDF2WithHmacSHA512/256 SecretKeyFactory algorithms. These algorithms were only added to OpenJCEPlus and are not yet available in OpenJCEPlusFIPS.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/816

Signed-off-by: Dev Agarwal [dev.agarwal@ibm.com](mailto:dev.agarwal@ibm.com)