### PR TITLE
Implement cleaner to replace deprecated finalizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   - [Run All Tests](#run-all-tests)
   - [Run Single Test](#run-single-test)
 - [OpenJCEPlus and OpenJCEPlusFIPS Provider SDK Installation](#openjceplus-and-openjceplusfips-provider-sdk-installation)
+- [Configuration Options](#configuration-options)
 - [Features and Algorithms](#features-and-algorithms)
 - [Contributions](#contributions)
 
@@ -263,6 +264,13 @@ take effect.
         ```console
         -Djgskit.library.path=$ANYDIRECTORY
         ```
+## Configuration Options
+
+The following properties can be used to configure application behavior at runtime.
+
+| Property | Use Case |
+|----------|----------|
+| `-Dopenjceplus.cleaners.num=<number_cleaner_threads>` | The cleaner is used for cleaning up native memory no longer in use by OpenJCEPlus and OpenJCEPlusFIPS providers. This option sets the number of cleaner threads to improve cleaning efficiency, particularly useful when encountering `Out Of Memory` (OOM) errors. Default value is `2`. |
 
 # Features And Algorithms
 
@@ -465,7 +473,6 @@ A `ProviderException` is thrown now if the user attempts to use an `ECKeyPairGen
 AES Key Wrap based on NIST SP800-38F.
 
 Code does not allow the specification of an IV. However, it will return the default ICV as defined in the NIST SP800-38F. 
-
 
 # Contributions
 

--- a/src/main/java/com/ibm/crypto/plus/provider/DSASignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -28,7 +28,7 @@ abstract class DSASignature extends SignatureSpi {
     DSASignature(OpenJCEPlusProvider provider, String ockDigestAlgo) {
         try {
             this.provider = provider;
-            this.signature = Signature.getInstance(provider.getOCKContext(), ockDigestAlgo);
+            this.signature = Signature.getInstance(provider.getOCKContext(), ockDigestAlgo, provider);
         } catch (Exception e) {
             throw provider.providerException("Failed to initialize DSA signature", e);
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/ECDSASignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECDSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -33,7 +33,7 @@ abstract class ECDSASignature extends SignatureSpi {
     ECDSASignature(OpenJCEPlusProvider provider, String ockDigestAlgo) {
         try {
             this.provider = provider;
-            this.signature = Signature.getInstance(provider.getOCKContext(), ockDigestAlgo);
+            this.signature = Signature.getInstance(provider.getOCKContext(), ockDigestAlgo, provider);
         } catch (Exception e) {
             throw provider.providerException("Failed to initialize ECDSA signature", e);
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/MessageDigest.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/MessageDigest.java
@@ -19,7 +19,7 @@ abstract class MessageDigest extends MessageDigestSpi implements Cloneable {
     MessageDigest(OpenJCEPlusProvider provider, String ockDigestAlgo) {
         try {
             this.provider = provider;
-            this.digest = Digest.getInstance(provider.getOCKContext(), ockDigestAlgo);
+            this.digest = Digest.getInstance(provider.getOCKContext(), ockDigestAlgo, provider);
         } catch (Exception e) {
             throw provider.providerException("Failure in MessageDigest", e);
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.crypto.SecretKey;
-import sun.security.util.Debug;
 
 public final class OpenJCEPlus extends OpenJCEPlusProvider {
 
@@ -66,9 +65,6 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
     // Instance of this provider, so we don't have to call the provider list
     // to find ourselves or run the risk of not being in the list.
     private static volatile OpenJCEPlus instance;
-
-    // User enabled debugging
-    private static Debug debug = Debug.getInstance(DEBUG_VALUE);
 
     private static boolean ockInitialized = false;
     private static OCKContext ockContext;

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.crypto.SecretKey;
-import sun.security.util.Debug;
 
 public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
 
@@ -61,9 +60,6 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
     // Instance of this provider, so we don't have to call the provider list
     // to find ourselves or run the risk of not being in the list.
     private static volatile OpenJCEPlusFIPS instance;
-
-    // User enabled debugging
-    private static Debug debug = Debug.getInstance(DEBUG_VALUE);
 
     private static boolean ockInitialized = false;
     private static OCKContext ockContext;

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
@@ -9,7 +9,10 @@
 package com.ibm.crypto.plus.provider;
 
 import com.ibm.crypto.plus.provider.ock.OCKContext;
+import java.lang.ref.Cleaner;
 import java.security.ProviderException;
+import java.util.concurrent.atomic.AtomicInteger;
+import sun.security.util.Debug;
 
 // Internal interface for OpenJCEPlus and OpenJCEPlus implementation classes.
 // Implemented as an abstract class rather than an interface so that 
@@ -28,10 +31,40 @@ public abstract class OpenJCEPlusProvider extends java.security.Provider {
 
     static final boolean allowLegacyHKDF = Boolean.getBoolean("openjceplus.allowLegacyHKDF");
 
+    private final Cleaner[] cleaners;
+
+    private final int DEFAULT_NUM_CLEANERS = 2;
+
+    private final int numCleaners;
+
+    private AtomicInteger count = new AtomicInteger(0);
+
+    protected static final Debug debug = Debug.getInstance(DEBUG_VALUE); 
+
     OpenJCEPlusProvider(String name, String info) {
         super(name, PROVIDER_VER, info);
+
+        numCleaners = Integer.getInteger("openjceplus.cleaners.num", DEFAULT_NUM_CLEANERS);
+        if (numCleaners < 1){
+            throw new IllegalArgumentException(numCleaners + " is an invalid number of cleaner threads, must be at least 1.");
+        }
+
+        cleaners = new Cleaner[numCleaners];
+        for (int i = 0; i < numCleaners; i++) {
+            final Cleaner cleaner = Cleaner.create();
+            cleaners[i] = cleaner;
+        }
     }
 
+    public void registerCleanable(Object owner, Runnable cleanAction) {
+        Cleaner cleaner = cleaners[Math.abs(count.getAndIncrement() % numCleaners)];
+        cleaner.register(owner, cleanAction);
+    }
+
+    public static Debug getDebug() {
+        return debug;
+    }
+    
     // Get OCK context for crypto operations
     //
     abstract OCKContext getOCKContext();

--- a/src/main/java/com/ibm/crypto/plus/provider/RSASignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSASignature.java
@@ -35,7 +35,7 @@ abstract class RSASignature extends SignatureSpi {
         try {
             this.provider = provider;
             this.ockDigestAlgo = ockDigestAlgo;
-            this.signature = Signature.getInstance(provider.getOCKContext(), ockDigestAlgo);
+            this.signature = Signature.getInstance(provider.getOCKContext(), ockDigestAlgo, provider);
         } catch (Exception e) {
             throw provider.providerException("Failed to initialize RSA signature", e);
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/Signature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/Signature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -8,6 +8,7 @@
 
 package com.ibm.crypto.plus.provider.ock;
 
+import com.ibm.crypto.plus.provider.OpenJCEPlusProvider;
 import java.security.InvalidKeyException;
 
 public final class Signature {
@@ -20,19 +21,19 @@ public final class Signature {
     private final String badIdMsg = "Digest Identifier or PKey Identifier is not valid";
     private final static String debPrefix = "SIGNATURE";
 
-    public static Signature getInstance(OCKContext ockContext, String digestAlgo)
+    public static Signature getInstance(OCKContext ockContext, String digestAlgo, OpenJCEPlusProvider provider)
             throws OCKException {
         if (ockContext == null) {
             throw new IllegalArgumentException("context is null");
         }
-        return new Signature(ockContext, digestAlgo);
+        return new Signature(ockContext, digestAlgo, provider);
     }
 
 
-    private Signature(OCKContext ockContext, String digestAlgo) throws OCKException {
+    private Signature(OCKContext ockContext, String digestAlgo, OpenJCEPlusProvider provider) throws OCKException {
         //final String methodName = "Signature(String)";
         this.ockContext = ockContext;
-        this.digest = Digest.getInstance(ockContext, digestAlgo);
+        this.digest = Digest.getInstance(ockContext, digestAlgo, provider);
         //OCKDebug.Msg (debPrefix, methodName, "digestAlgo :" + digestAlgo);
     }
 


### PR DESCRIPTION
The cleaner is the replacement for the deprecated finalize() method for cleaning objects before garbage collection.

Each class that was previously using finalize() will have an anonymous function that cleans up the necessary resources. The number of cleaner threads can be set by a property with the default value being 2. The object and its anonymous function are registered to one of the cleaner threads in round robin order.

Signed-off-by: Sabrina Lee <sabrinalee@ibm.com>