### PR TITLE
Allow mvn test execution for entire windows family

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ Build Status:
 
 ## How to Build `OpenJCEPlus` and Java Native Interface Library
 
-`OpenJCEPlus` and `OpenJCEPlusFIPS` providers are currently supported on the following architectures and operating system combinations as reported by `mvn --version` in the values `OS name` and `arch`:
-| OS name                 | arch        |
+`OpenJCEPlus` and `OpenJCEPlusFIPS` providers are currently supported on the following architectures and operating system combinations as reported by `mvn --version` in the values `OS name` and `arch` or `family` in the case of windows:
+| OS name ( or family )   | arch        |
 | ----------------------- | ----------- |
 | linux                   | aarch64     |
 | linux                   | amd64       |
 | linux                   | s390x       |
 | linux                   | ppc64le     |
-| Windows Server 2022     | amd64       |
+| Windows (family)        | amd64       |
 | AIX                     | ppc64       |
 | Mac OS X                | aarch64     |
 | Mac OS X                | amd64       |

--- a/pom.xml
+++ b/pom.xml
@@ -119,10 +119,10 @@
             </properties>
           </profile>
           <profile>
-            <id>Profile for Windows Server 2022 amd64</id>
+            <id>Profile for Windows amd64</id>
             <activation>
               <os>
-                <name>Windows Server 2022</name>
+                <family>Windows</family>
                 <arch>amd64</arch>
               </os>
             </activation>


### PR DESCRIPTION
While we typically execute builds and testing for openjceplus on windows 2022 we would like to remove the restriction so they can be run on other machines also.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/844

Signed-off-by: Jason Katonica <katonica@us.ibm.com>