### PR TITLE
Support OpenXL compiler for AIX

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -209,15 +209,16 @@ def run(platform) {
             // Some OSes have some further specific requirements.
             if (software == "aix") {
                 // Java 25 requires C++17.1 runtime. Otherwise crashes occur.
-                nodeTags += "&&sw.tool.c++runtime.17_1"
+                nodeTags = "hw.arch.${node_hardware}&&sw.os.aix.7_2&&sw.tool.c++runtime.17_1&&ci.role.build"
+            } else {
+
+                // Machines tagged as ci.role.test are expected to have
+                // software to compile, build, and test OpenJCEPlus.
+                nodeTags += "&&ci.role.test"
+
+                // Exclude machines that are FIPS140-2 configured.
+                nodeTags += "&&!ci.role.test.fips"
             }
-
-            // Machines tagged as ci.role.test are expected to have
-            // software to compile, build, and test OpenJCEPlus.
-            nodeTags += "&&ci.role.test"
-
-            // Exclude machines that are FIPS140-2 configured.
-            nodeTags += "&&!ci.role.test.fips"
 
             // Add additional labels specified by user.
             nodeTags += (ADDITIONAL_NODE_LABELS) ? "&&" + ADDITIONAL_NODE_LABELS : ""

--- a/src/main/native/jgskit.mak
+++ b/src/main/native/jgskit.mak
@@ -20,7 +20,7 @@ ifeq (${PLATFORM},arm-linux64)
   OSINCLUDEDIR=linux
 else ifeq (${PLATFORM},ppc-aix64)
   PLAT=ap
-  CC=xlclang
+  CC=ibm-clang_r
   CFLAGS+= -DAIX -m64
   LDFLAGS+= -brtl -m64
   OSINCLUDEDIR=aix

--- a/utils.groovy
+++ b/utils.groovy
@@ -203,7 +203,7 @@ def runOpenJCEPlus(command, software) {
         } else if (software == "mac") {
             java_home = "export JAVA_HOME=$WORKSPACE/java/jdk/Contents/Home;"
         } else if (software == "aix") {
-            environment = "export PATH=/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin:${mavenPath}:\$PATH;"
+            environment = "export PATH=/opt/IBM/openxlC/17.1.3/bin:/opt/IBM/openxlC/17.1.3/tools:/opt/IBM/openxlC/17.1.3/compat/llvm:${mavenPath}:\$PATH;"
         }
 
         if (software != "windows") {


### PR DESCRIPTION
This update migrates to the OpenXL compiler. This update is expected
only for Java 25 and higher.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>