### PR TITLE
 Fix pipeline branch names for artifactory archival

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -245,7 +245,7 @@ def upload_artifactory(uploadSpec) {
  */
 def getSanitizedBranchName() {
     SANITIZED_BRANCH_NAME=sh(
-        script: "echo $env.GIT_BRANCH | tr -c '[:alpha:][:digit:][.]' '-' | tr -d '\r\n' | sed 's/.\$//'",
+        script: "echo $env.BRANCH_NAME | tr -c '[:alpha:][:digit:][.]' '-' | tr -d '\r\n' | sed 's/.\$//'",
         returnStdout: true
     ).trim()
     return SANITIZED_BRANCH_NAME


### PR DESCRIPTION
The branch name was always resolving to a null value causing builds
with the same build number to upload on top of each other in various
branches. This update seems to restore the correct branch name by using
a different environment variable set by Jenkins checkout plugin.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>