### PR TITLE
Migrate to use xlclang compiler for AIX platform

### DIFF
--- a/src/main/native/CCM.c
+++ b/src/main/native/CCM.c
@@ -145,7 +145,7 @@ void handleIV_CCM(int ivLength, int keyLen, int blockSize, int J0Offset,
         }
 
         // Appending IV.length
-        putLongtoByteArray_CCM(ivLengthOG * 8, (signed char*)&lastIV,
+        putLongtoByteArray_CCM(ivLengthOG * 8, (char*)&lastIV,
                                lastIVLen - 8);
         z_kimd_native_CCM((signed char*)&lastIV, lastIVLen, 0,
                           (signed char*)&ghashParamBlock, 65);

--- a/src/main/native/GCM.c
+++ b/src/main/native/GCM.c
@@ -125,6 +125,8 @@ ICC_AES_GCM_CTX* getOrfreeGCMContext(ICC_CTX* ockCtx, int keyLen) {
         gcmCtx        = NULL;
         return NULL;
     }
+#else
+    return NULL;
 #endif
 }
 
@@ -961,7 +963,7 @@ void handleIV(int ivLength, int keyLen, int blockSize, int J0Offset, char* iv,
         }
 
         // Appending IV.length
-        putLongtoByteArray(ivLengthOG * 8, (signed char*)&lastIV,
+        putLongtoByteArray(ivLengthOG * 8, (char*)&lastIV,
                            lastIVLen - 8);
         z_kimd_native((signed char*)&lastIV, lastIVLen, 0,
                       (signed char*)&ghashParamBlock, 65);

--- a/src/main/native/jgskit.mac.mak
+++ b/src/main/native/jgskit.mac.mak
@@ -9,8 +9,9 @@
 
 TOPDIR=../../..
 
-CFLAGS= -fPIC -DMAC -Werror -pedantic -Wall -fstack-protector
-LDFLAGS= -shared -m64 -DMAC
+CFLAGS= -fPIC -DMAC -Werror -std=gnu99 -pedantic -Wall -fstack-protector -m64
+LDFLAGS= -shared -m64
+CC = gcc
 
 ifeq (${PLATFORM},x86_64-mac)
   ARCHFLAGS= -arch x86_64
@@ -62,14 +63,14 @@ OBJS = \
 
 TARGET = ${HOSTOUT}/libjgskit.dylib
 
-all : ${TARGET}
+all : displaycompiler ${TARGET}
 
 ${TARGET} : ${OBJS}
-	gcc ${LDFLAGS} ${ARCHFLAGS} -o ${TARGET} ${OBJS} -L ${GSKIT_HOME}/lib64 -l jgsk8iccs
+	${CC} ${LDFLAGS} ${ARCHFLAGS} -o ${TARGET} ${OBJS} -L ${GSKIT_HOME}/lib64 -l jgsk8iccs
 
 ${HOSTOUT}/%.o : %.c
 	test -d ${@D} || mkdir -p ${@D} 2>/dev/null
-	gcc \
+	${CC} \
 		${ARCHFLAGS} \
 		${CFLAGS} \
 		${DEBUG_FLAGS} \
@@ -80,6 +81,12 @@ ${HOSTOUT}/%.o : %.c
 		-I${OPENJCEPLUS_HEADER_FILES} \
 		-o $@ \
 		$<
+
+displaycompiler :
+	@echo "-------------------------------------"
+	@echo "Compiler version: " && ${CC} --version
+	@echo "Building with ${CC} compiler..."
+	@echo "-------------------------------------"
 
 # Force BuildDate to be compiled every time.
 #
@@ -109,4 +116,4 @@ clean :
 	rm -f com_ibm_crypto_plus_provider_ock_FastJNIBuffer.h
 	rm -f com_ibm_crypto_plus_provider_ock_NativeInterface.h
 
-.PHONY : all headers clean FORCE
+.PHONY : all headers clean FORCE displaycompiler

--- a/src/main/native/jgskit.mak
+++ b/src/main/native/jgskit.mak
@@ -11,35 +11,33 @@ TOPDIR=../../..
 
 PLAT=x86
 CC=gcc
-CFLAGS= -fPIC
+CFLAGS= -fPIC -Werror -std=gnu99 -pedantic -Wall -fstack-protector
 LDFLAGS= -shared
-AIX_LIBPATH = /usr/lib:/lib
 
 ifeq (${PLATFORM},arm-linux64)
   PLAT=xr
-  CFLAGS+= -DLINUX -Werror -std=gnu99 -pedantic -Wall -fstack-protector
-  LDFLAGS+= -DLINUX
+  CFLAGS+= -DLINUX
   OSINCLUDEDIR=linux
 else ifeq (${PLATFORM},ppc-aix64)
   PLAT=ap
-  CC=xlc
-  CFLAGS= -qcpluscmt -q64 -qpic -DAIX -qhalt=w
-  LDFLAGS= -G -q64 -blibpath:${AIX_LIBPATH}
+  CC=xlclang
+  CFLAGS+= -DAIX -m64
+  LDFLAGS+= -brtl -m64
   OSINCLUDEDIR=aix
 else ifeq (${PLATFORM},ppcle-linux64)
   PLAT=xl
-  CFLAGS+= -DLINUX -Werror
+  CFLAGS+= -DLINUX -m64
   LDFLAGS+= -m64
   OSINCLUDEDIR=linux
 else ifeq (${PLATFORM},s390-linux64)
   PLAT=xz
+  CFLAGS+= -DS390_PLATFORM -DLINUX -m64
   LDFLAGS+= -m64
-  CFLAGS+= -DS390_PLATFORM -DLINUX -Werror
   OSINCLUDEDIR=linux
 else ifeq (${PLATFORM},s390-zos64)
   CC=xlc
   PLAT=mz
-  CFLAGS= -DS390
+  CFLAGS= -DS390 -m64
   CFLAGS+= -O3 -Wc,strict,hgpr,hot
   CFLAGS+= -Wc,XPLINK,LP64,DLL,exportall
   LDFLAGS= -Wl,XPLINK,LP64,DLL,AMODE=64
@@ -47,7 +45,7 @@ else ifeq (${PLATFORM},s390-zos64)
   OSINCLUDEDIR=zos
 else ifeq (${PLATFORM},x86-linux64)
   PLAT=xa
-  CFLAGS+= -DLINUX -Werror -std=gnu99 -pedantic -Wall -fstack-protector
+  CFLAGS+= -DLINUX -m64
   LDFLAGS+= -m64
   OSINCLUDEDIR=linux
 endif
@@ -99,7 +97,7 @@ TARGET = ${HOSTOUT}/libjgskit.so
 
 GSK8ICCS64=jgsk8iccs_64
 
-all : ${TARGET}
+all : displaycompiler ${TARGET}
 
 ifneq (,$(filter s390-zos64,${PLATFORM}))
   TARGET_LIBS := ${ICCARCHIVE}
@@ -122,6 +120,11 @@ ${HOSTOUT}/%.o : %.c
 		-I${OPENJCEPLUS_HEADER_FILES} \
 		-o $@ \
 		$<
+
+displaycompiler :
+	@echo "Compiler version: " && ${CC} --version
+	@echo "Building with ${CC} compiler..."
+	@echo "-------------------------------------"
 
 # Force BuildDate to be compiled every time.
 #
@@ -151,4 +154,4 @@ clean :
 	rm -f com_ibm_crypto_plus_provider_ock_FastJNIBuffer.h
 	rm -f com_ibm_crypto_plus_provider_ock_NativeInterface.h
 
-.PHONY : all headers clean FORCE
+.PHONY : all headers clean FORCE displaycompiler

--- a/src/main/native/jgskit.win64.cygwin.mak
+++ b/src/main/native/jgskit.win64.cygwin.mak
@@ -11,6 +11,7 @@ TOPDIR = $(MAKEDIR)\..\..\..
 
 PLAT = win
 CFLAGS= -nologo -DWINDOWS
+CC = cl
 
 #DEBUG_DETAIL = -DDEBUG_RANDOM_DETAIL -DDEBUG_RAND_DETAIL -DDEBUG_DH_DETAIL -DDEBUG_DSA_DETAIL -DDEBUG_DIGEST_DETAIL -DDEBUG_EC_DETAIL  -DDEBUG_EXTENDED_RANDOM_DETAIL -DDEBUG_GCM_DETAIL -DDEBUG_CCM_DETAIL -DDEBUG_HMAC_DETAIL -DDEBUG_PKEY_DETAIL -DDEBUG_CIPHER_DETAIL -DDEBUG_RSA_DETAIL -DDEBUG_SIGNATURE_DETAIL -DDEBUG_SIGNATURE_DSANONE_DETAIL -DDEBUG_SIGNATURE_RSASSL_DETAIL -DDEBUG_HKDF_DETAIL -DDEBUG_RSAPSS_DETAIL -DDEBUG_PBKDF_DETAIL
 
@@ -55,7 +56,7 @@ TARGET = libjgskit_64.dll
 JGSKIT_RC_SRC = jgskit_resource.rc
 JGSKIT_RC_OBJ = jgskit_resource.res
 
-all : copy
+all : displaycompiler copy
 
 copy : $(TARGET)
 	-@mkdir -p $(HOSTOUT) 2>nul
@@ -70,7 +71,7 @@ $(JGSKIT_RC_OBJ) : $(JGSKIT_RC_SRC)
 	rc $(BUILD_CFLAGS) -Fo$@ $(JGSKIT_RC_SRC)
 
 .c.obj :
-	cl \
+	$(CC) \
 		$(DEBUG_FLAGS) \
 		$(CFLAGS) \
 		-c \
@@ -78,6 +79,11 @@ $(JGSKIT_RC_OBJ) : $(JGSKIT_RC_SRC)
 		-I"$(JAVA_HOME)/include" \
 		-I"$(JAVA_HOME)/include/win32" \
 		$*.c
+
+displaycompiler :
+	@echo "Compiler version: " && $(CC)
+	@echo "Building with $(CC) compiler..."
+	@echo "-------------------------------------"
 
 # Force BuildDate to be recompiled every time
 #
@@ -104,4 +110,4 @@ clean :
 	-@del $(HOSTOUT)\*.dll
 	-@del $(HOSTOUT)\*.res
 
-.PHONY : all clean copy headers
+.PHONY : all clean copy headers displaycompiler

--- a/src/main/native/jgskit.win64.mak
+++ b/src/main/native/jgskit.win64.mak
@@ -11,6 +11,7 @@ TOPDIR = $(MAKEDIR)../../..
 
 PLAT = win
 CFLAGS= -nologo -DWINDOWS
+CC = cl
 
 #DEBUG_DETAIL = -DDEBUG_RANDOM_DETAIL -DDEBUG_RAND_DETAIL -DDEBUG_DH_DETAIL -DDEBUG_DSA_DETAIL -DDEBUG_DIGEST_DETAIL -DDEBUG_EC_DETAIL  -DDEBUG_EXTENDED_RANDOM_DETAIL -DDEBUG_GCM_DETAIL -DDEBUG_CCM_DETAIL -DDEBUG_HMAC_DETAIL -DDEBUG_PKEY_DETAIL -DDEBUG_CIPHER_DETAIL -DDEBUG_RSA_DETAIL -DDEBUG_SIGNATURE_DETAIL -DDEBUG_SIGNATURE_DSANONE_DETAIL -DDEBUG_SIGNATURE_RSASSL_DETAIL -DDEBUG_HKDF_DETAIL -DDEBUG_RSAPSS_DETAIL -DDEBUG_PBKDF_DETAIL
 
@@ -56,7 +57,7 @@ TARGET = $(HOSTOUT)/libjgskit_64.dll
 JGSKIT_RC_SRC = jgskit_resource.rc
 JGSKIT_RC_OBJ = $(HOSTOUT)/jgskit_resource.res
 
-all : $(TARGET)
+all : displaycompiler $(TARGET)
 
 $(TARGET) : $(OBJS) $(JGSKIT_RC_OBJ)
 	link -dll -out:$@ $(OBJS) $(JGSKIT_RC_OBJ) -LIBPATH:"$(GSKIT_HOME)/lib" jgsk8iccs_64.lib
@@ -66,7 +67,7 @@ $(JGSKIT_RC_OBJ) : $(JGSKIT_RC_SRC)
 
 $(HOSTOUT)/%.obj : %.c
 	-@mkdir -p $(HOSTOUT) 2>nul
-	cl \
+	$(CC) \
 		$(DEBUG_FLAGS) \
 		$(CFLAGS) \
 		-c \
@@ -76,6 +77,11 @@ $(HOSTOUT)/%.obj : %.c
 		-I"$(OPENJCEPLUS_HEADER_FILES)" \
 		-Fo$@ \
 		$<
+
+displaycompiler :
+	@echo "Compiler version: " && $(CC)
+	@echo "Building with $(CC) compiler..."
+	@echo "-------------------------------------"
 
 # Force BuildDate to be recompiled every time
 #

--- a/utils.groovy
+++ b/utils.groovy
@@ -180,7 +180,9 @@ def runOpenJCEPlus(command, software) {
 
         def java_home = "export JAVA_HOME=$WORKSPACE/java/jdk;"
         def gskit_home = "export GSKIT_HOME=$WORKSPACE/openjceplus/OCK/jgsk_sdk;"
-        def environment = "export PATH=$WORKSPACE/apache-maven-3.9.10/bin:\$PATH;"
+        def mavenPath = "$WORKSPACE/apache-maven-3.9.10/bin"
+        def environment = "export PATH=${mavenPath}:\$PATH;"
+
         def ock_path = "$WORKSPACE/openjceplus/OCK/"
         if (software == "windows") {
             ock_path = "$WORKSPACE\\openjceplus\\OCK\\"
@@ -198,6 +200,8 @@ def runOpenJCEPlus(command, software) {
                """
         } else if (software == "mac") {
             java_home = "export JAVA_HOME=$WORKSPACE/java/jdk/Contents/Home;"
+        } else if (software == "aix") {
+            environment = "export PATH=/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin:${mavenPath}:\$PATH;"
         }
 
         if (software != "windows") {


### PR DESCRIPTION
Java now requires the use of xlclang compiler when compiling on AIX. This project will also follow this convention and migrate toward the use of xlclang.

Makefiles were modified to print the version of compiler being used.

The compiler was defined at the top of each makefile in a single location for each platform.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/453

Signed-off-by: Jason Katonica <katonica@us.ibm.com>

