### PR TITLE
Fix typos and whitespace issues

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -34,5 +34,6 @@
         <module name="StringLiteralEquality"/>
         <module name="UnusedImports"/>
         <module name="UnusedLocalVariable"/>
+        <module name="WhitespaceAfter"/>
     </module>
 </module>

--- a/src/main/java/com/ibm/crypto/plus/provider/AESKeyWrapCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKeyWrapCipher.java
@@ -76,7 +76,7 @@ abstract class AESKeyWrapCipher extends CipherSpi {
             byte[] temp = new byte[newSize];
             if (buffer != null && bufSize > 0) {
                 System.arraycopy(buffer, 0, temp, 0, bufSize);
-                Arrays.fill(buffer, (byte)0x00);
+                Arrays.fill(buffer, (byte) 0x00);
             }
             buffer = temp;
         }
@@ -117,7 +117,7 @@ abstract class AESKeyWrapCipher extends CipherSpi {
             throw new ProviderException("Operation doFinal failed", ocke);
         }
         this.bufSize = 0;
-        Arrays.fill(buffer, (byte)0x00);
+        Arrays.fill(buffer, (byte) 0x00);
         this.buffer = null;
         return out;
     }
@@ -147,7 +147,7 @@ abstract class AESKeyWrapCipher extends CipherSpi {
 
         } finally {
             if (out != null) {
-                Arrays.fill(out, (byte)0);
+                Arrays.fill(out, (byte) 0x00);
             }
         }
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/MLKEMImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/MLKEMImpl.java
@@ -98,7 +98,8 @@ public class MLKEMImpl implements KEMSpi {
             }
 
             try {
-                OJPKEM.KEM_encapsulate(provider.getOCKContext(),((PQCPublicKey) publicKey).getPQCKey().getPKeyId(), encapsulation, secret);
+                OJPKEM.KEM_encapsulate(provider.getOCKContext(),
+                        ((PQCPublicKey) publicKey).getPQCKey().getPKeyId(), encapsulation, secret);
             } catch (OCKException e) {
                 throw new ProviderException("OCK Exception: ", e);
             }
@@ -160,7 +161,8 @@ public class MLKEMImpl implements KEMSpi {
                 throw new NullPointerException();
             }
             try {
-                secret = OJPKEM.KEM_decapsulate(provider.getOCKContext(), ((PQCPrivateKey)this.privateKey).getPQCKey().getPKeyId(), cipherText);
+                secret = OJPKEM.KEM_decapsulate(provider.getOCKContext(),
+                        ((PQCPrivateKey) this.privateKey).getPQCKey().getPKeyId(), cipherText);
 
             } catch (OCKException e) {
                 throw new DecapsulateException("Decapsulation Error: ", e);

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
@@ -677,32 +677,32 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
 
         // SHA512-224
         aliases = new String[] {"SHA512/224", "OID.2.16.840.1.101.3.4.2.5",
-                "2.16.840.1.101.3.4.2.5",};
+                "2.16.840.1.101.3.4.2.5", };
         putService(new OpenJCEPlusService(jce, "MessageDigest", "SHA-512/224",
                 "com.ibm.crypto.plus.provider.MessageDigest$SHA512_224", aliases));
 
         // SHA512-256
         aliases = new String[] {"SHA512/256", "OID.2.16.840.1.101.3.4.2.6",
-                "2.16.840.1.101.3.4.2.6",};
+                "2.16.840.1.101.3.4.2.6", };
         putService(new OpenJCEPlusService(jce, "MessageDigest", "SHA-512/256",
                 "com.ibm.crypto.plus.provider.MessageDigest$SHA512_256", aliases));
 
         //SHA3 Hashes
 
         aliases = new String[] {"SHA3-224", "OID.2.16.840.1.101.3.4.2.7",
-                "2.16.840.1.101.3.4.2.7",};
+                "2.16.840.1.101.3.4.2.7", };
         putService(new OpenJCEPlusService(jce, "MessageDigest", "SHA3-224",
                 "com.ibm.crypto.plus.provider.MessageDigest$SHA3_224", aliases));
         aliases = new String[] {"SHA3-256", "OID.2.16.840.1.101.3.4.2.8",
-                "2.16.840.1.101.3.4.2.8",};
+                "2.16.840.1.101.3.4.2.8", };
         putService(new OpenJCEPlusService(jce, "MessageDigest", "SHA3-256",
                 "com.ibm.crypto.plus.provider.MessageDigest$SHA3_256", aliases));
         aliases = new String[] {"SHA3-384", "OID.2.16.840.1.101.3.4.2.9",
-                "2.16.840.1.101.3.4.2.9",};
+                "2.16.840.1.101.3.4.2.9", };
         putService(new OpenJCEPlusService(jce, "MessageDigest", "SHA3-384",
                 "com.ibm.crypto.plus.provider.MessageDigest$SHA3_384", aliases));
         aliases = new String[] {"SHA3-512", "OID.2.16.840.1.101.3.4.2.10",
-                "2.16.840.1.101.3.4.2.10",};
+                "2.16.840.1.101.3.4.2.10", };
         putService(new OpenJCEPlusService(jce, "MessageDigest", "SHA3-512",
                 "com.ibm.crypto.plus.provider.MessageDigest$SHA3_512", aliases));
 
@@ -923,22 +923,22 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
                 "com.ibm.crypto.plus.provider.RSASignature$SHA512withRSA", aliases));
 
         aliases = new String[] {"OID.2.16.840.1.101.3.4.3.13", "2.16.840.1.101.3.4.3.13",
-                "SHA3-224/RSA", "SHA3-224withRSA",};
+                "SHA3-224/RSA", "SHA3-224withRSA", };
         putService(new OpenJCEPlusService(jce, "Signature", "SHA3-224withRSA",
                 "com.ibm.crypto.plus.provider.RSASignature$SHA3_224withRSA", aliases));
 
         aliases = new String[] {"OID.2.16.840.1.101.3.4.3.14", "2.16.840.1.101.3.4.3.14",
-                "SHA3-256/RSA", "SHA3-256withRSA",};
+                "SHA3-256/RSA", "SHA3-256withRSA", };
         putService(new OpenJCEPlusService(jce, "Signature", "SHA3-256withRSA",
                 "com.ibm.crypto.plus.provider.RSASignature$SHA3_256withRSA", aliases));
 
         aliases = new String[] {"OID.2.16.840.1.101.3.4.3.15", "2.16.840.1.101.3.4.3.15",
-                "SHA3-384/RSA", "SHA3-384withRSA",};
+                "SHA3-384/RSA", "SHA3-384withRSA", };
         putService(new OpenJCEPlusService(jce, "Signature", "SHA3-384withRSA",
                 "com.ibm.crypto.plus.provider.RSASignature$SHA3_384withRSA", aliases));
 
         aliases = new String[] {"OID.2.16.840.1.101.3.4.3.16", "2.16.840.1.101.3.4.3.16",
-                "SHA3-512/RSA", "SHA3-512withRSA",};
+                "SHA3-512/RSA", "SHA3-512withRSA", };
         putService(new OpenJCEPlusService(jce, "Signature", "SHA3-512withRSA",
                 "com.ibm.crypto.plus.provider.RSASignature$SHA3_512withRSA", aliases));
 

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -524,32 +524,32 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
 
         // SHA512-224
         aliases = new String[] {"SHA512/224", "OID.2.16.840.1.101.3.4.2.5",
-                "2.16.840.1.101.3.4.2.5",};
+                "2.16.840.1.101.3.4.2.5", };
         putService(new OpenJCEPlusService(jce, "MessageDigest", "SHA-512/224",
                 "com.ibm.crypto.plus.provider.MessageDigest$SHA512_224", aliases));
 
         // SHA512-256
 
         aliases = new String[] {"SHA512/256", "OID.2.16.840.1.101.3.4.2.6",
-                "2.16.840.1.101.3.4.2.6",};
+                "2.16.840.1.101.3.4.2.6", };
         putService(new OpenJCEPlusService(jce, "MessageDigest", "SHA-512/256",
                 "com.ibm.crypto.plus.provider.MessageDigest$SHA512_256", aliases));
 
         //SHA3 Hashes
         aliases = new String[] {"SHA3-224", "OID.2.16.840.1.101.3.4.2.7",
-                "2.16.840.1.101.3.4.2.7",};
+                "2.16.840.1.101.3.4.2.7", };
         putService(new OpenJCEPlusService(jce, "MessageDigest", "SHA3-224",
                 "com.ibm.crypto.plus.provider.MessageDigest$SHA3_224", aliases));
         aliases = new String[] {"SHA3-256", "OID.2.16.840.1.101.3.4.2.8",
-                "2.16.840.1.101.3.4.2.8",};
+                "2.16.840.1.101.3.4.2.8", };
         putService(new OpenJCEPlusService(jce, "MessageDigest", "SHA3-256",
                 "com.ibm.crypto.plus.provider.MessageDigest$SHA3_256", aliases));
         aliases = new String[] {"SHA3-384", "OID.2.16.840.1.101.3.4.2.9",
-                "2.16.840.1.101.3.4.2.9",};
+                "2.16.840.1.101.3.4.2.9", };
         putService(new OpenJCEPlusService(jce, "MessageDigest", "SHA3-384",
                 "com.ibm.crypto.plus.provider.MessageDigest$SHA3_384", aliases));
         aliases = new String[] {"SHA3-512", "OID.2.16.840.1.101.3.4.2.10",
-                "2.16.840.1.101.3.4.2.10",};
+                "2.16.840.1.101.3.4.2.10", };
         putService(new OpenJCEPlusService(jce, "MessageDigest", "SHA3-512",
                 "com.ibm.crypto.plus.provider.MessageDigest$SHA3_512", aliases));
         /* =======================================================================

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCKeyFactory.java
@@ -55,8 +55,8 @@ class PQCKeyFactory extends KeyFactorySpi {
                     Arrays.fill(bytes, (byte) 0);
                 }
             } else if (keySpec instanceof EncodedKeySpec
-                && ((EncodedKeySpec)keySpec).getFormat().equalsIgnoreCase("RAW")) {
-                byte[] bytes = ((EncodedKeySpec)keySpec).getEncoded();
+                && ((EncodedKeySpec) keySpec).getFormat().equalsIgnoreCase("RAW")) {
+                byte[] bytes = ((EncodedKeySpec) keySpec).getEncoded();
                 try {
                     return new PQCPrivateKey(provider, bytes, algName);
                 } finally {
@@ -90,8 +90,8 @@ class PQCKeyFactory extends KeyFactorySpi {
                     Arrays.fill(bytes, (byte) 0);
                 }
             } else if (keySpec instanceof EncodedKeySpec
-                    && ((EncodedKeySpec)keySpec).getFormat().equalsIgnoreCase("RAW")) {
-                byte[] bytes = ((EncodedKeySpec)keySpec).getEncoded();
+                    && ((EncodedKeySpec) keySpec).getFormat().equalsIgnoreCase("RAW")) {
+                byte[] bytes = ((EncodedKeySpec) keySpec).getEncoded();
                 try {
                     return new PQCPublicKey(provider, bytes, algName);
                 } finally {
@@ -196,16 +196,16 @@ class PQCKeyFactory extends KeyFactorySpi {
                     sb.append(String.format("%02X", key[i]));
                 }
                 String s =sb.toString();
-                int b =  Integer.parseInt(s,16);
+                int b =  Integer.parseInt(s, 16);
                 if (b == (key.length - 4)) {
                     //This is an encoding
                     return true;
                 }
             } 
             return false;
-        } catch (Exception e) {              
+        } catch (Exception e) {
             return false;
-        }    
+        }
     }
 
     public static final class MLKEM512 extends PQCKeyFactory {

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCKeyPairGenerator.java
@@ -44,22 +44,21 @@ abstract class PQCKeyPairGenerator extends KeyPairGeneratorSpi {
         if (keysize != -1) {
             throw new InvalidParameterException("keysize not supported");
         }
-        // This functions is here for compatibility with Oracle and Spi
-        // However, since OCKC does not allow specification of Random
+        // This function is here for compatibility with Oracle and Spi.
+        // However, since OCKC does not allow specification of Random,
         // this function does nothing.
     }
 
     @Override
     public KeyPair generateKeyPair() {
         try {
-            //System.out.println("Generating KeyPair for " + mlkemAlg);
             PQCKey mlkemKey = PQCKey.generateKeyPair(provider.getOCKContext(), mlkemAlg);
             byte[] privKeyBytes = mlkemKey.getPrivateKeyBytes();
-            PQCPrivateKey privKey = new PQCPrivateKey(provider, PQCKey.createPrivateKey(provider.getOCKContext(), 
-                                                               mlkemAlg, privKeyBytes));
+            PQCPrivateKey privKey = new PQCPrivateKey(provider, PQCKey.createPrivateKey(provider.getOCKContext(),
+                                                        mlkemAlg, privKeyBytes));
             byte[] pubKeyBytes = mlkemKey.getPublicKeyBytes();
-            PQCPublicKey pubKey = new PQCPublicKey(provider, PQCKey.createPublicKey(provider.getOCKContext(), 
-                                                               mlkemAlg, pubKeyBytes));        
+            PQCPublicKey pubKey = new PQCPublicKey(provider, PQCKey.createPublicKey(provider.getOCKContext(),
+                                                        mlkemAlg, pubKeyBytes));
             return new KeyPair(pubKey, privKey);
         } catch (Exception e) {
             throw provider.providerException("Failure in generateKeyPair - " +e.getCause(), e);

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCKnownOIDs.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCKnownOIDs.java
@@ -46,7 +46,7 @@ public enum PQCKnownOIDs {
     // return null if not found
     protected static PQCKnownOIDs findMatch(String x) {
         x = x.toUpperCase(Locale.ENGLISH);
-        x = x.replace('-','_');
+        x = x.replace('-', '_');
 
         PQCKnownOIDs fnd = name2enum.get(x);
         return fnd;
@@ -93,7 +93,7 @@ public enum PQCKnownOIDs {
 
     // returns the user-friendly standard algorithm name
     protected String stdName() {
-        return stdName.replace('_','-' );
+        return stdName.replace('_', '-' );
     }
 
     // return the internal aliases

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCPrivateKey.java
@@ -19,7 +19,7 @@ import sun.security.util.DerValue;
 import sun.security.x509.AlgorithmId;
 
 /*
- * A PQC private key for the NIST FIPS 203 Algorithm.
+ * A PQC private key for the NIST FIPS 203 algorithm.
  */
 @SuppressWarnings("restriction")
 final class PQCPrivateKey extends PKCS8Key {
@@ -34,14 +34,13 @@ final class PQCPrivateKey extends PKCS8Key {
     private transient boolean destroyed = false;
 
     /**
-     * Create a MLKEM private key from the parameters and key data.
+     * Create a PQC private key from the key data and the algorithm name.
      *
-     * @param keyBytes
-     *                the private key bytes used to decapsulate a secret key
+     * @param keyBytes  the private key bytes
+     * @param algName   the name of the algorithm used
      */
-    public PQCPrivateKey(OpenJCEPlusProvider provider, byte[] keyBytes, String algName)
+    PQCPrivateKey(OpenJCEPlusProvider provider, byte[] keyBytes, String algName)
             throws InvalidKeyException {
-   
         this.algid = new AlgorithmId(PQCAlgorithmId.getOID(algName));
         this.name = PQCKnownOIDs.findMatch(this.algid.getName()).stdName();
         this.provider = provider;
@@ -60,7 +59,6 @@ final class PQCPrivateKey extends PKCS8Key {
         try {  
             try {
                 pkOct = new DerValue(DerValue.tag_OctetString, key);
-     
                 this.pqcKey = PQCKey.createPrivateKey(provider.getOCKContext(), 
                                    this.name, pkOct.toByteArray());
                 this.key = pkOct.toByteArray();
@@ -69,16 +67,15 @@ final class PQCPrivateKey extends PKCS8Key {
             }
         } catch (Exception e) {
             throw new InvalidKeyException("Invalid key " + e.getMessage(), e);
-        }   
+        }
     }
 
     /**
-     * Create a ML_KEM private key from it's DER encoding (PKCS#8)
+     * Create a PQC private key from an existing PQCKey.
      *
-     * @param encoded
-     *                the encoded parameters.
+     * @param pqcKey the PQCKey to be used to create the private key
      */
-    public PQCPrivateKey(OpenJCEPlusProvider provider, PQCKey pqcKey) throws InvalidKeyException {
+    PQCPrivateKey(OpenJCEPlusProvider provider, PQCKey pqcKey) throws InvalidKeyException {
         try {
             this.provider = provider;
             this.pqcKey = pqcKey;
@@ -105,12 +102,11 @@ final class PQCPrivateKey extends PKCS8Key {
     }
 
     /**
-     * Create a private key from it's DER encoding (PKCS#8)
+     * Create a private key from it's DER encoding (PKCS#8).
      *
-     * @param encoded
-     *                the encoded parameters.
+     * @param encoded   the encoded PKCS#8 key
      */
-    public PQCPrivateKey(OpenJCEPlusProvider provider, byte[] encoded) throws InvalidKeyException {
+    PQCPrivateKey(OpenJCEPlusProvider provider, byte[] encoded) throws InvalidKeyException {
         super(encoded);
         this.provider = provider;
 
@@ -132,7 +128,7 @@ final class PQCPrivateKey extends PKCS8Key {
                                    this.name, this.key);
         } catch (Exception e) {
             throw new InvalidKeyException("Invalid key " + e.getMessage(), e);
-        }   
+        }
     }
 
     @Override
@@ -192,7 +188,7 @@ final class PQCPrivateKey extends PKCS8Key {
     public void destroy() throws DestroyFailedException {
         if (!destroyed) {
             destroyed = true;
-            Arrays.fill(this.key, 0, this.key.length, (byte)0x00);
+            Arrays.fill(this.key, 0, this.key.length, (byte) 0x00);
             this.key = null;
             this.encodedKey = null;
             this.pqcKey = null;
@@ -221,16 +217,16 @@ final class PQCPrivateKey extends PKCS8Key {
                     sb.append(String.format("%02X", key[i]));
                 }
                 String s =sb.toString();
-                int b =  Integer.parseInt(s,16);
+                int b =  Integer.parseInt(s, 16);
                 if (b == (key.length - 4)) {
                     //This is an encoding
                     return true;
                 }
             } 
             return false;
-        } catch (Exception e) {              
+        } catch (Exception e) {
             return false;
-        }    
+        }
     }
 
 }

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCPublicKey.java
@@ -35,7 +35,7 @@ final class PQCPublicKey extends X509Key
     private transient boolean destroyed = false;
     private transient PQCKey pqcKey = null; // Transient per tag [SERIALIZATION] in DesignNotes.txt
 
-    public PQCPublicKey(OpenJCEPlusProvider provider, byte[] rawKey, String algName)
+    PQCPublicKey(OpenJCEPlusProvider provider, byte[] rawKey, String algName)
             throws InvalidKeyException {
         this.algid = new AlgorithmId(PQCAlgorithmId.getOID(algName));
         this.provider = provider;
@@ -57,7 +57,7 @@ final class PQCPublicKey extends X509Key
         }
     }
 
-    public PQCPublicKey(OpenJCEPlusProvider provider, PQCKey pqcKey) {
+    PQCPublicKey(OpenJCEPlusProvider provider, PQCKey pqcKey) {
         try {
             this.provider = provider;
             byte[] rawKey = pqcKey.getPublicKeyBytes();
@@ -74,7 +74,7 @@ final class PQCPublicKey extends X509Key
         }
     }
 
-    public PQCPublicKey(OpenJCEPlusProvider provider, byte[] encoded) throws InvalidKeyException {
+    PQCPublicKey(OpenJCEPlusProvider provider, byte[] encoded) throws InvalidKeyException {
         this.provider = provider;
 
         try {
@@ -87,7 +87,6 @@ final class PQCPublicKey extends X509Key
             tmp.close();
             
             this.pqcKey = PQCKey.createPublicKey(provider.getOCKContext(), name, b);
-                      
         } catch (Exception e) {
             throw provider.providerException("Failure in PublicKey -"+e.getMessage(), e);
         }
@@ -129,7 +128,6 @@ final class PQCPublicKey extends X509Key
             tmp.close();
             bytes.close();
         } catch (IOException ex) {
-            //System.out.println("Exception creating encoding - "+ex.getMessage());
             return encodedKey;
         }
         return encodedKey;

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCSignatureImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCSignatureImpl.java
@@ -67,7 +67,6 @@ abstract class PQCSignatureImpl extends SignatureSpi {
             throws InvalidAlgorithmParameterException {
         if (params == null) {
             return;
- 
         } else {
             throw new InvalidAlgorithmParameterException("Algorithm does not support parameters.");
         }
@@ -87,18 +86,17 @@ abstract class PQCSignatureImpl extends SignatureSpi {
             throw new InvalidKeyException("Unsupported key type: ", e);
         }
 
-        //Validate that the alg of the key matchs the alg specified on creation of this object
+        // Validate that the alg of the key matches the alg specified on creation of this object.
         if (this.alg != null && !((keyPrivate.getAlgorithm()).equalsIgnoreCase(this.alg))) {
             throw new InvalidKeyException("Key must be of algorithm " + this.alg);
         }
 
         try {
             this.signature.initialize(keyPrivate.getPQCKey());
-            //this.signature.initialize(keyPrivate);
         } catch (Exception e) {
             throw provider.providerException("Failure in engineInitSign", e);
         }
-        // Set to sign mode and reset message
+        // Set to sign mode and reset message.
         this.privateKeyInit = true;
         this.publicKeyInit = false;
         this.message.reset();
@@ -112,7 +110,7 @@ abstract class PQCSignatureImpl extends SignatureSpi {
         } catch (Exception e) {
             throw new InvalidKeyException("Unsupported key type: ", e);
         }
-        //Validate that the alg of the key matchs the alg specified on creation of this object
+        // Validate that the alg of the key matches the alg specified on creation of this object.
         if (this.alg != null && !((keyPublic.getAlgorithm()).equalsIgnoreCase(this.alg))) {
             throw new InvalidKeyException("Expected algorithm " + this.alg + ", but got " + keyPublic.getAlgorithm());
         }
@@ -122,7 +120,7 @@ abstract class PQCSignatureImpl extends SignatureSpi {
             throw provider.providerException("Failure in engineInitVerify", e);
         }
 
-        // Set to verify mode and reset message
+        // Set to verify mode and reset message.
         this.privateKeyInit = false;
         this.publicKeyInit = true;
         this.message.reset();
@@ -154,7 +152,7 @@ abstract class PQCSignatureImpl extends SignatureSpi {
 
     @Override
     protected void engineUpdate(byte[] b, int off, int len) throws SignatureException {
-        // update can be called several times, as this is required by JCK 569 to maintain interop with Sun
+        // Update can be called several times, as this is required by JCK 569 to maintain interop with Sun.
         message.write(b, off, len);
     }
 
@@ -172,7 +170,7 @@ abstract class PQCSignatureImpl extends SignatureSpi {
             message.reset();
             return this.signature.verify(sigBytes, messageBytes);
         } catch (Exception e) {
-            // return false rather than throwing exception
+            // Return false rather than throwing exception.
             return false;
         }
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPSSSignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPSSSignature.java
@@ -44,7 +44,7 @@ public final class RSAPSSSignature extends SignatureSpi {
     private SignatureRSAPSS signature = null;
 
     // PSS parameters
-    PSSParameterSpec pssParameterSpec = null;//PSSParameterSpec.DEFAULT;
+    PSSParameterSpec pssParameterSpec = null; //PSSParameterSpec.DEFAULT;
 
     private static final Hashtable<String, Integer> DIGEST_LENGTHS = new Hashtable<String, Integer>();
     static {

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
@@ -62,7 +62,7 @@ final class XDHPublicKeyImpl extends X509Key implements XECPublicKey, Destroyabl
         int bMod8 = (keyArray.length * 8) % 8;
         if (bMod8 != 0) {
             int msk = (1 << bMod8) - 1;
-            keyArray[0] &= (byte)msk;
+            keyArray[0] &= (byte) msk;
         }
 
         this.u = new BigInteger(1, keyArray); // u is the public key reversed
@@ -124,7 +124,7 @@ final class XDHPublicKeyImpl extends X509Key implements XECPublicKey, Destroyabl
             int bMod8 = (reverseKey.length * 8) % 8;
             if (bMod8 != 0) {
                 int msk = (1 << bMod8) - 1;
-                reverseKey[0] &= (byte)msk;
+                reverseKey[0] &= (byte) msk;
             }
 
             this.u = new BigInteger(1, reverseKey); // u is the public key reversed

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/AESKeyWrap.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/AESKeyWrap.java
@@ -20,7 +20,7 @@ public final class AESKeyWrap {
             throws OCKException {
         if (ockContext == null || key == null) {
             throw new OCKException("Invalid input data");
-        }        
+        }
         this.ockContext = ockContext;
         this.key = key;
         this.padding = padding;
@@ -44,9 +44,9 @@ public final class AESKeyWrap {
             throw new OCKException("Failed to wrap data" + e.getMessage());
         }  finally {
             //Clear inData
-            Arrays.fill(inData, (byte)0);  
-        }   
-        return output;    
+            Arrays.fill(inData, (byte) 0);
+        }
+        return output;
     }
 
     public byte[] unwrap(byte[] data, int start, int length) throws OCKException {
@@ -67,10 +67,9 @@ public final class AESKeyWrap {
             throw new OCKException("Failed to unwrap data"+ e.getMessage());
         }  finally {
             //Clear inData
-            Arrays.fill(inData, (byte)0);  
-        }       
-        return output;    
+            Arrays.fill(inData, (byte) 0);
+        }
+        return output;
     }
-
 
 }

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/PQCKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/PQCKey.java
@@ -26,16 +26,16 @@ public final class PQCKey implements AsymmetricKey {
 
     public static PQCKey generateKeyPair(OCKContext ockContext, String algName)
             throws OCKException {
-        long keyId = 0;        
+        long keyId = 0;
         // final String methodName = "generateKeyPair ";
         if (ockContext == null) {
             throw new IllegalArgumentException("context is null");
         }
         try {
-            String NoDashAlg = algName.replace('-','_');
+            String NoDashAlg = algName.replace('-', '_');
             keyId = NativeInterface.MLKEY_generate(ockContext.getId(), NoDashAlg);
 
-            if (keyId == 0) {   
+            if (keyId == 0) {
                 throw new OCKException("OCKPQCKey.generateKeyPair: MLKEY_generate failed");
             }    
         } catch (Exception e) {
@@ -55,7 +55,7 @@ public final class PQCKey implements AsymmetricKey {
             throw new IllegalArgumentException("key bytes is null");
         }
         long keyId = 0;
-        String NoDashAlg = algName.replace('-','_');
+        String NoDashAlg = algName.replace('-', '_');
         keyId = NativeInterface.MLKEY_createPrivateKey(ockContext.getId(), NoDashAlg,
                 privateKeyBytes);
 
@@ -73,7 +73,7 @@ public final class PQCKey implements AsymmetricKey {
             throw new IllegalArgumentException("key bytes is null");
         }
         long keyId = 0;
-        String NoDashAlg = algName.replace('-','_');
+        String NoDashAlg = algName.replace('-', '_');
         keyId = NativeInterface.MLKEY_createPublicKey(ockContext.getId(), NoDashAlg,
             publicKeyBytes);
 

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/PQCSignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/PQCSignature.java
@@ -89,7 +89,7 @@ public final class PQCSignature {
         boolean verified = false;
 
         verified = NativeInterface.PQC_SIGNATURE_verify(this.ockContext.getId(),
-                                                        this.key.getPKeyId(),sigBytes, data);
+                                                        this.key.getPKeyId(), sigBytes, data);
 
         return verified;
     }

--- a/src/main/java/ibm/security/internal/spec/RawKeySpec.java
+++ b/src/main/java/ibm/security/internal/spec/RawKeySpec.java
@@ -12,7 +12,7 @@ import java.security.spec.KeySpec;
 import java.util.Arrays;
 
 /**
- * This is here for easier compatability with OpenJDK 21 and above.
+ * This is here for easier compatibility with OpenJDK 21 and above.
  * 
  * This is a KeySpec that is used to specify a key by its byte array implementation. Since the
  * new PQC algs the bytes are defined as byte arrays.
@@ -35,7 +35,7 @@ public class RawKeySpec implements KeySpec {
 
     protected void finalize() throws Throwable {
         if (keyBytes != null) {
-            Arrays.fill(keyBytes,0,keyBytes.length, (byte)0);
+            Arrays.fill(keyBytes, 0, keyBytes.length, (byte) 0);
         }
     }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAES.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAES.java
@@ -989,7 +989,7 @@ public class BaseTestAES extends BaseTestCipher {
 
             // Verify the text
             cp.init(Cipher.DECRYPT_MODE, key, params);
-            resultBuffer = Arrays.copyOf(cipherText, cipherText.length);//cp.getOutputSize(cipherText.length));
+            resultBuffer = Arrays.copyOf(cipherText, cipherText.length); //cp.getOutputSize(cipherText.length));
             resultLen = cp.doFinal(resultBuffer, 0, cipherText.length, resultBuffer);
             byte[] newPlainText = Arrays.copyOf(resultBuffer, resultLen);
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESCopySafe.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESCopySafe.java
@@ -64,7 +64,7 @@ public class BaseTestAESCopySafe extends BaseTestJunit5 {
     private void doTest(Cipher c, int inputOffset, int outputOffset, MODE mode, boolean isUpdate)
             throws Exception {
         byte[] clearText = new byte[INPUT_LENGTH];
-        Arrays.fill(clearText, 0, INPUT_LENGTH, (byte)0x01);
+        Arrays.fill(clearText, 0, INPUT_LENGTH, (byte) 0x01);
         System.arraycopy(clearText, 0, workingBuffer, 0, INPUT_LENGTH);
 
         // Get baseline encrypted value. This baseline will be used through the rest of the 
@@ -120,7 +120,7 @@ public class BaseTestAESCopySafe extends BaseTestJunit5 {
         }
         initCipher(c, mode, false);
 
-        Arrays.fill(workingBuffer, 0, INPUT_LENGTH, (byte)0x00);
+        Arrays.fill(workingBuffer, 0, INPUT_LENGTH, (byte) 0x00);
         System.arraycopy(cipherText, 0, workingBuffer, inputOffset, cipherText.length);
 
         if (DEBUG) {
@@ -145,7 +145,7 @@ public class BaseTestAESCopySafe extends BaseTestJunit5 {
         }
 
         // Zero the working buffer just for ease of debug.
-        Arrays.fill(clearText, 0, INPUT_LENGTH, (byte)0x00);
+        Arrays.fill(clearText, 0, INPUT_LENGTH, (byte) 0x00);
     }
 
     private void initCipher(Cipher c, MODE mode, boolean isEncrypt)

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMSameBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMSameBuffer.java
@@ -263,7 +263,7 @@ public class BaseTestAESGCMSameBuffer extends BaseTestJunit5 {
         buffer.flip();
         ByteBuffer outBB = ByteBuffer.allocateDirect(cipher.getOutputSize(dataLength));
 
-        cipher.doFinal(textBB, outBB);// get cipher text in outBB
+        cipher.doFinal(textBB, outBB); // get cipher text in outBB
         outBB.flip();
 
         // restore positions

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM_ExtIV.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM_ExtIV.java
@@ -85,7 +85,7 @@ public class BaseTestAESGCM_ExtIV extends BaseTestJunit5 {
             }
         }
 
-        byte[] iv = new byte[16];// com.ibm.crypto.plus.provider.AESConstants.AES_BLOCK_SIZE];
+        byte[] iv = new byte[16]; // com.ibm.crypto.plus.provider.AESConstants.AES_BLOCK_SIZE];
         SecureRandom rnd = new java.security.SecureRandom();
         rnd.nextBytes(iv);
     }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM_IntIV.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM_IntIV.java
@@ -54,7 +54,7 @@ public class BaseTestAESGCM_IntIV extends BaseTestJunit5 {
 
         key = aesKeyGen.generateKey();
 
-        byte[] iv = new byte[16];// com.ibm.crypto.plus.provider.AESConstants.AES_BLOCK_SIZE];
+        byte[] iv = new byte[16]; // com.ibm.crypto.plus.provider.AESConstants.AES_BLOCK_SIZE];
         SecureRandom rnd = new java.security.SecureRandom();
         rnd.nextBytes(iv);
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESInterop.java
@@ -849,7 +849,7 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
 
             // Verify the text
             cpB.init(Cipher.DECRYPT_MODE, key, params);
-            resultBuffer = Arrays.copyOf(cipherText, cipherText.length);// cp.getOutputSize(cipherText.length));
+            resultBuffer = Arrays.copyOf(cipherText, cipherText.length); // cp.getOutputSize(cipherText.length));
             resultLen = cpB.doFinal(resultBuffer, 0, cipherText.length, resultBuffer);
             byte[] newPlainText = Arrays.copyOf(resultBuffer, resultLen);
 
@@ -895,7 +895,7 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
             }
 
             boolean success = Arrays.equals(cipherText, cipherText0);
-            assertTrue(success,"Encrypted text does not match expected result");
+            assertTrue(success, "Encrypted text does not match expected result");
 
             // Verify the text
             cpB.init(Cipher.DECRYPT_MODE, key, params);

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESKeyWrap.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESKeyWrap.java
@@ -136,7 +136,7 @@ public class BaseTestAESKeyWrap extends BaseTestJunit5Interop {
             cp.init(Cipher.WRAP_MODE, kek);
             byte[] cipherText = cp.wrap(keyToBeWrapped);
 
-            if (cipherText[2] == (byte)0xFF) {
+            if (cipherText[2] == (byte) 0xFF) {
                 cipherText[2] = (byte) 0x01;
             } else {
                 cipherText[2] = (byte) 0xFF;
@@ -425,7 +425,7 @@ public class BaseTestAESKeyWrap extends BaseTestJunit5Interop {
     public void testNullKey(String alg) throws Exception {
         try {
             Cipher cp = Cipher.getInstance(alg, getProviderName());
-            cp.init(Cipher.WRAP_MODE, (Key)null);
+            cp.init(Cipher.WRAP_MODE, (Key) null);
 
             fail("testNullKey did not fail as expected.");
         } catch (InvalidKeyException ike) {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAttributes.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAttributes.java
@@ -18,8 +18,8 @@ public class BaseTestAttributes extends BaseTestJunit5 {
     @Test
     public void testServices() throws Exception {
         Provider p = Security.getProvider(getProviderName());
-        for(Provider.Service s : p.getServices()) {
-            if(s.getType().equals("SecureRandom")) {
+        for (Provider.Service s : p.getServices()) {
+            if (s.getType().equals("SecureRandom")) {
                 testSecureRandom(SecureRandom.getInstance(s.getAlgorithm(), p));
             }
         }
@@ -30,6 +30,6 @@ public class BaseTestAttributes extends BaseTestJunit5 {
         String attr = sr.getProvider().getProperty("SecureRandom."
                 + sr.getAlgorithm() + " ThreadSafe");
         
-        assertTrue("true".equals(attr), "Not ThreadSafe" + attr);        
+        assertTrue("true".equals(attr), "Not ThreadSafe" + attr);
     }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20.java
@@ -776,7 +776,7 @@ public class BaseTestChaCha20 extends BaseTestCipher implements ChaCha20Constant
             // Verify the text
             cp = Cipher.getInstance(CHACHA20_ALGORITHM, getProviderName());
             cp.init(Cipher.DECRYPT_MODE, key, paramSpec);
-            resultBuffer = Arrays.copyOf(cipherText, cipherText.length);//cp.getOutputSize(cipherText.length));
+            resultBuffer = Arrays.copyOf(cipherText, cipherText.length); //cp.getOutputSize(cipherText.length));
             resultLen = cp.doFinal(resultBuffer, 0, cipherText.length, resultBuffer);
             byte[] newPlainText = Arrays.copyOf(resultBuffer, resultLen);
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20Poly1305.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestChaCha20Poly1305.java
@@ -932,7 +932,7 @@ public class BaseTestChaCha20Poly1305 extends BaseTestCipher implements ChaCha20
             // Verify the text
             cp = Cipher.getInstance(CHACHA20_POLY1305_ALGORITHM, getProviderName());
             cp.init(Cipher.DECRYPT_MODE, key, paramSpec);
-            resultBuffer = Arrays.copyOf(cipherText, cipherText.length);//cp.getOutputSize(cipherText.length));
+            resultBuffer = Arrays.copyOf(cipherText, cipherText.length); //cp.getOutputSize(cipherText.length));
             resultLen = cp.doFinal(resultBuffer, 0, cipherText.length, resultBuffer);
             byte[] newPlainText = Arrays.copyOf(resultBuffer, resultLen);
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDeterministic.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDeterministic.java
@@ -248,7 +248,7 @@ public class BaseTestDeterministic extends BaseTestJunit5 {
             case "EdDSA", "Ed25519", "XDH", "X25519" -> 255;
             case "Ed448", "X448" -> 448;
             case "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024" -> 0;
-            case "ML-DSA-44","ML-DSA-65","ML-DSA-87" -> 0;
+            case "ML-DSA-44", "ML-DSA-65", "ML-DSA-87" -> 0;
             default -> throw new UnsupportedOperationException(alg);
         };
         if (size != 0) {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHKDF.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHKDF.java
@@ -122,7 +122,7 @@ public class BaseTestHKDF extends BaseTestJunit5 {
             {"SHA1", "0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c", "", "",
                     "2adccada18779e7c2077ad2eb19d3f3e731385dd", "2c91117204d745f3500d636a62f64f0a"
                             + "b3bae548aa53d423b0d1f27ebba6f5e5" + "673a081d70cce7acfc48",
-                    "42"},};
+                    "42"}, };
 
     @Test
     public void testHKDF1() throws Exception {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHKDFInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHKDFInterop.java
@@ -110,7 +110,7 @@ public class BaseTestHKDFInterop extends BaseTestJunit5Interop {
             {"SHA1", "0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c", "", "",
                     "2adccada18779e7c2077ad2eb19d3f3e731385dd", "2c91117204d745f3500d636a62f64f0a"
                             + "b3bae548aa53d423b0d1f27ebba6f5e5" + "673a081d70cce7acfc48",
-                    "42"},};
+                    "42"}, };
 
     @Test
     public void testJcePlustoBC() throws InvalidAlgorithmParameterException,

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA224.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA224.java
@@ -36,13 +36,13 @@ public class BaseTestHmacSHA224 extends BaseTestJunit5 {
             (byte) 0x58, (byte) 0xe8, (byte) 0xcd, (byte) 0x30, (byte) 0xb0, (byte) 0x8b,
             (byte) 0x41, (byte) 0x40, (byte) 0x24, (byte) 0x85, (byte) 0x81, (byte) 0xed,
             (byte) 0x17, (byte) 0x4c, (byte) 0xb3, (byte) 0x4e, (byte) 0x12, (byte) 0x24,
-            (byte) 0xbc, (byte) 0xc1, (byte) 0xef, (byte) 0xc8, (byte) 0x1b,};
+            (byte) 0xbc, (byte) 0xc1, (byte) 0xef, (byte) 0xc8, (byte) 0x1b, };
 
     static final byte[] key_2 = {(byte) 0x00, (byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04,
             (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x09, (byte) 0x0a,
             (byte) 0x0b, (byte) 0x0c, (byte) 0x0d, (byte) 0x0e, (byte) 0x0f, (byte) 0x10,
             (byte) 0x11, (byte) 0x12, (byte) 0x13, (byte) 0x14, (byte) 0x15, (byte) 0x16,
-            (byte) 0x17, (byte) 0x18, (byte) 0x19, (byte) 0x1a, (byte) 0x1b,};
+            (byte) 0x17, (byte) 0x18, (byte) 0x19, (byte) 0x1a, (byte) 0x1b, };
 
     static final String data2 = "Sample message for keylen<blocklen";
     static final byte[] data_2 = data2.getBytes(StandardCharsets.UTF_8);
@@ -51,7 +51,7 @@ public class BaseTestHmacSHA224 extends BaseTestJunit5 {
             (byte) 0xb6, (byte) 0x7e, (byte) 0xf8, (byte) 0xb7, (byte) 0xa1, (byte) 0x69,
             (byte) 0xe9, (byte) 0xa0, (byte) 0xa5, (byte) 0x99, (byte) 0x71, (byte) 0x4a,
             (byte) 0x2c, (byte) 0xec, (byte) 0xba, (byte) 0x65, (byte) 0x99, (byte) 0x9a,
-            (byte) 0x51, (byte) 0xbe, (byte) 0xb8, (byte) 0xfb, (byte) 0xbe,};
+            (byte) 0x51, (byte) 0xbe, (byte) 0xb8, (byte) 0xfb, (byte) 0xbe, };
 
     static final byte[] key_3 = {(byte) 0x00, (byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04,
             (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x09, (byte) 0x0a,
@@ -69,7 +69,7 @@ public class BaseTestHmacSHA224 extends BaseTestJunit5 {
             (byte) 0x4d, (byte) 0x4e, (byte) 0x4f, (byte) 0x50, (byte) 0x51, (byte) 0x52,
             (byte) 0x53, (byte) 0x54, (byte) 0x55, (byte) 0x56, (byte) 0x57, (byte) 0x58,
             (byte) 0x59, (byte) 0x5a, (byte) 0x5b, (byte) 0x5c, (byte) 0x5d, (byte) 0x5e,
-            (byte) 0x5f, (byte) 0x60, (byte) 0x61, (byte) 0x62, (byte) 0x63,};
+            (byte) 0x5f, (byte) 0x60, (byte) 0x61, (byte) 0x62, (byte) 0x63, };
 
     static final byte[] data_3 = data1.getBytes(StandardCharsets.UTF_8);
 
@@ -77,7 +77,7 @@ public class BaseTestHmacSHA224 extends BaseTestJunit5 {
             (byte) 0xaf, (byte) 0x85, (byte) 0x31, (byte) 0x60, (byte) 0x1a, (byte) 0xe6,
             (byte) 0x23, (byte) 0x00, (byte) 0x99, (byte) 0xd9, (byte) 0x0b, (byte) 0xef,
             (byte) 0x88, (byte) 0xaa, (byte) 0xef, (byte) 0xb9, (byte) 0x61, (byte) 0xf4,
-            (byte) 0x08, (byte) 0x0a, (byte) 0xbc, (byte) 0x01, (byte) 0x4d,};
+            (byte) 0x08, (byte) 0x0a, (byte) 0xbc, (byte) 0x01, (byte) 0x4d, };
 
     static final byte[] key_4 = {(byte) 0x00, (byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04,
             (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x09, (byte) 0x0a,
@@ -87,14 +87,14 @@ public class BaseTestHmacSHA224 extends BaseTestJunit5 {
             (byte) 0x1d, (byte) 0x1e, (byte) 0x1f, (byte) 0x20, (byte) 0x21, (byte) 0x22,
             (byte) 0x23, (byte) 0x24, (byte) 0x25, (byte) 0x26, (byte) 0x27, (byte) 0x28,
             (byte) 0x29, (byte) 0x2a, (byte) 0x2b, (byte) 0x2c, (byte) 0x2d, (byte) 0x2e,
-            (byte) 0x2f, (byte) 0x30,};
+            (byte) 0x2f, (byte) 0x30, };
 
     static final String data4 = "Sample message for keylen<blocklen, with truncated tag";
     static final byte[] data_4 = data4.getBytes(StandardCharsets.UTF_8);
 
     static final byte[] digest_4 = {(byte) 0xd5, (byte) 0x22, (byte) 0xf1, (byte) 0xdf, (byte) 0x59,
             (byte) 0x6c, (byte) 0xa4, (byte) 0xb4, (byte) 0xb1, (byte) 0xc2, (byte) 0x3d,
-            (byte) 0x27, (byte) 0xbd, (byte) 0xe0, (byte) 0x67, (byte) 0xd6,};
+            (byte) 0x27, (byte) 0xbd, (byte) 0xe0, (byte) 0x67, (byte) 0xd6, };
 
     @Test
     public void testHmacSHA224_key1() throws Exception {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA224Interop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHmacSHA224Interop.java
@@ -37,13 +37,13 @@ public class BaseTestHmacSHA224Interop extends BaseTestJunit5Interop {
             (byte) 0x58, (byte) 0xe8, (byte) 0xcd, (byte) 0x30, (byte) 0xb0, (byte) 0x8b,
             (byte) 0x41, (byte) 0x40, (byte) 0x24, (byte) 0x85, (byte) 0x81, (byte) 0xed,
             (byte) 0x17, (byte) 0x4c, (byte) 0xb3, (byte) 0x4e, (byte) 0x12, (byte) 0x24,
-            (byte) 0xbc, (byte) 0xc1, (byte) 0xef, (byte) 0xc8, (byte) 0x1b,};
+            (byte) 0xbc, (byte) 0xc1, (byte) 0xef, (byte) 0xc8, (byte) 0x1b, };
 
     static final byte[] key_2 = {(byte) 0x00, (byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04,
             (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x09, (byte) 0x0a,
             (byte) 0x0b, (byte) 0x0c, (byte) 0x0d, (byte) 0x0e, (byte) 0x0f, (byte) 0x10,
             (byte) 0x11, (byte) 0x12, (byte) 0x13, (byte) 0x14, (byte) 0x15, (byte) 0x16,
-            (byte) 0x17, (byte) 0x18, (byte) 0x19, (byte) 0x1a, (byte) 0x1b,};
+            (byte) 0x17, (byte) 0x18, (byte) 0x19, (byte) 0x1a, (byte) 0x1b, };
 
     static final String data2 = "Sample message for keylen<blocklen";
     static final byte[] data_2 = data2.getBytes();
@@ -52,7 +52,7 @@ public class BaseTestHmacSHA224Interop extends BaseTestJunit5Interop {
             (byte) 0xb6, (byte) 0x7e, (byte) 0xf8, (byte) 0xb7, (byte) 0xa1, (byte) 0x69,
             (byte) 0xe9, (byte) 0xa0, (byte) 0xa5, (byte) 0x99, (byte) 0x71, (byte) 0x4a,
             (byte) 0x2c, (byte) 0xec, (byte) 0xba, (byte) 0x65, (byte) 0x99, (byte) 0x9a,
-            (byte) 0x51, (byte) 0xbe, (byte) 0xb8, (byte) 0xfb, (byte) 0xbe,};
+            (byte) 0x51, (byte) 0xbe, (byte) 0xb8, (byte) 0xfb, (byte) 0xbe, };
 
     static final byte[] key_3 = {(byte) 0x00, (byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04,
             (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x09, (byte) 0x0a,
@@ -70,7 +70,7 @@ public class BaseTestHmacSHA224Interop extends BaseTestJunit5Interop {
             (byte) 0x4d, (byte) 0x4e, (byte) 0x4f, (byte) 0x50, (byte) 0x51, (byte) 0x52,
             (byte) 0x53, (byte) 0x54, (byte) 0x55, (byte) 0x56, (byte) 0x57, (byte) 0x58,
             (byte) 0x59, (byte) 0x5a, (byte) 0x5b, (byte) 0x5c, (byte) 0x5d, (byte) 0x5e,
-            (byte) 0x5f, (byte) 0x60, (byte) 0x61, (byte) 0x62, (byte) 0x63,};
+            (byte) 0x5f, (byte) 0x60, (byte) 0x61, (byte) 0x62, (byte) 0x63, };
 
     static final byte[] data_3 = data1.getBytes();
 
@@ -78,7 +78,7 @@ public class BaseTestHmacSHA224Interop extends BaseTestJunit5Interop {
             (byte) 0xaf, (byte) 0x85, (byte) 0x31, (byte) 0x60, (byte) 0x1a, (byte) 0xe6,
             (byte) 0x23, (byte) 0x00, (byte) 0x99, (byte) 0xd9, (byte) 0x0b, (byte) 0xef,
             (byte) 0x88, (byte) 0xaa, (byte) 0xef, (byte) 0xb9, (byte) 0x61, (byte) 0xf4,
-            (byte) 0x08, (byte) 0x0a, (byte) 0xbc, (byte) 0x01, (byte) 0x4d,};
+            (byte) 0x08, (byte) 0x0a, (byte) 0xbc, (byte) 0x01, (byte) 0x4d, };
 
     static final byte[] key_4 = {(byte) 0x00, (byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04,
             (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x09, (byte) 0x0a,
@@ -88,14 +88,14 @@ public class BaseTestHmacSHA224Interop extends BaseTestJunit5Interop {
             (byte) 0x1d, (byte) 0x1e, (byte) 0x1f, (byte) 0x20, (byte) 0x21, (byte) 0x22,
             (byte) 0x23, (byte) 0x24, (byte) 0x25, (byte) 0x26, (byte) 0x27, (byte) 0x28,
             (byte) 0x29, (byte) 0x2a, (byte) 0x2b, (byte) 0x2c, (byte) 0x2d, (byte) 0x2e,
-            (byte) 0x2f, (byte) 0x30,};
+            (byte) 0x2f, (byte) 0x30, };
 
     static final String data4 = "Sample message for keylen<blocklen, with truncated tag";
     static final byte[] data_4 = data4.getBytes();
 
     static final byte[] digest_4 = {(byte) 0xd5, (byte) 0x22, (byte) 0xf1, (byte) 0xdf, (byte) 0x59,
             (byte) 0x6c, (byte) 0xa4, (byte) 0xb4, (byte) 0xb1, (byte) 0xc2, (byte) 0x3d,
-            (byte) 0x27, (byte) 0xbd, (byte) 0xe0, (byte) 0x67, (byte) 0xd6,};
+            (byte) 0x27, (byte) 0xbd, (byte) 0xe0, (byte) 0x67, (byte) 0xd6, };
 
     @Test
     public void test_data1() throws Exception {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestKEM.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestKEM.java
@@ -28,7 +28,7 @@ public class BaseTestKEM extends BaseTestJunit5 {
     protected KeyFactory pqcKeyFactory;
 
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512","ML_KEM_768","ML_KEM_1024"})
+    @CsvSource({"ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
     public void testKEM(String Algorithm) throws Exception {
 
         KEM kem = KEM.getInstance(Algorithm, getProviderName());
@@ -38,18 +38,18 @@ public class BaseTestKEM extends BaseTestJunit5 {
         pqcKeyPair.getPrivate();
 
         KEM.Encapsulator encr = kem.newEncapsulator(pqcKeyPair.getPublic());
-        KEM.Encapsulated enc = encr.encapsulate(0,32,"AES");
+        KEM.Encapsulated enc = encr.encapsulate(0, 32, "AES");
 
         SecretKey keyE = enc.key();
        
         KEM.Decapsulator decr = kem.newDecapsulator(pqcKeyPair.getPrivate());
-        SecretKey keyD = decr.decapsulate(enc.encapsulation(),0,32,"AES");
+        SecretKey keyD = decr.decapsulate(enc.encapsulation(), 0, 32, "AES");
         
-        assertArrayEquals(keyE.getEncoded(),keyD.getEncoded(),"Secrets do NOT match");
+        assertArrayEquals(keyE.getEncoded(), keyD.getEncoded(), "Secrets do NOT match");
     }
 
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512","ML_KEM_768","ML_KEM_1024"})
+    @CsvSource({"ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
     public void testKEMEmptyNoToFrom(String Algorithm) throws Exception {
 
         KEM kem = KEM.getInstance(Algorithm, getProviderName());
@@ -66,11 +66,11 @@ public class BaseTestKEM extends BaseTestJunit5 {
         KEM.Decapsulator decr = kem.newDecapsulator(pqcKeyPair.getPrivate());
         SecretKey keyD = decr.decapsulate(enc.encapsulation());
         
-        assertArrayEquals(keyE.getEncoded(),keyD.getEncoded(),"Secrets do NOT match");
+        assertArrayEquals(keyE.getEncoded(), keyD.getEncoded(), "Secrets do NOT match");
     }
 
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512","ML_KEM_768","ML_KEM_1024"})
+    @CsvSource({"ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
     public void testKEMError(String Algorithm) throws Exception {
         KEM.Encapsulated enc = null;
 
@@ -103,19 +103,19 @@ public class BaseTestKEM extends BaseTestJunit5 {
                     break;
             }
             try {
-                enc = encr.encapsulate(from,to,"AES");
+                enc = encr.encapsulate(from, to, "AES");
                 fail("testKEMError failed -Encapsulated length's test failed.");
             } catch (IndexOutOfBoundsException iob) {
             }
         }
 
         try {
-            enc = encr.encapsulate(0,32,null);
+            enc = encr.encapsulate(0, 32, null);
             fail("testKEMError failed -Encapsulated null alg worked.");
         } catch (NullPointerException iob) {
         }
 
-        enc = encr.encapsulate(0,32,"AES");
+        enc = encr.encapsulate(0, 32, "AES");
        
         KEM.Decapsulator decr = kem.newDecapsulator(pqcKeyPair.getPrivate());
         for (int i =0; i < 4; i++) {
@@ -140,20 +140,20 @@ public class BaseTestKEM extends BaseTestJunit5 {
                     break;
             }
             try {
-                decr.decapsulate(enc.encapsulation(),from,to,"AES");
+                decr.decapsulate(enc.encapsulation(), from, to, "AES");
                 fail("testKEMError failed -Decapsulate length's test failed.");
             } catch (IndexOutOfBoundsException iob) {
             }
         }
 
         try {
-            decr.decapsulate(enc.encapsulation(),0,32,null);
+            decr.decapsulate(enc.encapsulation(), 0, 32, null);
             fail("testKEMError failed -Decapsulate alg null worked.");
         } catch (NullPointerException iob) {
         }
     }
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512","ML_KEM_768","ML_KEM_1024"})
+    @CsvSource({"ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
     public void testKEMSmallerSecret(String Algorithm) throws Exception {
 
         KEM kem = KEM.getInstance(Algorithm, getProviderName());
@@ -163,14 +163,14 @@ public class BaseTestKEM extends BaseTestJunit5 {
         pqcKeyPair.getPrivate();
 
         KEM.Encapsulator encr = kem.newEncapsulator(pqcKeyPair.getPublic());
-        KEM.Encapsulated enc = encr.encapsulate(0,16,"AES");
+        KEM.Encapsulated enc = encr.encapsulate(0, 16, "AES");
 
         SecretKey keyE = enc.key();
-       
+
         KEM.Decapsulator decr = kem.newDecapsulator(pqcKeyPair.getPrivate());
-        SecretKey keyD = decr.decapsulate(enc.encapsulation(),0,16,"AES");
+        SecretKey keyD = decr.decapsulate(enc.encapsulation(), 0, 16, "AES");
         
-        assertArrayEquals(keyE.getEncoded(),keyD.getEncoded(),"Secrets do NOT match");
+        assertArrayEquals(keyE.getEncoded(), keyD.getEncoded(), "Secrets do NOT match");
     }
 
     protected KeyPair generateKeyPair(String Algorithm) throws Exception {
@@ -197,7 +197,7 @@ public class BaseTestKEM extends BaseTestJunit5 {
     }
 
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512","ML_KEM_768","ML_KEM_1024"})
+    @CsvSource({"ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
     protected void keyFactoryCreateFromEncoded(String Algorithm) throws Exception {
 
         pqcKeyFactory = KeyFactory.getInstance(Algorithm, getProviderName());
@@ -211,9 +211,10 @@ public class BaseTestKEM extends BaseTestJunit5 {
         PrivateKey priv =  pqcKeyFactory.generatePrivate(pkcs8Spec);
 
 
-        assertArrayEquals(pub.getEncoded(),pqcKeyPair.getPublic().getEncoded(),"Public key does not match generated public key");
-        assertArrayEquals(priv.getEncoded(),pqcKeyPair.getPrivate().getEncoded(),"Private key does not match generated public key");
-
+        assertArrayEquals(pub.getEncoded(), pqcKeyPair.getPublic().getEncoded(),
+                    "Public key does not match generated public key");
+        assertArrayEquals(priv.getEncoded(), pqcKeyPair.getPrivate().getEncoded(),
+                    "Private key does not match generated public key");
     }
 }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKEMMultiThread.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKEMMultiThread.java
@@ -36,7 +36,7 @@ public class BaseTestPQCKEMMultiThread extends BaseTestJunit5 {
      * newDecapsulator methods on the same KEM object at the same time.
      */
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512","ML_KEM_768","ML_KEM_1024"})
+    @CsvSource({"ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
     protected void testParallelEncapsulator(String algo) throws Exception {
         KeyPair kp = keyPair.gen(algo);
         kem = KEM.getInstance(algo, getProviderName());
@@ -54,7 +54,8 @@ public class BaseTestPQCKEMMultiThread extends BaseTestJunit5 {
             KEM.Decapsulator decT = kem.newDecapsulator(kp.getPrivate());
             for (Future<KEM.Encapsulator> future : futures) {
                 KEM.Encapsulated enc = future.get().encapsulate();
-                assertArrayEquals(decT.decapsulate(enc.encapsulation()).getEncoded(),enc.key().getEncoded(),"Secrets do NOT match");
+                assertArrayEquals(decT.decapsulate(enc.encapsulation()).getEncoded(), enc.key().getEncoded(),
+                                    "Secrets do NOT match");
             }
         } finally {
             if (executor != null) {
@@ -71,7 +72,7 @@ public class BaseTestPQCKEMMultiThread extends BaseTestJunit5 {
      * Encapsulator or Decapsulator object at the same time.
      */
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512","ML_KEM_768","ML_KEM_1024"})
+    @CsvSource({"ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
     protected void testParallelEncapsulate(String algo) throws Exception {
         KeyPair kp = keyPair.gen(algo);
         kem = KEM.getInstance(algo, getProviderName());
@@ -87,7 +88,8 @@ public class BaseTestPQCKEMMultiThread extends BaseTestJunit5 {
             }
             KEM.Decapsulator decT = kem.newDecapsulator(kp.getPrivate());
             for (Future<KEM.Encapsulated> future : futures) {
-                assertArrayEquals(decT.decapsulate(future.get().encapsulation()).getEncoded(),future.get().key().getEncoded(),"Secrets do NOT match");
+                assertArrayEquals(decT.decapsulate(future.get().encapsulation()).getEncoded(),
+                        future.get().key().getEncoded(), "Secrets do NOT match");
             }
         } finally {
             if (executor != null) {
@@ -104,7 +106,7 @@ public class BaseTestPQCKEMMultiThread extends BaseTestJunit5 {
      * Encapsulator or Decapsulator object at the same time.
      */
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512","ML_KEM_768","ML_KEM_1024"})
+    @CsvSource({"ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
     protected void testParallelDecapsulator(String algo) throws Exception {
         KeyPair kp = keyPair.gen(algo);
         kem = KEM.getInstance(algo, getProviderName());
@@ -120,7 +122,8 @@ public class BaseTestPQCKEMMultiThread extends BaseTestJunit5 {
 
             KEM.Encapsulated enc = kem.newEncapsulator(kp.getPublic()).encapsulate();
             for (Future<KEM.Decapsulator> decT : futures) {
-                assertArrayEquals(decT.get().decapsulate(enc.encapsulation()).getEncoded(),enc.key().getEncoded(),"Secrets do NOT match");
+                assertArrayEquals(decT.get().decapsulate(enc.encapsulation()).getEncoded(),
+                        enc.key().getEncoded(), "Secrets do NOT match");
             }
         } finally {
             if (executor != null) {
@@ -137,7 +140,7 @@ public class BaseTestPQCKEMMultiThread extends BaseTestJunit5 {
      * Encapsulator or Decapsulator object at the same time.
      */
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512","ML_KEM_768","ML_KEM_1024"})
+    @CsvSource({"ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
     protected void testParallelDecapsulate(String algo) throws Exception {
         KeyPair kp = keyPair.gen(algo);
         kem = KEM.getInstance(algo, getProviderName());
@@ -155,7 +158,7 @@ public class BaseTestPQCKEMMultiThread extends BaseTestJunit5 {
                 futures.add(cs.submit(task));
             }
             for (Future<SecretKey> future : futures) {
-                assertArrayEquals(future.get().getEncoded(), enc.key().getEncoded(),"Secrets do NOT match");
+                assertArrayEquals(future.get().getEncoded(), enc.key().getEncoded(), "Secrets do NOT match");
             }
         } finally {
             if (executor != null) {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeyInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeyInterop.java
@@ -265,7 +265,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     }
  
     @ParameterizedTest
-    @CsvSource({"ML-DSA-44","ML-DSA-65","ML-DSA-87"})
+    @CsvSource({"ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
     public void testSignInteropAndVerifyPlus(String algorithm) {
         try {
             if (getProviderName().equals("OpenJCEPlusFIPS")) {
@@ -299,7 +299,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
         }
     }
     @ParameterizedTest
-    @CsvSource({"ML-DSA-44","ML-DSA-65","ML-DSA-87"})
+    @CsvSource({"ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
     public void testSignInteropKeysPlusSignVerify(String algorithm) {
         try {
             if (getProviderName().equals("OpenJCEPlusFIPS") || 
@@ -333,7 +333,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
         }
     }
     @ParameterizedTest
-    @CsvSource({"ML-DSA-44","ML-DSA-65","ML-DSA-87"})
+    @CsvSource({"ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
     public void testSignPlusKeysInteropSignVerify(String algorithm) {
         try {
             if (getProviderName().equals("OpenJCEPlusFIPS") || 
@@ -367,7 +367,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
         }
     }
     @ParameterizedTest
-    @CsvSource({"ML-DSA-44","ML-DSA-65","ML-DSA-87"})
+    @CsvSource({"ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
     public void testSignPlusAndVerifyInterop(String algorithm) {
         try {
             if (getProviderName().equals("OpenJCEPlusFIPS")) {
@@ -403,7 +403,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     }
 
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512","ML-KEM-768","ML-KEM-1024"})
+    @CsvSource({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
     public void testKEMPlusKeyInteropAll(String Algorithm) {
         try {
             if (getProviderName().equals("OpenJCEPlusFIPS") || 
@@ -427,15 +427,15 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
             PublicKey publicKeyInterop = keyFactoryPlus.generatePublic(publicKeySpecPlus);
 
             KEM.Encapsulator encr = kemInterop.newEncapsulator(publicKeyInterop);
-            KEM.Encapsulated enc = encr.encapsulate(0,32,"AES");
+            KEM.Encapsulated enc = encr.encapsulate(0, 32, "AES");
             if (enc == null){
                 System.out.println("enc = null");
                 assertTrue(false, "KEMPlusCreatesInteropGet failed no enc.");
             }
             SecretKey keyE = enc.key();
-           
+
             KEM.Decapsulator decr = kemInterop.newDecapsulator(privateKeyInterop);
-            SecretKey keyD = decr.decapsulate(enc.encapsulation(),0,32,"AES");
+            SecretKey keyD = decr.decapsulate(enc.encapsulation(), 0, 32, "AES");
 
             assertTrue(Arrays.equals(keyE.getEncoded(), keyD.getEncoded()), "Secrets do NOT match");
         } catch (Exception ex) {
@@ -443,9 +443,9 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
             assertTrue(false, "KEMPlusCreatesInteropGet failed");
         }
     }
-     
+
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512","ML-KEM-768","ML-KEM-1024"})
+    @CsvSource({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
     public void testKEMInteropKeyPlusAll(String Algorithm) {
         try {
             if (getProviderName().equals("OpenJCEPlusFIPS") || 
@@ -469,15 +469,15 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
             PublicKey publicKeyPlus = keyFactoryPlus.generatePublic(publicKeySpecInterop);
 
             KEM.Encapsulator encr = kemPlus.newEncapsulator(publicKeyPlus);
-            KEM.Encapsulated enc = encr.encapsulate(0,32,"AES");
+            KEM.Encapsulated enc = encr.encapsulate(0, 32, "AES");
             if (enc == null){
                 System.out.println("enc = null");
                 assertTrue(false, "KEMPlusCreatesInteropGet failed no enc.");
             }
             SecretKey keyE = enc.key();
-           
+
             KEM.Decapsulator decr = kemPlus.newDecapsulator(privateKeyPlus);
-            SecretKey keyD = decr.decapsulate(enc.encapsulation(),0,32,"AES");
+            SecretKey keyD = decr.decapsulate(enc.encapsulation(), 0, 32, "AES");
 
             assertTrue(Arrays.equals(keyE.getEncoded(), keyD.getEncoded()), "Secrets do NOT match");
         } catch (Exception ex) {
@@ -487,7 +487,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     }
         
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512","ML-KEM-768","ML-KEM-1024"})
+    @CsvSource({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
     public void testKEMPlusCreatesInteropGet(String Algorithm) {
         try {
             if (getProviderName().equals("OpenJCEPlusFIPS")) {
@@ -509,15 +509,15 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
             PublicKey publicKeyInterop = keyFactoryInterop.generatePublic(publicKeySpecInterop);
 
             KEM.Encapsulator encr = kemInterop.newEncapsulator(publicKeyInterop);
-            KEM.Encapsulated enc = encr.encapsulate(0,32,"AES");
+            KEM.Encapsulated enc = encr.encapsulate(0, 32, "AES");
             if (enc == null){
                 System.out.println("enc = null");
                 assertTrue(false, "KEMPlusCreatesInteropGet failed no enc.");
             }
             SecretKey keyE = enc.key();
-           
+
             KEM.Decapsulator decr = kemPlus.newDecapsulator(privateKeyPlus);
-            SecretKey keyD = decr.decapsulate(enc.encapsulation(),0,32,"AES");
+            SecretKey keyD = decr.decapsulate(enc.encapsulation(), 0, 32, "AES");
 
             assertTrue(Arrays.equals(keyE.getEncoded(), keyD.getEncoded()), "Secrets do NOT match");
         } catch (Exception ex) {
@@ -527,7 +527,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     }
 
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512","ML-KEM-768","ML-KEM-1024"})
+    @CsvSource({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
     public void testKEMInteropCreatesPlusGet(String Algorithm) {
         try {
             if (getProviderName().equals("OpenJCEPlusFIPS")) {
@@ -548,14 +548,14 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
             KeyFactory keyFactoryPlus = KeyFactory.getInstance(Algorithm, getProviderName());
             PublicKey publicKeyPlus = keyFactoryPlus.generatePublic(publicKeySpecInterop);
             KEM.Encapsulator encr = kemPlus.newEncapsulator(publicKeyPlus);
-            KEM.Encapsulated enc = encr.encapsulate(0,32,"AES");
+            KEM.Encapsulated enc = encr.encapsulate(0, 32, "AES");
 
             SecretKey keyE = enc.key();
 
             KEM.Decapsulator decr = kemInterop.newDecapsulator(privateKeyInterop);
 
-            SecretKey keyD = decr.decapsulate(enc.encapsulation(),0,32,"AES");
-         
+            SecretKey keyD = decr.decapsulate(enc.encapsulation(), 0, 32, "AES");
+
             assertTrue(Arrays.equals(keyE.getEncoded(), keyD.getEncoded()), "Secrets do NOT match");
         } catch (Exception ex) {
             ex.printStackTrace();

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeys.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeys.java
@@ -42,9 +42,9 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
     }
 
     @ParameterizedTest
-    @CsvSource({"MLKEM512", "ML_KEM_768",
-        "ML-KEM-1024", "ML_KEM_512", "ML_KEM_768", "ML_KEM_1024",
-        "ML_DSA_44","ML_DSA_65","ML-DSA-87"})
+    @CsvSource({"MLKEM512", "ML_KEM_768", "ML-KEM-1024",
+                "ML_KEM_512", "ML_KEM_768", "ML_KEM_1024",
+                "ML_DSA_44", "ML_DSA_65", "ML-DSA-87"})
     public void testPQCKeyGen(String Algorithm) throws Exception {
         if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS does not support PQC keys currently
@@ -61,9 +61,8 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
     }
 
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512", "ML-KEM-768",
-        "ML-KEM-1024",
-        "ML_DSA_44","ML_DSA_65","ML-DSA-87"})
+    @CsvSource({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024",
+                "ML_DSA_44", "ML_DSA_65", "ML-DSA-87"})
     public void testPQCKeyFactoryCreateFromEncoded(String Algorithm) throws Exception {
         if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS does not support PQC keys currently
@@ -72,8 +71,7 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
         keyFactoryCreateFromEncoded(Algorithm);
     }
     @ParameterizedTest
-    @CsvSource({"ML-DSA-44","ML-DSA-65", "ML-KEM-512"})
-
+    @CsvSource({"ML-DSA-44", "ML-DSA-65", "ML-KEM-512"})
     public void testPQCKeyFactoryCreateFromStaticEncoded(String Algorithm) throws Exception {
         if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS does not support PQC keys currently
@@ -208,7 +206,7 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
                 return keyMaterial;
             }
             next = val.data.getDerValue();
-            if (next.isContextSpecific((byte)0)) {
+            if (next.isContextSpecific((byte) 0)) {
                 if (val.data.available() == 0) {
                     keyMaterial =  Arrays.copyOfRange(tmp, 4, tmp.length);
                     return keyMaterial;
@@ -216,7 +214,7 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
                 next = val.data.getDerValue();
             }
 
-            if (next.isContextSpecific((byte)1)) {
+            if (next.isContextSpecific((byte) 1)) {
                 if (version == 0) {
                     throw new InvalidKeyException("publicKey seen in v1");
                 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeystore.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeystore.java
@@ -79,8 +79,8 @@ public class BaseTestPQCKeystore extends BaseTestJunit5 {
 
             System.out.println("Keystore created successfully at: " + ksFile.getAbsolutePath());
 
-            PrivateKey tmp = (PrivateKey)ks.getKey(algname, password.toCharArray());
-            X509Certificate tmpC = (X509Certificate)ks.getCertificate(algname);
+            PrivateKey tmp = (PrivateKey) ks.getKey(algname, password.toCharArray());
+            X509Certificate tmpC = (X509Certificate) ks.getCertificate(algname);
             PublicKey tmpPub = tmpC.getPublicKey();
 
             if (tmp == null || tmpPub == null) {
@@ -117,8 +117,7 @@ public class BaseTestPQCKeystore extends BaseTestJunit5 {
                         c.get(Calendar.YEAR) + " which is greater than 9999");
             }
 
-            CertificateValidity interval =
-                                   new CertificateValidity(firstDate,lastDate);
+            CertificateValidity interval = new CertificateValidity(firstDate, lastDate);
 
             X509CertInfo info = new X509CertInfo();
             // Add all mandatory attributes

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPQCSignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPQCSignature.java
@@ -23,7 +23,7 @@ public class BaseTestPQCSignature extends BaseTestJunit5Signature {
     static final byte[] origMsg = "this is the original message to be signed".getBytes();
 
     @ParameterizedTest
-    @CsvSource({"ML_DSA_44","ML-DSA-65","ML_DSA_87"})
+    @CsvSource({"ML_DSA_44", "ML-DSA-65", "ML_DSA_87"})
     public void testPQCKeySignature(String Algorithm) throws Exception {
 
         KeyPair keyPair = generateKeyPair(Algorithm);
@@ -31,7 +31,7 @@ public class BaseTestPQCSignature extends BaseTestJunit5Signature {
     }
 
     @ParameterizedTest
-    @CsvSource({"ML_DSA_44","ML-DSA-65","ML_DSA_87"})
+    @CsvSource({"ML_DSA_44", "ML-DSA-65", "ML_DSA_87"})
     public void testPQCKeySignatureEncodings(String Algorithm) throws Exception {
 
         KeyPair keyPair = generateKeyPair(Algorithm);

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop2.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop2.java
@@ -3236,7 +3236,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println("testRSAPSS(): PSSParameterSpec.saltLen          = 20");
                     if (printJunitTrace)
-                        System.out.println("testRSAPSS(): PSSParameterSpec.trailerField     = 1");// 200");
+                        System.out.println("testRSAPSS(): PSSParameterSpec.trailerField     = 1"); // 200");
 
                     PSSParameterSpec pssParameterSpec = new PSSParameterSpec("SHA384", // mdName
                             "MGF1", // mgfName
@@ -3378,7 +3378,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                             "MGF1", // mgfName
                             MGF1ParameterSpec.SHA512, // MGFParameterSpec
                             20, // saltLen
-                            1);// Oracle supports only 1//1023 );                    trailerField
+                            1); // Oracle supports only 1//1023 );                    trailerField
 
                     boolean result = doSignature(dataToBeSigned, rsaKeyPair,
                             signingProvidersSignatureAlgorithmName,

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestSHA224.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestSHA224.java
@@ -20,7 +20,7 @@ public class BaseTestSHA224 extends BaseTestMessageDigest {
             (byte) 0x05, (byte) 0xd8, (byte) 0x22, (byte) 0x86, (byte) 0x42, (byte) 0xa4,
             (byte) 0x77, (byte) 0xbd, (byte) 0xa2, (byte) 0x55, (byte) 0xb3, (byte) 0x2a,
             (byte) 0xad, (byte) 0xbc, (byte) 0xe4, (byte) 0xbd, (byte) 0xa0, (byte) 0xb3,
-            (byte) 0xf7, (byte) 0xe3, (byte) 0x6c, (byte) 0x9d, (byte) 0xa7,};
+            (byte) 0xf7, (byte) 0xe3, (byte) 0x6c, (byte) 0x9d, (byte) 0xa7, };
 
     static final byte[] input_2 = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
             .getBytes(StandardCharsets.UTF_8);
@@ -28,7 +28,7 @@ public class BaseTestSHA224 extends BaseTestMessageDigest {
             (byte) 0x27, (byte) 0x76, (byte) 0xcc, (byte) 0x5d, (byte) 0xba, (byte) 0x5d,
             (byte) 0xa1, (byte) 0xfd, (byte) 0x89, (byte) 0x01, (byte) 0x50, (byte) 0xb0,
             (byte) 0xc6, (byte) 0x45, (byte) 0x5c, (byte) 0xb4, (byte) 0xf5, (byte) 0x8b,
-            (byte) 0x19, (byte) 0x52, (byte) 0x52, (byte) 0x25, (byte) 0x25,};
+            (byte) 0x19, (byte) 0x52, (byte) 0x52, (byte) 0x25, (byte) 0x25, };
 
     @BeforeAll
     public void setUp() {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestTruncatedDigest.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestTruncatedDigest.java
@@ -115,7 +115,7 @@ public class BaseTestTruncatedDigest extends BaseTestJunit5Signature {
      */
     public void testRSASignatureSHA512_256() throws Exception {
         PSSParameterSpec pssParameter = new PSSParameterSpec("SHA512/256", "MGF1",
-                MGF1ParameterSpec.SHA512_256,20, 1);
+                MGF1ParameterSpec.SHA512_256, 20, 1);
         try {
             dotestSignature(content, IBM_ALG, 2048, pssParameter, getProviderName());
         } catch (Exception e) {


### PR DESCRIPTION
A new checkstyle rule is added to enforce whitespace after certain characters.

Code is updated to follow new checkstyle rule.

Additional typos are fixed.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/827

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>