### PR TITLE
Modify Jenkins pipelines discard policy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -265,6 +265,9 @@ def run(platform) {
  * and uploaded into Artifactory, for personal use or use by other pipelines.
  */
 pipeline {
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+    }
     parameters {
         separator(name: "TargetPlatforms", sectionHeader: "Target Platforms",
             separatorStyle: "border-width: 0",

--- a/JenkinsfilePerformance
+++ b/JenkinsfilePerformance
@@ -245,6 +245,9 @@ def run(platform) {
  * and uploaded into Artifactory, for personal use or use by other pipelines.
  */
 pipeline {
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+    }
     parameters {
         separator(name: "TargetPlatforms", sectionHeader: "Target Platforms",
             separatorStyle: "border-width: 0",


### PR DESCRIPTION
The discard policy was modified to keep only the past 100 builds in each branch.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>