### PR TITLE
Modify archive dir for build and perf pipelines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -140,7 +140,7 @@ def archive(platform, iteration) {
     def buildID = "${env.BUILD_ID}"
     def fileLocation = "$WORKSPACE/openjceplus/OpenJCEPlus"
     def sanitizedBranchName = externalLibrary.getSanitizedBranchName()
-    def directory = "sys-rt-generic-local/OpenJCEPlus_builds/$sanitizedBranchName/$buildID"
+    def directory = "sys-rt-generic-local/OpenJCEPlus_builds/buildtest/$sanitizedBranchName/$buildID"
 
     // The OpenJCEPlus repo to be used
     def repo = "NULL"

--- a/JenkinsfilePerformance
+++ b/JenkinsfilePerformance
@@ -111,7 +111,7 @@ def archive(platform, iteration) {
     def buildID = "${env.BUILD_ID}"
     def fileLocation = "$WORKSPACE/openjceplus/OpenJCEPlus"
     def sanitizedBranchName = externalLibrary.getSanitizedBranchName()
-    def directory = "sys-rt-generic-local/OpenJCEPlus_builds/$sanitizedBranchName/$buildID"
+    def directory = "sys-rt-generic-local/OpenJCEPlus_builds/performance/$sanitizedBranchName/$buildID"
 
     // The OpenJCEPlus repo to be used
     def repo = "NULL"


### PR DESCRIPTION
The build and test pipeline and the performance pipeline currently upload to the same location in artifactory. If both the branch name and build number match they can overlay each others result.

This update adds another folder to differentiate more cleanly between the two pipeline results in artifactory.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/868

Signed-off-by: Jason Katonica <katonica@us.ibm.com>