### PR TITLE
Modify PQC related alias names

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,9 @@ KeyPairGenerator            | EC                         |X                |X   
 KeyPairGenerator            | Ed25519                    |                 |X             |              |
 KeyPairGenerator            | Ed448                      |                 |X             |              |
 KeyPairGenerator            | EdDSA                      |                 |X             |              |
+KeyPairGenerator            | ML-DSA-44                  |                 |X             |              |
+KeyPairGenerator            | ML-DSA-65                  |                 |X             |              |
+KeyPairGenerator            | ML-DSA-87                  |                 |X             |              |
 KeyPairGenerator            | ML-KEM-512                 |                 |X             |[ML-KEM](#ml-kem)|
 KeyPairGenerator            | ML-KEM-768                 |                 |X             |[ML-KEM](#ml-kem)|
 KeyPairGenerator            | ML-KEM-1024                |                 |X             |[ML-KEM](#ml-kem)|

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
@@ -35,7 +35,7 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
             + "Cipher algorithms                  : AES, ChaCha20, ChaCha20-Poly1305, DESede, RSA\n"
             + "Key agreement algorithms           : DiffieHellman, ECDH, XDH\n"
             + "Key Encapsulation Mechanisms       : ML-KEM-512, ML-KEM-768, ML-KEM-1024\n"
-            + "Key factory                        : DiffieHellman, DSA, EC, XEC,  RSA, RSAPSS\n"
+            + "Key factory                        : DiffieHellman, DSA, EC, XEC,  RSA, RSAPSS, ML-KEM-512, ML-KEM-768, ML-KEM-1024\n"
             + "Key generator                      : AES, ChaCha20, DESede, HmacMD5, HmacSHA1, HmacSHA224,\n"
             + "                                       HmacMD5, HmacSHA1, HmacSHA224, HmacSHA256, HmacSHA384, HmacSHA512,\n"
             + "                                       HmacSHA3-224, HmacSHA3-256, HmacSHA3-384, HmacSHA3-512,\n"
@@ -339,32 +339,32 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
          * PQC key factories
          * =======================================================================
          */
-        aliases = new String[] {"ML_KEM_512", "MLKEM512", "2.16.840.1.101.3.4.4.1"};
+        aliases = new String[] {"ML_KEM_512", "MLKEM512", "OID.2.16.840.1.101.3.4.4.1", "2.16.840.1.101.3.4.4.1"};
 
         putService(new OpenJCEPlusService(jce, "KeyFactory", "ML-KEM-512",
                   "com.ibm.crypto.plus.provider.PQCKeyFactory$MLKEM512", aliases));
 
-        aliases = new String[] {"ML_KEM_768", "MLKEM768", "2.16.840.1.101.3.4.4.2"};
+        aliases = new String[] {"ML-KEM", "ML_KEM_768", "MLKEM768", "OID.2.16.840.1.101.3.4.4.2", "2.16.840.1.101.3.4.4.2"};
 
         putService(new OpenJCEPlusService(jce, "KeyFactory", "ML-KEM-768",
                "com.ibm.crypto.plus.provider.PQCKeyFactory$MLKEM768", aliases));
                 
-        aliases = new String[] {"ML_KEM_1024", "MLKEM1024", "2.16.840.1.101.3.4.4.3"};
+        aliases = new String[] {"ML_KEM_1024", "MLKEM1024", "OID.2.16.840.1.101.3.4.4.3", "2.16.840.1.101.3.4.4.3"};
 
         putService(new OpenJCEPlusService(jce, "KeyFactory", "ML-KEM-1024",
                "com.ibm.crypto.plus.provider.PQCKeyFactory$MLKEM1024", aliases));
                         
-        aliases = new String[] {"ML_DSA_44", "MLDSA44", "2.16.840.1.101.3.4.3.17"};
+        aliases = new String[] {"ML_DSA_44", "MLDSA44", "OID.2.16.840.1.101.3.4.3.17", "2.16.840.1.101.3.4.3.17"};
 
         putService(new OpenJCEPlusService(jce, "KeyFactory", "ML-DSA-44",
                "com.ibm.crypto.plus.provider.PQCKeyFactory$MLDSA44", aliases));
                                
-        aliases = new String[] {"ML_DSA_65", "MLDSA65", "2.16.840.1.101.3.4.3.18"};
+        aliases = new String[] {"ML-DSA", "ML_DSA_65", "MLDSA65", "OID.2.16.840.1.101.3.4.3.18", "2.16.840.1.101.3.4.3.18"};
 
         putService(new OpenJCEPlusService(jce, "KeyFactory", "ML-DSA-65",
                "com.ibm.crypto.plus.provider.PQCKeyFactory$MLDSA65", aliases));
                                 
-        aliases = new String[] {"ML_DSA_87", "MLDSA87", "2.16.840.1.101.3.4.3.19"};
+        aliases = new String[] {"ML_DSA_87", "MLDSA87", "OID.2.16.840.1.101.3.4.3.19", "2.16.840.1.101.3.4.3.19"};
 
         putService(new OpenJCEPlusService(jce, "KeyFactory", "ML-DSA-87",
                "com.ibm.crypto.plus.provider.PQCKeyFactory$MLDSA87", aliases));
@@ -525,32 +525,32 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
          * PQC key pair generators
          * =======================================================================
          */
-        aliases = new String[] {"ML_KEM_512", "MLKEM512", "2.16.840.1.101.3.4.4.1"};
+        aliases = new String[] {"ML_KEM_512", "MLKEM512", "OID.2.16.840.1.101.3.4.4.1", "2.16.840.1.101.3.4.4.1"};
 
         putService(new OpenJCEPlusService(jce, "KeyPairGenerator", "ML-KEM-512",
                   "com.ibm.crypto.plus.provider.PQCKeyPairGenerator$MLKEM512", aliases));
 
-        aliases = new String[] {"ML_KEM_768", "MLKEM768", "2.16.840.1.101.3.4.4.2"};
+        aliases = new String[] {"ML-KEM", "ML_KEM_768", "MLKEM768", "OID.2.16.840.1.101.3.4.4.2", "2.16.840.1.101.3.4.4.2"};
 
         putService(new OpenJCEPlusService(jce, "KeyPairGenerator", "ML-KEM-768",
                "com.ibm.crypto.plus.provider.PQCKeyPairGenerator$MLKEM768", aliases));
 
-        aliases = new String[] {"ML_KEM_1024", "MLKEM1024", "2.16.840.1.101.3.4.4.3"};
+        aliases = new String[] {"ML_KEM_1024", "MLKEM1024", "OID.2.16.840.1.101.3.4.4.3", "2.16.840.1.101.3.4.4.3"};
 
         putService(new OpenJCEPlusService(jce, "KeyPairGenerator", "ML-KEM-1024",
                "com.ibm.crypto.plus.provider.PQCKeyPairGenerator$MLKEM1024", aliases));
 
-        aliases = new String[] {"ML_DSA_44", "MLDSA44", "2.16.840.1.101.3.4.3.17"};
+        aliases = new String[] {"ML_DSA_44", "MLDSA44", "OID.2.16.840.1.101.3.4.3.17", "2.16.840.1.101.3.4.3.17"};
 
         putService(new OpenJCEPlusService(jce, "KeyPairGenerator", "ML-DSA-44",
                "com.ibm.crypto.plus.provider.PQCKeyPairGenerator$MLDSA44", aliases));
 
-        aliases = new String[] {"ML_DSA_65", "MLDSA65", "2.16.840.1.101.3.4.3.18"};
+        aliases = new String[] {"ML-DSA", "ML_DSA_65", "MLDSA65", "OID.2.16.840.1.101.3.4.3.18", "2.16.840.1.101.3.4.3.18"};
 
         putService(new OpenJCEPlusService(jce, "KeyPairGenerator", "ML-DSA-65",
                "com.ibm.crypto.plus.provider.PQCKeyPairGenerator$MLDSA65", aliases));
 
-        aliases = new String[] {"ML_DSA_87", "MLDSA87", "2.16.840.1.101.3.4.3.19"};
+        aliases = new String[] {"ML_DSA_87", "MLDSA87", "OID.2.16.840.1.101.3.4.3.19", "2.16.840.1.101.3.4.3.19"};
 
         putService(new OpenJCEPlusService(jce, "KeyPairGenerator", "ML-DSA-87",
                "com.ibm.crypto.plus.provider.PQCKeyPairGenerator$MLDSA87", aliases)); 
@@ -712,17 +712,17 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
          * PQC key encapsulation mechanisms
          * =======================================================================
          */
-        aliases = new String[] {"ML_KEM_512", "ML-KEM", "MLKEM512", "2.16.840.1.101.3.4.4.1"};
+        aliases = new String[] {"ML_KEM_512", "MLKEM512", "OID.2.16.840.1.101.3.4.4.1", "2.16.840.1.101.3.4.4.1"};
 
         putService(new OpenJCEPlusService(jce, "KEM", "ML-KEM-512",
                "com.ibm.crypto.plus.provider.MLKEMImpl$MLKEM512", aliases));
 
-        aliases = new String[] {"ML_KEM_768", "MLKEM768", "2.16.840.1.101.3.4.4.2"};
+        aliases = new String[] {"ML-KEM", "ML_KEM_768", "MLKEM768", "OID.2.16.840.1.101.3.4.4.2", "2.16.840.1.101.3.4.4.2"};
 
         putService(new OpenJCEPlusService(jce, "KEM", "ML-KEM-768",
                "com.ibm.crypto.plus.provider.MLKEMImpl$MLKEM768", aliases));
 
-        aliases = new String[] {"ML_KEM_1024", "MLKEM1024", "2.16.840.1.101.3.4.4.3"};
+        aliases = new String[] {"ML_KEM_1024", "MLKEM1024", "OID.2.16.840.1.101.3.4.4.3", "2.16.840.1.101.3.4.4.3"};
 
         putService(new OpenJCEPlusService(jce, "KEM", "ML-KEM-1024",
                "com.ibm.crypto.plus.provider.MLKEMImpl$MLKEM1024", aliases));
@@ -978,17 +978,17 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
          * PQC signatures
          * =======================================================================
          */
-        aliases = new String[] {"ML_DSA_44", "MLDSA44", "2.16.840.1.101.3.4.3.17"};
+        aliases = new String[] {"ML_DSA_44", "MLDSA44", "OID.2.16.840.1.101.3.4.3.17", "2.16.840.1.101.3.4.3.17"};
 
         putService(new OpenJCEPlusService(jce, "Signature", "ML-DSA-44",
                "com.ibm.crypto.plus.provider.PQCSignatureImpl$MLDSA44", aliases));
 
-        aliases = new String[] {"ML_DSA_65", "MLDSA65", "2.16.840.1.101.3.4.3.18"};
+        aliases = new String[] {"ML-DSA", "ML_DSA_65", "MLDSA65", "OID.2.16.840.1.101.3.4.3.18", "2.16.840.1.101.3.4.3.18"};
 
         putService(new OpenJCEPlusService(jce, "Signature", "ML-DSA-65",
                "com.ibm.crypto.plus.provider.PQCSignatureImpl$MLDSA65", aliases));
 
-        aliases = new String[] {"ML_DSA_87", "MLDSA87", "2.16.840.1.101.3.4.3.19"};
+        aliases = new String[] {"ML_DSA_87", "MLDSA87", "OID.2.16.840.1.101.3.4.3.19", "2.16.840.1.101.3.4.3.19"};
 
         putService(new OpenJCEPlusService(jce, "Signature", "ML-DSA-87",
                "com.ibm.crypto.plus.provider.PQCSignatureImpl$MLDSA87", aliases));

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestKEM.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestKEM.java
@@ -28,7 +28,7 @@ public class BaseTestKEM extends BaseTestJunit5 {
     protected KeyFactory pqcKeyFactory;
 
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
+    @CsvSource({"ML-KEM", "ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
     public void testKEM(String Algorithm) throws Exception {
 
         KEM kem = KEM.getInstance(Algorithm, getProviderName());
@@ -49,7 +49,7 @@ public class BaseTestKEM extends BaseTestJunit5 {
     }
 
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
+    @CsvSource({"ML-KEM", "ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
     public void testKEMEmptyNoToFrom(String Algorithm) throws Exception {
 
         KEM kem = KEM.getInstance(Algorithm, getProviderName());
@@ -70,7 +70,7 @@ public class BaseTestKEM extends BaseTestJunit5 {
     }
 
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
+    @CsvSource({"ML-KEM", "ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
     public void testKEMError(String Algorithm) throws Exception {
         KEM.Encapsulated enc = null;
 
@@ -153,7 +153,7 @@ public class BaseTestKEM extends BaseTestJunit5 {
         }
     }
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
+    @CsvSource({"ML-KEM", "ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
     public void testKEMSmallerSecret(String Algorithm) throws Exception {
 
         KEM kem = KEM.getInstance(Algorithm, getProviderName());
@@ -197,7 +197,7 @@ public class BaseTestKEM extends BaseTestJunit5 {
     }
 
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
+    @CsvSource({"ML-KEM", "ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
     protected void keyFactoryCreateFromEncoded(String Algorithm) throws Exception {
 
         pqcKeyFactory = KeyFactory.getInstance(Algorithm, getProviderName());

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKEMMultiThread.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKEMMultiThread.java
@@ -36,7 +36,7 @@ public class BaseTestPQCKEMMultiThread extends BaseTestJunit5 {
      * newDecapsulator methods on the same KEM object at the same time.
      */
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
+    @CsvSource({"ML-KEM", "ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
     protected void testParallelEncapsulator(String algo) throws Exception {
         KeyPair kp = keyPair.gen(algo);
         kem = KEM.getInstance(algo, getProviderName());
@@ -72,7 +72,7 @@ public class BaseTestPQCKEMMultiThread extends BaseTestJunit5 {
      * Encapsulator or Decapsulator object at the same time.
      */
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
+    @CsvSource({"ML-KEM", "ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
     protected void testParallelEncapsulate(String algo) throws Exception {
         KeyPair kp = keyPair.gen(algo);
         kem = KEM.getInstance(algo, getProviderName());
@@ -106,7 +106,7 @@ public class BaseTestPQCKEMMultiThread extends BaseTestJunit5 {
      * Encapsulator or Decapsulator object at the same time.
      */
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
+    @CsvSource({"ML-KEM", "ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
     protected void testParallelDecapsulator(String algo) throws Exception {
         KeyPair kp = keyPair.gen(algo);
         kem = KEM.getInstance(algo, getProviderName());
@@ -140,7 +140,7 @@ public class BaseTestPQCKEMMultiThread extends BaseTestJunit5 {
      * Encapsulator or Decapsulator object at the same time.
      */
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
+    @CsvSource({"ML-KEM", "ML-KEM-512", "ML_KEM_768", "ML_KEM_1024"})
     protected void testParallelDecapsulate(String algo) throws Exception {
         KeyPair kp = keyPair.gen(algo);
         kem = KEM.getInstance(algo, getProviderName());

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeyInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeyInterop.java
@@ -265,11 +265,14 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     }
  
     @ParameterizedTest
-    @CsvSource({"ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
-    public void testSignInteropAndVerifyPlus(String algorithm) {
+    @CsvSource({"ML-DSA", "ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
+    public void testSignInteropAndVerifyPlus(String algorithm) throws Exception {
         try {
             if (getProviderName().equals("OpenJCEPlusFIPS")) {
                 //This is not in the FIPS provider yet.
+                return;
+            }
+            if (algorithm.equalsIgnoreCase("ML-DSA") && getInteropProviderName2().equalsIgnoreCase("BC")) {
                 return;
             }
             keyPairGenInterop = KeyPairGenerator.getInstance(algorithm, getInteropProviderName2());
@@ -295,11 +298,11 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
             assertTrue(verifyingPlus.verify(signedBytesInterop), "Signature verification failed");
         } catch (Exception ex) {
             ex.printStackTrace();
-            assertTrue(false, "SignInteropAndVerifyPlus failed");
+            throw ex;
         }
     }
     @ParameterizedTest
-    @CsvSource({"ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
+    @CsvSource({"ML-DSA", "ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
     public void testSignInteropKeysPlusSignVerify(String algorithm) {
         try {
             if (getProviderName().equals("OpenJCEPlusFIPS") || 
@@ -332,8 +335,9 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
             assertTrue(false, "SignInteropAndVerifyPlus failed");
         }
     }
+
     @ParameterizedTest
-    @CsvSource({"ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
+    @CsvSource({"ML-DSA", "ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
     public void testSignPlusKeysInteropSignVerify(String algorithm) {
         try {
             if (getProviderName().equals("OpenJCEPlusFIPS") || 
@@ -367,7 +371,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
         }
     }
     @ParameterizedTest
-    @CsvSource({"ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
+    @CsvSource({"ML-DSA", "ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
     public void testSignPlusAndVerifyInterop(String algorithm) {
         try {
             if (getProviderName().equals("OpenJCEPlusFIPS")) {
@@ -403,7 +407,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     }
 
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+    @CsvSource({"ML-KEM", "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
     public void testKEMPlusKeyInteropAll(String Algorithm) {
         try {
             if (getProviderName().equals("OpenJCEPlusFIPS") || 
@@ -445,7 +449,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     }
 
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+    @CsvSource({"ML-KEM", "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
     public void testKEMInteropKeyPlusAll(String Algorithm) {
         try {
             if (getProviderName().equals("OpenJCEPlusFIPS") || 
@@ -487,7 +491,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     }
         
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+    @CsvSource({"ML-KEM", "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
     public void testKEMPlusCreatesInteropGet(String Algorithm) {
         try {
             if (getProviderName().equals("OpenJCEPlusFIPS")) {
@@ -527,7 +531,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     }
 
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+    @CsvSource({"ML-KEM", "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
     public void testKEMInteropCreatesPlusGet(String Algorithm) {
         try {
             if (getProviderName().equals("OpenJCEPlusFIPS")) {
@@ -564,4 +568,3 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     }
 
 }
-

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeys.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeys.java
@@ -42,9 +42,9 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
     }
 
     @ParameterizedTest
-    @CsvSource({"MLKEM512", "ML_KEM_768", "ML-KEM-1024",
+    @CsvSource({"ML-KEM", "MLKEM512", "ML_KEM_768", "ML-KEM-1024",
                 "ML_KEM_512", "ML_KEM_768", "ML_KEM_1024",
-                "ML_DSA_44", "ML_DSA_65", "ML-DSA-87"})
+                "ML-DSA", "ML_DSA_44", "ML_DSA_65", "ML-DSA-87"})
     public void testPQCKeyGen(String Algorithm) throws Exception {
         if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS does not support PQC keys currently
@@ -61,8 +61,8 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
     }
 
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024",
-                "ML_DSA_44", "ML_DSA_65", "ML-DSA-87"})
+    @CsvSource({"ML-KEM", "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024",
+                "ML-DSA", "ML_DSA_44", "ML_DSA_65", "ML-DSA-87"})
     public void testPQCKeyFactoryCreateFromEncoded(String Algorithm) throws Exception {
         if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS does not support PQC keys currently
@@ -71,7 +71,7 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
         keyFactoryCreateFromEncoded(Algorithm);
     }
     @ParameterizedTest
-    @CsvSource({"ML-DSA-44", "ML-DSA-65", "ML-KEM-512"})
+    @CsvSource({"ML-DSA", "ML-DSA-44", "ML-DSA-65", "ML-KEM", "ML-KEM-512"})
     public void testPQCKeyFactoryCreateFromStaticEncoded(String Algorithm) throws Exception {
         if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS does not support PQC keys currently
@@ -229,4 +229,3 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
         }  
     }
 }
-

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeystore.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeystore.java
@@ -50,7 +50,7 @@ public class BaseTestPQCKeystore extends BaseTestJunit5 {
     KeyPair kp = null;
 
     @BeforeAll
-    public void setUp() {
+    public void setUp() throws Exception {
         try {
             ksFile = new File(ksName);
             os = new FileOutputStream(ksFile);
@@ -58,12 +58,12 @@ public class BaseTestPQCKeystore extends BaseTestJunit5 {
             ks.load(null, password.toCharArray());
         } catch (Exception e) {
             System.out.println("Error setting up test: "+e.getMessage());
+            throw e;
         }
-
     }
     @ParameterizedTest
     @CsvSource({"ML-DSA-87"})
-    public void KeystoreTest(String algname) {
+    public void KeystoreTest(String algname) throws Exception {
         try {
             KeyPairGenerator keyPairGen = KeyPairGenerator.getInstance(algname, getProviderName());
             kp = keyPairGen.generateKeyPair(); 
@@ -93,7 +93,7 @@ public class BaseTestPQCKeystore extends BaseTestJunit5 {
             if (ksFile.exists()){
                 ksFile.delete();
             }
-            fail("Got Exception in KeystoreTest");
+            throw e;
         }
         ksFile.delete();
     }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPQCSignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPQCSignature.java
@@ -23,7 +23,7 @@ public class BaseTestPQCSignature extends BaseTestJunit5Signature {
     static final byte[] origMsg = "this is the original message to be signed".getBytes();
 
     @ParameterizedTest
-    @CsvSource({"ML_DSA_44", "ML-DSA-65", "ML_DSA_87"})
+    @CsvSource({"ML-DSA", "ML_DSA_44", "ML-DSA-65", "ML_DSA_87"})
     public void testPQCKeySignature(String Algorithm) throws Exception {
 
         KeyPair keyPair = generateKeyPair(Algorithm);
@@ -31,7 +31,7 @@ public class BaseTestPQCSignature extends BaseTestJunit5Signature {
     }
 
     @ParameterizedTest
-    @CsvSource({"ML_DSA_44", "ML-DSA-65", "ML_DSA_87"})
+    @CsvSource({"ML-DSA", "ML_DSA_44", "ML-DSA-65", "ML_DSA_87"})
     public void testPQCKeySignatureEncodings(String Algorithm) throws Exception {
 
         KeyPair keyPair = generateKeyPair(Algorithm);

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPQCSignatureWithAliases.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPQCSignatureWithAliases.java
@@ -21,12 +21,12 @@ public class BaseTestPQCSignatureWithAliases extends BaseTestJunit5Signature {
     boolean doSignatureTest = false;   // If false, generate key pairs only.  Do not execute the signature portion of the test case.
 
     @ParameterizedTest
-    @CsvSource({"ML-KEM-512",   "ML_KEM_512",  "MLKEM512",  "2.16.840.1.101.3.4.4.1",
-        "ML-KEM-768",   "ML_KEM_768",  "MLKEM768",  "2.16.840.1.101.3.4.4.2",
-        "ML-KEM-1024",  "ML_KEM_1024", "MLKEM1024", "2.16.840.1.101.3.4.4.3",
-        "ML-DSA-44",  "ML_DSA_44", "MLDSA44", "2.16.840.1.101.3.4.3.17",
-        "ML-DSA-65",  "ML_DSA_65", "MLDSA65", "2.16.840.1.101.3.4.3.18",
-        "ML-DSA-87",  "ML_DSA_87", "MLDSA87", "2.16.840.1.101.3.4.3.19"})
+    @CsvSource({"ML-KEM", "ML-KEM-512", "ML_KEM_512", "MLKEM512", "OID.2.16.840.1.101.3.4.4.1", "2.16.840.1.101.3.4.4.1",
+        "ML-KEM-768", "ML_KEM_768", "MLKEM768", "OID.2.16.840.1.101.3.4.4.2", "2.16.840.1.101.3.4.4.2",
+        "ML-KEM-1024", "ML_KEM_1024", "MLKEM1024", "OID.2.16.840.1.101.3.4.4.3", "2.16.840.1.101.3.4.4.3",
+        "ML-DSA", "ML-DSA-44", "ML_DSA_44", "MLDSA44", "OID.2.16.840.1.101.3.4.3.17", "2.16.840.1.101.3.4.3.17",
+        "ML-DSA-65", "ML_DSA_65", "MLDSA65", "OID.2.16.840.1.101.3.4.3.18", "2.16.840.1.101.3.4.3.18",
+        "ML-DSA-87", "ML_DSA_87", "MLDSA87", "OID.2.16.840.1.101.3.4.3.19", "2.16.840.1.101.3.4.3.19"})
     public void testPQCKeys(String pqcKeyType) {
 
         int numberOfTestsExecuted = 0;

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressMLKEM.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressMLKEM.java
@@ -55,10 +55,10 @@ public class BaseTestMemStressMLKEM extends BaseTestJunit5 {
     //
     //
     @ParameterizedTest
-    @ValueSource(strings = { "ML-KEM-512", "ML_KEM_512", "MLKEM512",
-        "2.16.840.1.101.3.4.4.1", "ML-KEM-768", "ML_KEM_768",
-        "MLKEM768", "2.16.840.1.101.3.4.4.2", "ML-KEM-1024",
-        "ML_KEM_1024", "MLKEM1024", "2.16.840.1.101.3.4.4.3" })
+    @ValueSource(strings = {"ML-KEM", "ML-KEM-512", "ML_KEM_512", "MLKEM512",
+        "OID.2.16.840.1.101.3.4.4.1", "2.16.840.1.101.3.4.4.1", "ML-KEM-768", "ML_KEM_768",
+        "MLKEM768", "OID.2.16.840.1.101.3.4.4.2", "2.16.840.1.101.3.4.4.2", "ML-KEM-1024",
+        "ML_KEM_1024", "MLKEM1024", "OID.2.16.840.1.101.3.4.4.3", "2.16.840.1.101.3.4.4.3" })
     public void testMLKEM(String algorithmName) throws Exception {
         if (getProviderName().equals("OpenJCEPlusFIPS")) {
             // This is not in the FIPS provider yet.


### PR DESCRIPTION
The services `KEM` , `KeyFactory`, and `KeyPairGenerator` for `ML-KEM`
and `ML-DSA` algorithms appear to differ in a few ways compared to
`OpenJDK` providers. The following changes were made to align the
algorithms supported in OpenJCEPlus:
1. The `KeyFactory` alias names `ML-KEM` and `ML-DSA` have been
introduced. `ML-KEM` defaults to `ML_KEM_768` and `ML-DSA` defaults to
`ML_DSA_65`.
2. The `KeyPairGenerator` alias names `ML-KEM` and `ML-DSA` have been
introduced. `ML-KEM` defaults to `ML_KEM_768` and `ML-DSA` defaults to
`ML_DSA_65`.
3. The `Signature` alias `ML-DSA` was introduced. This alias defaults to
`ML_DSA_65`.
4. The `Signature` alias `ML-KEM` now uses `ML_KEM_768` as the default. Previously
this was set to `ML_KEM_512`.
5. Various PQC related algorithms now use alias names `OID.*` to
match OpenJDK.

Tests to exercise the above changes were also made accordingly. One
thing to note is that interop testing with bouncy castle failed since
BC castle provider had a different default value for ML-DSA alias name.
We choose to match OpenJDK providers instead of BC in this case.

Other updates made include:
1. References to the `ML-DSA-XX` set of algorithms were added to the
README in the `KeyPairGenerator` section.
2. The OpenJCEPlus provider string representation was updated to include
the `ML-KEM-XX` algorithms.

Fixes: https://github.com/IBM/OpenJCEPlus/issues/839

Fixes: https://github.com/IBM/OpenJCEPlus/issues/738

Signed-off-by: Jason Katonica <katonica@us.ibm.com>