### PR TITLE
Fixes for PQC test cases and Fix Serialization issues with keys.

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/AESKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKey.java
@@ -9,7 +9,6 @@
 package com.ibm.crypto.plus.provider;
 
 import java.security.InvalidKeyException;
-import java.security.KeyRep;
 import java.util.Arrays;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -26,6 +25,8 @@ final class AESKey implements SecretKey {
 
     private transient boolean destroyed = false;
 
+    private OpenJCEPlusProvider provider = null;
+
     /**
      * Create an AES key from a given key
      *
@@ -35,12 +36,13 @@ final class AESKey implements SecretKey {
      * @exception InvalidKeyException
      *                if the given key has wrong size
      */
-    AESKey(byte[] key) throws InvalidKeyException {
+    AESKey(OpenJCEPlusProvider provider, byte[] key) throws InvalidKeyException {
         if ((key == null) || !AESUtils.isKeySizeValid(key.length)) {
             throw new InvalidKeyException("Wrong key size");
         }
 
         this.key = new byte[key.length];
+        this.provider = provider;
         System.arraycopy(key, 0, this.key, 0, key.length);
     }
 
@@ -117,7 +119,7 @@ final class AESKey implements SecretKey {
      */
     private Object writeReplace() throws java.io.ObjectStreamException {
         checkDestroyed();
-        return new KeyRep(KeyRep.Type.SECRET, getAlgorithm(), getFormat(), getEncoded());
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.SECRET, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
     }
 
     /**

--- a/src/main/java/com/ibm/crypto/plus/provider/AESKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKeyFactory.java
@@ -46,7 +46,7 @@ public final class AESKeyFactory extends SecretKeyFactorySpi {
     protected SecretKey engineGenerateSecret(KeySpec keySpec) throws InvalidKeySpecException {
         try {
             if (keySpec instanceof SecretKeySpec) {
-                return new AESKey(((SecretKeySpec) keySpec).getEncoded());
+                return new AESKey(provider, ((SecretKeySpec) keySpec).getEncoded());
             }
             throw new InvalidKeySpecException("Inappropriate key specification");
         } catch (InvalidKeyException e) {

--- a/src/main/java/com/ibm/crypto/plus/provider/AESKeyGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKeyGenerator.java
@@ -49,7 +49,7 @@ public final class AESKeyGenerator extends KeyGeneratorSpi {
         cryptoRandom.nextBytes(keyBytes);
 
         try {
-            return new AESKey(keyBytes);
+            return new AESKey(provider, keyBytes);
         } catch (InvalidKeyException e) {
             // Should never happen
             throw new ProviderException(e.getMessage());

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Key.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Key.java
@@ -9,7 +9,6 @@
 package com.ibm.crypto.plus.provider;
 
 import java.security.InvalidKeyException;
-import java.security.KeyRep;
 import java.util.Arrays;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -26,6 +25,8 @@ final class ChaCha20Key implements SecretKey, ChaCha20Constants {
 
     private transient boolean destroyed = false;
 
+    private OpenJCEPlusProvider provider = null;
+
     /**
      * Create an ChaCha20 key from a given key
      *
@@ -35,7 +36,7 @@ final class ChaCha20Key implements SecretKey, ChaCha20Constants {
      * @exception InvalidKeyException
      *                if the given key has wrong size
      */
-    ChaCha20Key(byte[] key) throws InvalidKeyException {
+    ChaCha20Key(OpenJCEPlusProvider provider, byte[] key) throws InvalidKeyException {
 
         if ((key == null) || (key.length != ChaCha20_KEY_SIZE)) {
             throw new InvalidKeyException("Wrong key size");
@@ -118,7 +119,7 @@ final class ChaCha20Key implements SecretKey, ChaCha20Constants {
      */
     private Object writeReplace() throws java.io.ObjectStreamException {
         checkDestroyed();
-        return new KeyRep(KeyRep.Type.SECRET, getAlgorithm(), getFormat(), getEncoded());
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.SECRET, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
     }
 
     /**

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyFactory.java
@@ -46,7 +46,7 @@ public final class ChaCha20KeyFactory extends SecretKeyFactorySpi {
     protected SecretKey engineGenerateSecret(KeySpec keySpec) throws InvalidKeySpecException {
         try {
             if (keySpec instanceof SecretKeySpec) {
-                return new ChaCha20Key(((SecretKeySpec) keySpec).getEncoded());
+                return new ChaCha20Key(provider, ((SecretKeySpec) keySpec).getEncoded());
             }
             throw new InvalidKeySpecException("Inappropriate key specification");
         } catch (InvalidKeyException e) {

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyGenerator.java
@@ -49,7 +49,7 @@ public final class ChaCha20KeyGenerator extends KeyGeneratorSpi implements ChaCh
         cryptoRandom.nextBytes(keyBytes);
 
         try {
-            return new ChaCha20Key(keyBytes);
+            return new ChaCha20Key(provider, keyBytes);
         } catch (InvalidKeyException e) {
             // Should never happen
             throw new ProviderException(e.getMessage());

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeKey.java
@@ -9,7 +9,6 @@
 package com.ibm.crypto.plus.provider;
 
 import java.security.InvalidKeyException;
-import java.security.KeyRep;
 import java.util.Arrays;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.DESedeKeySpec;
@@ -28,6 +27,8 @@ final class DESedeKey implements SecretKey, Destroyable {
 
     private transient boolean destroyed = false;
 
+    private OpenJCEPlusProvider provider = null;
+
     /**
      * Creates a DES-EDE key from a given key.
      *
@@ -35,7 +36,7 @@ final class DESedeKey implements SecretKey, Destroyable {
      *
      * @exception InvalidKeyException if the given key has a wrong size
      */
-    DESedeKey(byte[] key) throws InvalidKeyException {
+    DESedeKey(OpenJCEPlusProvider provider, byte[] key) throws InvalidKeyException {
         if ((key == null) || (key.length < DESedeKeySpec.DES_EDE_KEY_LEN)) {
             throw new InvalidKeyException("Wrong key size");
         }
@@ -120,7 +121,7 @@ final class DESedeKey implements SecretKey, Destroyable {
      */
     private Object writeReplace() throws java.io.ObjectStreamException {
         checkDestroyed();
-        return new KeyRep(KeyRep.Type.SECRET, getAlgorithm(), getFormat(), getEncoded());
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.SECRET, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
     }
 
     /**

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeKeyFactory.java
@@ -47,10 +47,10 @@ public final class DESedeKeyFactory extends SecretKeyFactorySpi {
     protected SecretKey engineGenerateSecret(KeySpec keySpec) throws InvalidKeySpecException {
         try {
             if (keySpec instanceof DESedeKeySpec) {
-                return new DESedeKey(((DESedeKeySpec) keySpec).getKey());
+                return new DESedeKey(provider, ((DESedeKeySpec) keySpec).getKey());
             }
             if (keySpec instanceof SecretKeySpec) {
-                return new DESedeKey(((SecretKeySpec) keySpec).getEncoded());
+                return new DESedeKey(provider, ((SecretKeySpec) keySpec).getEncoded());
             }
             throw new InvalidKeySpecException("Inappropriate key specification");
         } catch (InvalidKeyException e) {

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeKeyGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeKeyGenerator.java
@@ -74,7 +74,7 @@ public final class DESedeKeyGenerator extends KeyGeneratorSpi {
         }
 
         try {
-            return new DESedeKey(rawkey);
+            return new DESedeKey(provider, rawkey);
         } catch (InvalidKeyException e) {
             // Should never happen
             throw new ProviderException(e.getMessage());

--- a/src/main/java/com/ibm/crypto/plus/provider/DHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHKeyAgreement.java
@@ -204,7 +204,7 @@ public final class DHKeyAgreement extends KeyAgreementSpi {
         byte[] secret = engineGenerateSecret();
         if (algorithm.equalsIgnoreCase("DESede") || algorithm.equalsIgnoreCase("TripleDES")) {
             // Triple DES
-            return new DESedeKey(secret);
+            return new DESedeKey(provider, secret);
         } else if (algorithm.equalsIgnoreCase("AES")) {
             // AES
             int keysize = secret.length;

--- a/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
@@ -265,6 +265,11 @@ final class DHPrivateKey extends PKCS8Key implements javax.crypto.interfaces.DHP
         return "DH";
     }
 
+    protected Object writeReplace() throws java.io.ObjectStreamException {
+        checkDestroyed();
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PRIVATE, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
+    } 
+    
     /**
      * Returns the encoding format of this key: "PKCS#8"
      */

--- a/src/main/java/com/ibm/crypto/plus/provider/DHPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHPublicKey.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
 import java.security.InvalidKeyException;
-import java.security.KeyRep;
 import java.security.spec.InvalidParameterSpecException;
 import javax.crypto.spec.DHParameterSpec;
 import javax.security.auth.DestroyFailedException;
@@ -402,7 +401,7 @@ final class DHPublicKey extends X509Key
      */
     private Object writeReplace() throws java.io.ObjectStreamException {
         checkDestroyed();
-        return new KeyRep(KeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded());
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
     }
 
     public String toString() {

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAPrivateKey.java
@@ -259,6 +259,11 @@ final class DSAPrivateKey extends PKCS8Key
         }
     }
 
+    protected Object writeReplace() throws java.io.ObjectStreamException {
+        checkDestroyed();
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PRIVATE, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
+    } 
+    
     public static boolean equals(DSAParams spec1, DSAParams spec2) {
         if (spec1 == spec2) {
             return true;

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAPublicKey.java
@@ -14,7 +14,6 @@ import java.io.Serializable;
 import java.math.BigInteger;
 import java.security.AlgorithmParameters;
 import java.security.InvalidKeyException;
-import java.security.KeyRep;
 import java.security.interfaces.DSAParams;
 import java.security.spec.DSAParameterSpec;
 import java.security.spec.InvalidParameterSpecException;
@@ -239,7 +238,7 @@ final class DSAPublicKey extends X509Key
      */
     private Object writeReplace() throws java.io.ObjectStreamException {
         checkDestroyed();
-        return new KeyRep(KeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded());
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
     }
 
     /**

--- a/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
@@ -641,8 +641,12 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
         } catch (InvalidParameterSpecException e) {
             throw new IOException("Invalid EC private key");
         }
-
-    }
+    }   
+     
+    protected Object writeReplace() throws java.io.ObjectStreamException {
+        checkDestroyed();
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PRIVATE, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
+    } 
 
     /**
      * Destroys this key. A call to any of its other methods after this will

--- a/src/main/java/com/ibm/crypto/plus/provider/ECPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECPublicKey.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.security.AlgorithmParameters;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
-import java.security.KeyRep;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
 import java.security.spec.InvalidParameterSpecException;
@@ -191,7 +190,7 @@ final class ECPublicKey extends X509Key
      */
     private Object writeReplace() throws java.io.ObjectStreamException {
         checkDestroyed();
-        return new KeyRep(KeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded());
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
     }
 
     /*

--- a/src/main/java/com/ibm/crypto/plus/provider/JCEPlusKeyRep.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/JCEPlusKeyRep.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package com.ibm.crypto.plus.provider;
+
+import java.io.NotSerializableException;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.security.KeyFactory;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Locale;
+import javax.crypto.spec.SecretKeySpec;
+
+class JCEPlusKeyRep implements Serializable {
+
+    private static final long serialVersionUID = -4441922173618237196L;
+
+    protected enum Type {
+
+        /** Type for secret keys. */
+        SECRET,
+
+        /** Type for public keys. */
+        PUBLIC,
+
+        /** Type for private keys. */
+        PRIVATE
+    }
+
+    private static final String PKCS8 = "PKCS#8";
+    private static final String X509 = "X.509";
+    private static final String RAW = "RAW";
+
+    private final Type keyType;
+
+    private final String keyAlg;
+
+    private final String encodingFormat;
+
+    private final byte[] encodedKey;
+
+    private final String provider;
+
+    public JCEPlusKeyRep(Type type, String algorithm,
+            String format, byte[] encoded, String oJcePlusProvider) {
+ 
+        if (oJcePlusProvider == null || type == null || algorithm == null ||
+            format == null || encoded == null) {
+            throw new NullPointerException("invalid null input(s)");
+        }
+        
+        this.keyType = type;
+        this.keyAlg = algorithm;
+        this.encodingFormat = format.toUpperCase(Locale.ENGLISH);
+        this.encodedKey = encoded.clone();
+        this.provider = oJcePlusProvider;
+    }
+     
+    protected Object readResolve() throws ObjectStreamException {
+        try {
+            if (keyType == Type.SECRET && RAW.equals(encodingFormat)) {
+                return new SecretKeySpec(encodedKey, keyAlg);
+            } else if (keyType == Type.PUBLIC && X509.equals(encodingFormat)) {
+                KeyFactory f = KeyFactory.getInstance(keyAlg, provider);
+                return f.generatePublic(new X509EncodedKeySpec(encodedKey));
+            } else if (keyType == Type.PRIVATE && PKCS8.equals(encodingFormat)) {
+                KeyFactory f = KeyFactory.getInstance(keyAlg, provider);
+                return f.generatePrivate(new PKCS8EncodedKeySpec(encodedKey));
+            } else {
+                throw new NotSerializableException("Key type and format combination invalid: " +
+                    keyType + " " + encodingFormat);
+            }
+        } catch (NotSerializableException nse) {
+            throw nse;
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            NotSerializableException nse = new NotSerializableException("java.security.Key: " +
+                "[" + keyType + "] " +
+                "[" + keyAlg + "] " +
+                "[" + encodingFormat + 
+                "[" + provider + "]");
+            nse.initCause(e);
+            throw nse;
+        }
+    }
+}

--- a/src/main/java/com/ibm/crypto/plus/provider/PBKDF2KeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PBKDF2KeyImpl.java
@@ -17,7 +17,6 @@ import java.io.ObjectStreamException;
 import java.lang.ref.Reference;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-import java.security.KeyRep;
 import java.security.MessageDigest;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Arrays;
@@ -41,6 +40,7 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
 
     private static final long serialVersionUID = -2234868909660948157L;
 
+    private OpenJCEPlusProvider provider = null;
     private char[] passwd;
     private byte[] salt;
     private final int iterCount;
@@ -67,6 +67,7 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
      */
     PBKDF2KeyImpl(OpenJCEPlusProvider provider, PBEKeySpec keySpec, String prfAlgo)
             throws InvalidKeySpecException {
+        this.provider = provider;
         this.passwd = keySpec.getPassword();
         // Convert the password from char[] to byte[]
         byte[] passwdBytes = getPasswordBytes(this.passwd);
@@ -216,7 +217,7 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
      */
     private Object writeReplace() throws ObjectStreamException {
         try {
-            return new KeyRep(KeyRep.Type.SECRET, getAlgorithm(), getFormat(), key);
+            return new JCEPlusKeyRep(JCEPlusKeyRep.Type.SECRET, getAlgorithm(), getFormat(), key, provider.getName());
         } finally {
             // prevent this from being cleaned for the above block
             Reference.reachabilityFence(this);

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateCrtKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateCrtKey.java
@@ -293,6 +293,11 @@ final class RSAPrivateCrtKey extends PKCS8Key
         return this.publicExponent;
     }
 
+    protected Object writeReplace() throws java.io.ObjectStreamException {
+        checkDestroyed();
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PRIVATE, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
+    } 
+
     /**
      * Destroys this key. A call to any of its other methods after this will
      * cause an IllegalStateException to be thrown.

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateKey.java
@@ -228,6 +228,11 @@ final class RSAPrivateKey extends PKCS8Key
         return this.modulus;
     }
 
+    protected Object writeReplace() throws java.io.ObjectStreamException {
+        checkDestroyed();
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PRIVATE, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
+    } 
+
     /**
      * Destroys this key. A call to any of its other methods after this will
      * cause an IllegalStateException to be thrown.

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPublicKey.java
@@ -13,7 +13,6 @@ import com.ibm.crypto.plus.provider.ock.RSAKey;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.InvalidKeyException;
-import java.security.KeyRep;
 import java.security.ProviderException;
 import java.security.spec.AlgorithmParameterSpec;
 import javax.security.auth.DestroyFailedException;
@@ -244,7 +243,7 @@ final class RSAPublicKey extends X509Key
      */
     private Object writeReplace() throws java.io.ObjectStreamException {
         checkDestroyed();
-        return new KeyRep(KeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded());
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
     }
 
     /**

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
@@ -17,7 +17,6 @@ import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
-import java.security.KeyRep;
 import java.security.interfaces.XECPrivateKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.NamedParameterSpec;
@@ -545,7 +544,7 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
     }
 
     protected Object writeReplace() throws java.io.ObjectStreamException {
-        return new KeyRep(KeyRep.Type.PRIVATE, getAlgorithm(), getFormat(), getEncoded());
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PRIVATE, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
     }
 
     /**

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
@@ -16,7 +16,6 @@ import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
-import java.security.KeyRep;
 import java.security.interfaces.XECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidParameterSpecException;
@@ -490,6 +489,6 @@ final class XDHPublicKeyImpl extends X509Key implements XECPublicKey, Destroyabl
     }
 
     protected Object writeReplace() throws java.io.ObjectStreamException {
-        return new KeyRep(KeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded());
+        return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PUBLIC, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
     }
 }

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/OCKException.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/OCKException.java
@@ -41,6 +41,12 @@ public final class OCKException extends java.lang.Exception {
         this.code = GKR_UNSPECIFIED;
     }
 
+    public OCKException(String s, Throwable cause) {
+        super(s, cause);
+        this.code = GKR_UNSPECIFIED;
+    }
+
+
     public OCKException(int code) {
         super(errorMessage(code));
         this.code = code;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestKeySerialization.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestKeySerialization.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+package ibm.jceplus.junit.base;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.security.AlgorithmParameters;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class BaseTestKeySerialization extends BaseTestJunit5Signature {
+    
+    static final byte[] origMsg = "this is the original message to be signed".getBytes();
+    static final byte[] plainText = "123456781234567812345678123456781234567812345678123456781234567".getBytes();
+
+    @ParameterizedTest
+    @CsvSource({"RSA, SHA256withRSA", "EC, SHA256withECDSA"})
+    public void SerializationKeyPairTest (String algorithm, String sigAlg) throws Exception {
+        KeyPairGenerator kpg = null;
+
+        kpg = KeyPairGenerator.getInstance(algorithm, getProviderName());
+
+        KeyPair keyPair = kpg.generateKeyPair();
+
+        // serialize and de-serialize the public key while storing in file
+        File publicKeyFile = createTempFile();
+        serializeKey(keyPair.getPublic(), publicKeyFile);
+        PublicKey deserializedPublicKey = (PublicKey) deserializeKey(publicKeyFile);
+
+        // private key serialize and de-serialize
+        File privateKeyFile = createTempFile();
+        serializeKey(keyPair.getPrivate(), privateKeyFile);
+        PrivateKey deserializedPrivateKey = (PrivateKey) deserializeKey(privateKeyFile);
+
+        assertEquals(keyPair.getPublic().getClass().getName(), 
+            deserializedPublicKey.getClass().getName(),
+            "Public deserialized class does not match original");
+
+        assertEquals(keyPair.getPrivate().getClass().getName(), 
+            deserializedPrivateKey.getClass().getName(),
+            "Private deserialized class does not match original");
+
+        assertArrayEquals(keyPair.getPublic().getEncoded(), 
+            deserializedPublicKey.getEncoded(),
+            "Public deserialized key does not match original");
+
+        assertArrayEquals(keyPair.getPrivate().getEncoded(), 
+            deserializedPrivateKey.getEncoded(),
+            "Private deserialized key does not match original");
+
+        doSignVerify(sigAlg, origMsg, keyPair.getPrivate(), deserializedPublicKey);
+
+        doSignVerify(sigAlg, origMsg, deserializedPrivateKey, keyPair.getPublic());
+
+    }
+
+    @ParameterizedTest
+    @CsvSource({"AES, 256, AES/CBC/PKCS5Padding", "AES, 256, AES/GCM/NoPadding"})
+    public void SerializationSecretKeyTest (String algorithm, int size, String cipherName) throws Exception {
+        KeyGenerator keyGen = null;
+        SecretKey key = null;
+        Cipher cp = null;
+
+        
+        keyGen = KeyGenerator.getInstance(algorithm, getProviderName());
+        keyGen.init(size);
+        key = keyGen.generateKey();
+
+        // serialize and de-serialize the public key while storing in file
+        File keyFile = createTempFile();
+        serializeKey(key, keyFile);
+        SecretKey deserializedKey = (SecretKey) deserializeKey(keyFile);
+
+
+        assertArrayEquals(key.getEncoded(), 
+            deserializedKey.getEncoded(),
+            "Key deserialized key does not match original");
+
+        cp = Cipher.getInstance(cipherName, getProviderName());
+        cp.init(Cipher.ENCRYPT_MODE, key);
+        byte[] cipherText = cp.doFinal(plainText);
+        AlgorithmParameters params = cp.getParameters();
+
+        // Verify the text
+        cp.init(Cipher.DECRYPT_MODE, deserializedKey, params);
+        byte[] newPlainText = cp.doFinal(cipherText, 0, cipherText.length);
+        assertArrayEquals(plainText, newPlainText, "Secret keys are different");
+    }
+
+    @ParameterizedTest
+    @CsvSource({"PBKDF2WithHmacSHA224", "PBKDF2WithHmacSHA256",
+        "PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512"})
+    public void SerializationPBKDF2tKeyTest (String algorithm) throws Exception {
+        SecretKey key = null;
+        PBEKeySpec pbeks = new PBEKeySpec("ABCDEFGHIJ".toCharArray(), new byte[32], 10000, 512);
+ 
+        SecretKeyFactory skf = SecretKeyFactory.getInstance(algorithm, this.getProviderName());
+        key = skf.generateSecret(pbeks);
+
+        // serialize and de-serialize key while storing in file
+        File keyFile = createTempFile();
+        serializeKey(key, keyFile);
+        SecretKey deserializedKey = (SecretKey) deserializeKey(keyFile);
+
+        assertArrayEquals(key.getEncoded(), 
+            deserializedKey.getEncoded(),
+            "Key deserialized key does not match original");
+
+    }
+
+    protected KeyPair generateKeyPair(KeyPairGenerator keyPairGen) throws Exception {
+        KeyPair keyPair = keyPairGen.generateKeyPair();
+
+        if (keyPair.getPrivate() == null) {
+            fail("Private key is null");
+        }
+
+        if (keyPair.getPublic() == null) {
+            fail("Public key is null");
+        }
+
+        return keyPair;
+    }
+
+    private File createTempFile() {
+        File file = null;
+        try {
+            file = File.createTempFile("key", ".ser");
+            return file;
+        } catch (IOException e) {
+            fail("temporary file cannot be created");
+        }
+        return file;
+    }
+
+    private boolean destroyFile(File file) {
+        return file.delete();
+    }
+
+    private void serializeKey(Object key, File file) {
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(new FileOutputStream(file))) {
+            objectOutputStream.writeObject(key);
+        } catch (IOException e) {
+            file.deleteOnExit();
+            fail("Error during serialization: " + e.getMessage());
+        }
+    }
+
+    private Object deserializeKey(File file) {
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new FileInputStream(file))) {
+            Object object = objectInputStream.readObject();
+            return object;
+        } catch (IOException | ClassNotFoundException e) {
+            file.deleteOnExit();
+            fail("Error during deserialization: " + e.getMessage());
+        }
+        return null;
+    }
+}    

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAll.java
@@ -93,6 +93,7 @@ import org.junit.platform.suite.api.Suite;
     TestInvalidArrayIndex.class,
     TestIsAssignableFromOrder.class,
     TestKeyEncodings.class,
+    TestKeySerialization.class,
     TestMD5.class,
     TestMiniRSAPSS2.class,
     TestPBKDF2.class,

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestKeySerialization.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestKeySerialization.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.junit.openjceplus;
+
+import ibm.jceplus.junit.base.BaseTestKeySerialization;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestKeySerialization extends BaseTestKeySerialization {
+   
+    @BeforeAll
+    public void beforeAll() {
+        Utils.loadProviderTestSuite();
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
+    }
+}

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestAll.java
@@ -73,6 +73,7 @@ import org.junit.platform.suite.api.Suite;
     TestImplementationClassesFinal.class,
     TestInvalidArrayIndex.class,
     TestKeyEncodings.class,
+    TestKeySerialization.class,
     TestMiniRSAPSS2.class,
     TestPBKDF2.class,
     TestPBKDF2Interop.class,

--- a/src/test/java/ibm/jceplus/junit/openjceplusfips/TestKeySerialization.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplusfips/TestKeySerialization.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.junit.openjceplusfips;
+
+import ibm.jceplus.junit.base.BaseTestKeySerialization;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestKeySerialization extends BaseTestKeySerialization {
+   
+    @BeforeAll
+    public void beforeAll() {
+        Utils.loadProviderTestSuite();
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
+    }
+}


### PR DESCRIPTION
Needed to remove the dependency of JDK17 in the testcases. Also, there is an issue with serialization. When KeyRep is used to serialize the key the provider order is used to de serialize the key which can cause the wrong key to be created. So, added a new KeyRep class that contains the provider which will allow the correct key to be created.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/680

Signed-off-by: John Peck <[140550562+johnpeck-us-ibm@users.noreply.github.com](mailto:140550562+johnpeck-us-ibm@users.noreply.github.com)>