### PR TITLE
Remove self integrity verification logic

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/AESCCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESCCMCipher.java
@@ -99,11 +99,6 @@ public final class AESCCMCipher extends CipherSpi implements AESConstants, CCMCo
 
 
     public AESCCMCipher(OpenJCEPlusProvider provider) {
-
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
-
         this.provider = provider;
         try {
             ockContext = provider.getOCKContext();

--- a/src/main/java/com/ibm/crypto/plus/provider/AESCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESCipher.java
@@ -44,9 +44,6 @@ public final class AESCipher extends CipherSpi implements AESConstants {
     private SecureRandom cryptoRandom = null;
 
     public AESCipher(OpenJCEPlusProvider provider) {
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
         buffer = new byte[engineGetBlockSize() * 3];
         this.provider = provider;
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/AESGCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESGCMCipher.java
@@ -137,10 +137,6 @@ public final class AESGCMCipher extends CipherSpi implements AESConstants, GCMCo
     private byte[] lastEncIv = null;
 
     public AESGCMCipher(OpenJCEPlusProvider provider) {
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
-
         this.provider = provider;
         try {
             ockContext = provider.getOCKContext();

--- a/src/main/java/com/ibm/crypto/plus/provider/AESKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -26,9 +26,6 @@ public final class AESKeyFactory extends SecretKeyFactorySpi {
      * Empty constructor
      */
     public AESKeyFactory(OpenJCEPlusProvider provider) {
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
         this.provider = provider;
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/AESKeyGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKeyGenerator.java
@@ -31,10 +31,6 @@ public final class AESKeyGenerator extends KeyGeneratorSpi {
      * Empty constructor
      */
     public AESKeyGenerator(OpenJCEPlusProvider provider) {
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
-
         this.provider = provider;
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/AESKeyWrapCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKeyWrapCipher.java
@@ -49,9 +49,6 @@ abstract class AESKeyWrapCipher extends CipherSpi {
     };
 
     public AESKeyWrapCipher(OpenJCEPlusProvider provider, boolean padding, int keySize) {
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
         this.provider = provider;
         this.setKeySize = keySize;
         this.setPadding = padding;

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Cipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Cipher.java
@@ -42,9 +42,6 @@ public final class ChaCha20Cipher extends CipherSpi implements ChaCha20Constants
     private SecureRandom cryptoRandom = null;
 
     public ChaCha20Cipher(OpenJCEPlusProvider provider) {
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this.getClass())) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
         this.provider = provider;
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -26,9 +26,6 @@ public final class ChaCha20KeyFactory extends SecretKeyFactorySpi {
      * Empty constructor
      */
     public ChaCha20KeyFactory(OpenJCEPlusProvider provider) {
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
         this.provider = provider;
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20KeyGenerator.java
@@ -31,10 +31,6 @@ public final class ChaCha20KeyGenerator extends KeyGeneratorSpi implements ChaCh
      * Empty constructor
      */
     public ChaCha20KeyGenerator(OpenJCEPlusProvider provider) {
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
-
         this.provider = provider;
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Poly1305Cipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Poly1305Cipher.java
@@ -51,9 +51,6 @@ public final class ChaCha20Poly1305Cipher extends CipherSpi
     private SecureRandom cryptoRandom = null;
 
     public ChaCha20Poly1305Cipher(OpenJCEPlusProvider provider) {
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
         this.provider = provider;
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeCipher.java
@@ -40,11 +40,6 @@ public final class DESedeCipher extends CipherSpi implements DESConstants {
     private SecureRandom cryptoRandom = null;
 
     public DESedeCipher(OpenJCEPlusProvider provider) {
-
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
-
         this.provider = provider;
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -27,11 +27,6 @@ public final class DESedeKeyFactory extends SecretKeyFactorySpi {
      * Empty constructor
      */
     public DESedeKeyFactory(OpenJCEPlusProvider provider) {
-
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
-
         this.provider = provider;
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeKeyGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeKeyGenerator.java
@@ -36,11 +36,6 @@ public final class DESedeKeyGenerator extends KeyGeneratorSpi {
      * Empty constructor
      */
     public DESedeKeyGenerator(OpenJCEPlusProvider provider) {
-
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
-
         this.provider = provider;
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/DHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHKeyAgreement.java
@@ -50,11 +50,6 @@ public final class DHKeyAgreement extends KeyAgreementSpi {
     }
 
     public DHKeyAgreement(OpenJCEPlusProvider provider) {
-
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
-
         this.provider = provider;
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/DHKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHKeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -26,11 +26,6 @@ public final class DHKeyPairGenerator extends KeyPairGeneratorSpi {
     private DHParameterSpec params;
 
     public DHKeyPairGenerator(OpenJCEPlusProvider provider) {
-
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
-
         this.provider = provider;
         initialize(2048, null);
 

--- a/src/main/java/com/ibm/crypto/plus/provider/ECDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECDHKeyAgreement.java
@@ -46,11 +46,6 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi { // implements
     private int secretLen;
 
     public ECDHKeyAgreement(OpenJCEPlusProvider provider) {
-
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
-
         // System.out.println ("In ECDHKeyAgreement");
         this.provider = provider;
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/HKDFGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/HKDFGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -45,10 +45,6 @@ public class HKDFGenerator extends KeyGeneratorSpi {
     public HKDFGenerator(OpenJCEPlusProvider provider, String digestAlgorithm)
             throws NoSuchAlgorithmException {
         Objects.requireNonNull(digestAlgorithm, "Must provide underlying HKDF Digest algorithm.");
-
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this.getClass())) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
 
         this.provider = provider;
         this.digestAlgorithm = digestAlgorithm;

--- a/src/main/java/com/ibm/crypto/plus/provider/HKDFKeyDerivation.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/HKDFKeyDerivation.java
@@ -70,11 +70,6 @@ public class HKDFKeyDerivation extends KDFSpi {
             throw new InvalidAlgorithmParameterException(
                     supportedHmac.hmacAlg + " does not support parameters");
         }
-        
-
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this.getClass())) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
 
         this.provider = provider;
         this.hmacAlgName = supportedHmac.hmacAlg;

--- a/src/main/java/com/ibm/crypto/plus/provider/HmacCore.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/HmacCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -23,11 +23,6 @@ abstract class HmacCore extends MacSpi {
     private HMAC hmac = null;
 
     HmacCore(OpenJCEPlusProvider provider, String ockDigestAlgo, int blockLength) {
-
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
-
         try {
             this.provider = provider;
             this.hmac = HMAC.getInstance(provider.getOCKContext(), ockDigestAlgo);

--- a/src/main/java/com/ibm/crypto/plus/provider/HmacKeyGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/HmacKeyGenerator.java
@@ -24,11 +24,6 @@ abstract class HmacKeyGenerator extends KeyGeneratorSpi {
     private SecureRandom cryptoRandom = null;
 
     HmacKeyGenerator(OpenJCEPlusProvider provider, String algo, int keysize) {
-
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
-
         this.provider = provider;
         this.algo = algo;
         this.keysize = keysize; // default keysize in bytes

--- a/src/main/java/com/ibm/crypto/plus/provider/MLKEMImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/MLKEMImpl.java
@@ -188,11 +188,6 @@ public class MLKEMImpl implements KEMSpi {
 
         public MLKEM512(OpenJCEPlusProvider provider) {
             super(provider, "ML-KEM-512");
-            
-            if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-                throw new SecurityException("Integrity check failed for: " + provider.getName());
-            }
-
         }
     }
 
@@ -200,11 +195,6 @@ public class MLKEMImpl implements KEMSpi {
 
         public MLKEM768(OpenJCEPlusProvider provider) {
             super(provider, "ML-KEM-768");
-
-            if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-                throw new SecurityException("Integrity check failed for: " + provider.getName());
-            }
-
         }
     }
 
@@ -212,10 +202,6 @@ public class MLKEMImpl implements KEMSpi {
 
         public MLKEM1024(OpenJCEPlusProvider provider) {           
             super(provider, "ML-KEM-1024");
-            
-            if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-                throw new SecurityException("Integrity check failed for: " + provider.getName());
-            }
         }
     }    
 }

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
@@ -28,23 +28,8 @@ public abstract class OpenJCEPlusProvider extends java.security.Provider {
 
     static final boolean allowLegacyHKDF = Boolean.getBoolean("openjceplus.allowLegacyHKDF");
 
-    //    private static boolean verifiedSelfIntegrity = false;
-    private static final boolean verifiedSelfIntegrity = true;
-
     OpenJCEPlusProvider(String name, String info) {
         super(name, PROVIDER_VER, info);
-    }
-
-    static final boolean verifySelfIntegrity(Object c) {
-        if (verifiedSelfIntegrity) {
-            return true;
-        }
-
-        return doSelfVerification(c);
-    }
-
-    private static final synchronized boolean doSelfVerification(Object c) {
-        return true;
     }
 
     // Get OCK context for crypto operations

--- a/src/main/java/com/ibm/crypto/plus/provider/RSA.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -55,11 +55,6 @@ public final class RSA extends CipherSpi {
     }
 
     public RSA(OpenJCEPlusProvider provider) {
-
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
-
         this.provider = provider;
         try {
             this.rsaCipher = RSACipher.getInstance(provider.getOCKContext());

--- a/src/main/java/com/ibm/crypto/plus/provider/TlsKeyMaterialGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/TlsKeyMaterialGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -50,11 +50,6 @@ public final class TlsKeyMaterialGenerator extends KeyGeneratorSpi {
      *                if fails to verify the JCE framework.
      */
     public TlsKeyMaterialGenerator(OpenJCEPlusProvider provider) {
-
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
-
         this.provider = provider;
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/TlsMasterSecretGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/TlsMasterSecretGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -40,11 +40,6 @@ public final class TlsMasterSecretGenerator extends KeyGeneratorSpi {
     private int protocolVersion;
 
     public TlsMasterSecretGenerator(OpenJCEPlusProvider provider) {
-
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
-
         this.provider = provider;
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/TlsPrfGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/TlsPrfGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -109,11 +109,6 @@ abstract class TlsPrfGenerator extends KeyGeneratorSpi {
     private TlsPrfParameterSpec spec;
 
     TlsPrfGenerator(OpenJCEPlusProvider provider) {
-
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
-
         this.provider = provider;
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/TlsRsaPremasterSecretGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/TlsRsaPremasterSecretGenerator.java
@@ -31,11 +31,6 @@ public final class TlsRsaPremasterSecretGenerator extends KeyGeneratorSpi {
     private SecureRandom cryptoRandom = null;
 
     public TlsRsaPremasterSecretGenerator(OpenJCEPlusProvider provider) {
-
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this)) {
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-        }
-
         this.provider = provider;
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
@@ -39,18 +39,10 @@ abstract class XDHKeyAgreement extends KeyAgreementSpi {
     private String alg = null;
 
     XDHKeyAgreement(OpenJCEPlusProvider provider) {
-
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this))
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-
         this.provider = provider;
     }
 
     XDHKeyAgreement(OpenJCEPlusProvider provider, String Alg) {
-
-        if (!OpenJCEPlusProvider.verifySelfIntegrity(this))
-            throw new SecurityException("Integrity check failed for: " + provider.getName());
-
         this.provider = provider;
         this.alg = Alg;
     }


### PR DESCRIPTION
This update removes logic associated with self verification that is no
longer in use.

Signed-off-by: Mohit Rajbhar <mohit.rajbhar@ibm.com>
