### PR TITLE
Refactor ECPrivateKey

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
@@ -23,7 +23,6 @@ import sun.security.pkcs.PKCS8Key;
 import sun.security.util.DerInputStream;
 import sun.security.util.DerOutputStream;
 import sun.security.util.DerValue;
-import sun.security.util.ObjectIdentifier;
 import sun.security.x509.AlgorithmId;
 
 final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.ECPrivateKey {
@@ -37,11 +36,6 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
     private OpenJCEPlusProvider provider = null;
     private BigInteger s;
     private transient ECParameterSpec params;
-
-    private ECPublicKey publicKey = null;
-    private byte[] privateKeyBytesEncoded = null;
-    private byte[] publicKeyBytes = null;
-    ObjectIdentifier namedCurveOID = null;
 
     private static final byte TAG_PARAMETERS_ATTRS = 0x00;
     private static final byte TAG_PUBLIC_KEY_ATTRS = 0x01;
@@ -61,80 +55,38 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
     ECPrivateKey(OpenJCEPlusProvider provider, BigInteger s, ECParameterSpec params)
             throws InvalidKeyException, InvalidParameterSpecException {
 
-        // The ECParameterSpec object contains:
-        // - the cofactor (int)
-        // - the EllipticCurve (EllipticCurve)
-        // - the generator (ECPoint)
-        // - the order (BigInteger)
-
-        // The variables "algid", "version", and "key" all reside within the
-        // parent
-        // class "PKCS8Key".
-
         this.provider = provider;
         this.s = s;
         this.params = params;
-        // System.out.println("this.s=" + ECUtils.bytesToHex(s.toByteArray()));
 
-        // Get an AlgorithmParameters object that has been initialized with the
-        // ECParameters (params).
         AlgorithmParameters myAlgorithmParameters = com.ibm.crypto.plus.provider.ECParameters
                 .getAlgorithmParameters(provider, params);
+        this.algid = new AlgorithmId(AlgorithmId.EC_oid, myAlgorithmParameters);
 
-        // Build an AlgorithmId object from the EC_oid and the
-        // AlgorithmParameters
-        // object just created.
-        // algid is defined in the parent class "PKCS8Key".
-        algid = new AlgorithmId(AlgorithmId.EC_oid, myAlgorithmParameters);
-
-        // generate the encoding
-
-        // try {
-        // key = ECParameters.trimZeroes(s.toByteArray());
-        // encode();
-        // } catch (IOException e) {
-        // throw new InvalidKeyException("could not DER encode x: " +
-        // e.getMessage());
-        // }
-
-
+        // Convert s to fixed-length array.
         byte[] sArr = s.toByteArray();
-        // convert to fixed-length array
         int numOctets = (params.getOrder().bitLength() + 7) / 8;
         byte[] sOctets = new byte[numOctets];
         int inPos = Math.max(sArr.length - sOctets.length, 0);
         int outPos = Math.max(sOctets.length - sArr.length, 0);
         int length = Math.min(sArr.length, sOctets.length);
         System.arraycopy(sArr, inPos, sOctets, outPos, length);
+
+        // Generate the private key encoding.
         DerOutputStream out = new DerOutputStream();
-        // PKCS8Key contains the decoding logic for all instances of
-        // PrivateKeys.
-        // It is checking that this version is set to zero.
-        // This section matches with what we do in FIPS70.
         out.putInteger(1); // version 1
         out.putOctetString(sOctets);
         DerValue val = new DerValue(DerValue.tag_Sequence, out.toByteArray());
         key = val.toByteArray();
 
         try {
-            this.publicKeyBytes = null;
-            byte[] privateKeyBytes = buildOCKPrivateKeyBytes();
-            // System.out.println("ECPrivateKey(s, paramSpec) privateKeyBytes="
-            // +
-            // ECUtils.bytesToHex(privateKeyBytes));
+            // Create appropriate encoding and create ecKey.
+            byte[] privateKeyBytes = createEncodedPrivateKeyWithParams();
             byte[] paramBytes = ECParameters.encodeECParameters(this.params);
             this.ecKey = ECKey.createPrivateKey(provider.getOCKContext(), privateKeyBytes,
                     paramBytes);
-            // System.out.println("ECPrivateKey(s, paramSpec) This.eckey private
-            // bytes="
-            // + ECUtils.bytesToHex(ecKey.getPrivateKeyBytes()));
-            // System.out.println("ECPrivateKey(s, paramSpec) This.eckey public
-            // bytes="
-            // + ECUtils.bytesToHex(ecKey.getPublicKeyBytes()));
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create EC private key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create EC private key", exception);
         }
 
     }
@@ -150,37 +102,25 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
         this.provider = provider;
 
         try {
-            parseKeyBits();
-        } catch (IOException e) {
-            throw new InvalidKeyException("parseKeyBits: " + e.getMessage());
-        }
+            // Set parameters.
+            AlgorithmParameters algParams = this.algid.getParameters();
+            if (algParams == null) {
+                throw new IOException(
+                        "EC domain parameters must be encoded in the algorithm identifier");
+            }
+            this.params = algParams.getParameterSpec(ECParameterSpec.class);
 
-        try {
-            getEncodedPrivateKeyBytes(encoded);
-        } catch (IOException e) {
-            // e.printStackTrace();
-            throw new InvalidKeyException("getEncodedPrivateKeyBytes " + e.getMessage());
-        }
-        // System.out.println("After decoding this.publicKey=" +
-        // this.publicKey);
-        try {
-            byte[] privateKeyBytes = privateKeyBytesEncoded; // buildOCKPrivateKeyBytes();
-            // System.out.println("ECPrivateKey(byte[]encoded) privateKeyBytes="
-            // +
-            // ECUtils.bytesToHex(privateKeyBytes));
+            // Get from the encoding:
+            //    * the private key as a BigInteger (this.s)
+            parsePrivateKeyEncoding();
+
+            // Create appropriate encoding and create ecKey.
+            byte[] privateKeyBytes = createEncodedPrivateKeyWithParams();
             byte[] paramBytes = ECParameters.encodeECParameters(params);
             this.ecKey = ECKey.createPrivateKey(provider.getOCKContext(), privateKeyBytes,
                     paramBytes);
-            // System.out.println("ECPrivateKey(bytes[] encoded) This.eckey
-            // private bytes="
-            // + ECUtils.bytesToHex(ecKey.getPrivateKeyBytes()));
-            // System.out.println("ECPrivateKey(bytes [] encoded) This.eckey
-            // public bytes="
-            // + ECUtils.bytesToHex(ecKey.getPublicKeyBytes()));
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create EC private key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create EC private key", exception);
         }
     }
 
@@ -188,23 +128,32 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
 
         // System.out.println("ECPrivateKey=" + ecKey.toString());
         this.provider = provider;
+        this.ecKey = ecKey;
 
+        // Set algid and params.
         DerOutputStream algidOut = null;
         try {
-
             algidOut = new DerOutputStream();
             algidOut.putOID(AlgorithmId.EC_oid);
             algidOut.putDerValue(new DerValue(ecKey.getParameters()));
             this.algid = AlgorithmId
                     .parse(new DerValue(DerValue.tag_Sequence, algidOut.toByteArray()));
 
-            this.key = convertOCKPrivateKeyBytes(ecKey.getPrivateKeyBytes());
-            this.ecKey = ecKey;
-            parseKeyBits();
+            AlgorithmParameters algParams = this.algid.getParameters();
+            if (algParams == null) {
+                throw new IOException(
+                        "EC domain parameters must be encoded in the algorithm identifier");
+            }
+            this.params = algParams.getParameterSpec(ECParameterSpec.class);
+
+            // Get private key encoding from ECKey.
+            this.key = ecKey.getPrivateKeyBytes();
+
+            // Get from the encoding:
+            //    * the private key as a BigInteger (this.s)
+            parsePrivateKeyEncoding();
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create EC private key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create EC private key", exception);
         } finally {
             if (algidOut != null) {
                 try {
@@ -216,323 +165,73 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
         }
     }
 
-    private void getEncodedPrivateKeyBytes(byte[] encoded) throws IOException {
-        // String methodName = "getEncodedPrivateKeyBytes ";
-        // System.out.println(methodName + ECUtils.bytesToHex(encoded));
-        DerInputStream in = new DerInputStream(encoded);
-        DerValue[] inputValue = in.getSequence(3);
-        BigInteger tempVersion = inputValue[0].getBigInteger();
-        if (tempVersion.compareTo(BigInteger.ZERO) != 0) {
-            throw new IOException("Decoding public key failed. The version must be zero");
-        }
-        ObjectIdentifier curveOID = null;
-        if (inputValue.length > 1) {
-            // System.out.println("trying to figure out curveOID");
-            if (inputValue[1].getTag() == DerValue.tag_Sequence) {
-                // System.out.println("It is a sequence");
-                DerInputStream oidInputStream = inputValue[1].toDerInputStream();
-                // DerValue[] oidValues = oidInputStream.get
-                oidInputStream.getOID();
-                curveOID = oidInputStream.getOID();
-            } else {
-                throw new IOException("Unexpected non sequence while parsing private key bytes");
-            }
-        }
-
-        byte[] privateKeyBytesEncoded = null;
-        if (inputValue.length < 2) {
-            this.publicKey = null;
-            this.privateKeyBytesEncoded = null;
-            this.publicKeyBytes = null;
-            return;
-        }
-        privateKeyBytesEncoded = inputValue[2].getDataBytes();
-        if (privateKeyBytesEncoded == null) {
-            // System.out.println(methodName + "publicKeyBytesEncoded is null");
-            this.publicKey = null;
-            this.privateKeyBytesEncoded = null;
-            this.publicKeyBytes = null;
-            return;
-        } else {
-            this.privateKeyBytesEncoded = privateKeyBytesEncoded;
-        }
-
-        // System.out.println(methodName + "privateKeyBytesEncoded=" +
-        // ECUtils.bytesToHex(privateKeyBytesEncoded));
-
-        // The JCEFIPS when encoding private key, adds the publicKeyBytes to the
-        // privateKey in a different way than other
-        // providers
-        // The sequence is as follows:
-        // Universal SEQ: universal primitve integer version,
-        // octect string (private Key bytes),
-        // context construted 0 with
-        // Universal primary object Id for well known curve
-        // Context constructed 1 with
-        // Primitive bit string (for JCEPlus, JCE, BC)
-        // SEQUENCE:
-        // SEQUENCE:
-        // Universal primary Object ID for pKCS encoding
-        // Universal Primary object ID for parameter curve
-        // Primitive bit string
-        // Convert the JCEFIPS encoding similar to others
-        DerInputStream privKeyBytesEncodedStream = new DerInputStream(privateKeyBytesEncoded);
+    /**
+     * The native library requires the parameters to be part of the encoding.
+     * If they existing encoding doesn't have them, add them. If it does
+     * contain them, check against the existing parameters.
+     *
+     * @return  the new encoding required by the native library
+     * @throws IOException
+     */
+    private byte[] createEncodedPrivateKeyWithParams() throws IOException {
+        DerInputStream privKeyBytesEncodedStream = new DerInputStream(this.key);
         DerValue[] inputDerValue = privKeyBytesEncodedStream.getSequence(4);
-        if (inputDerValue.length == 2 || inputDerValue.length == 3) {
-            BigInteger tempVersion1 = inputDerValue[0].getBigInteger();
-            if (tempVersion1.compareTo(BigInteger.ONE) != 0) {
-                throw new IOException("Decoding public key failed. The version must be 1");
+        DerOutputStream outEncodedStream = new DerOutputStream();
+
+        if (inputDerValue.length < 2) {
+            throw new IOException("Incorrect EC private key encoding");
+        }
+        BigInteger tempVersion1 = inputDerValue[0].getBigInteger();
+        if (tempVersion1.compareTo(BigInteger.ONE) != 0) {
+            throw new IOException("Decoding EC private key failed. The version must be 1");
+        }
+        outEncodedStream.putInteger(tempVersion1);
+
+        byte[] privateKeyBytes = inputDerValue[1].getOctetString();
+        outEncodedStream.putOctetString(privateKeyBytes);
+
+        byte[] encodedParams = this.getAlgorithmId().getEncodedParams();
+        if (inputDerValue.length > 2) {
+            if (!inputDerValue[2].isContextSpecific(TAG_PARAMETERS_ATTRS)) {
+                throw new IOException("Decoding EC private key failed. Third element is not tagged as parameters");
             }
-            byte[] privateKeyBytes = null;
-            if (inputDerValue.length > 1)
-                privateKeyBytes = inputDerValue[1].getOctetString();
-
-            DerOutputStream outEncodedStream = new DerOutputStream();
-            outEncodedStream.putInteger(tempVersion1);
-            outEncodedStream.putOctetString(privateKeyBytes);
-            // outEncodedStream.putDerValue(paramDerValue);
-            DerOutputStream outParamStream = new DerOutputStream();
-            outParamStream.putOID(curveOID);
-            outEncodedStream.write(
-                    DerValue.createTag(DerValue.TAG_CONTEXT, true, TAG_PARAMETERS_ATTRS),
-                    outParamStream.toByteArray());
-
-            DerInputStream paramDerInputStream = null;
-            DerValue paramDerValue = null;
-            if (inputDerValue.length > 2) {
-                paramDerInputStream = inputDerValue[2].getData();
-                paramDerValue = paramDerInputStream.getDerValue();
-                outParamStream = new DerOutputStream();
-                outParamStream.putDerValue(paramDerValue);
-                outEncodedStream.write(
-                        DerValue.createTag(DerValue.TAG_CONTEXT, true, TAG_PUBLIC_KEY_ATTRS),
-                        outParamStream.toByteArray());
-            }
-
-            DerOutputStream asn1Key = new DerOutputStream();
-            asn1Key.write(DerValue.tag_Sequence, outEncodedStream.toByteArray());
-            // System.out.println("calling asn1Key.toByteArray()");
-            this.privateKeyBytesEncoded = asn1Key.toByteArray();
-
-        } else {
-            BigInteger tempVersion1 = inputDerValue[0].getBigInteger();
-            if (tempVersion1.compareTo(BigInteger.ONE) != 0) {
-                throw new IOException("Decoding public key failed. The version must be 1");
-            }
-            byte[] privateKeyBytes = null;
-            if (inputDerValue.length > 1)
-                privateKeyBytes = inputDerValue[1].getOctetString();
-            DerInputStream paramDerInputStream = null;
-            DerValue paramDerValue = null;
-            if (inputDerValue.length > 2) {
-                paramDerInputStream = inputDerValue[2].getData();
-                paramDerValue = paramDerInputStream.getDerValue();
-            }
-            if (inputDerValue.length > 3
-                    && inputDerValue[3].isContextSpecific(TAG_PUBLIC_KEY_ATTRS)) {
-                // System.out.println("Encountered a tag_context");
-                try {
-                    DerInputStream pubKeyStream = inputDerValue[3].getData();
-                    byte[] pubKeyBytes = pubKeyStream.getBitString();
-                    // System.out.println(methodName + "pubKeyBytes=" +
-                    // ECUtils.bytesToHex(pubKeyBytes));
-
-                    // parse the pubKeyBytes to distinguish byte stream from
-                    // FIPS vs
-                    // other providers
-                    DerInputStream inputStream = new DerInputStream(pubKeyBytes);
-
-                    if (inputStream.peekByte() == DerValue.tag_Sequence) {
-                        DerValue[] inputDerValuePubBytes = inputStream.getSequence(2);
-                        byte[] actualKeyBits = null;
-                        if (inputDerValuePubBytes.length > 1) {
-                            actualKeyBits = inputDerValuePubBytes[1].getBitString();
-                        }
-                        // byte[] pubKeyBytesTrimmed =
-                        // ECParameters.trimZeroes(pubKeyBytes);
-
-                        // System.out.println(methodName + "pub
-                        // KeyBytesTrimmed=" +
-                        // ECUtils.bytesToHex(pubKeyBytesTrimmed));
-                        // System.out.println(methodName + "actualKeyBits=" +
-                        // ECUtils.bytesToHex(actualKeyBits));
-
-                        DerOutputStream outEncodedStream = new DerOutputStream();
-                        outEncodedStream.putInteger(tempVersion1);
-                        outEncodedStream.putOctetString(privateKeyBytes);
-                        // outEncodedStream.putDerValue(paramDerValue);
-                        DerOutputStream outParamStream = new DerOutputStream();
-                        outParamStream.putDerValue(paramDerValue);
-                        outEncodedStream.write(DerValue.createTag(DerValue.TAG_CONTEXT, true,
-                                TAG_PARAMETERS_ATTRS), outParamStream.toByteArray());
-
-                        if (actualKeyBits != null) {
-                            DerOutputStream tmp1out = new DerOutputStream();
-                            tmp1out.putBitString(actualKeyBits);
-
-                            outEncodedStream.write(DerValue.createTag(DerValue.TAG_CONTEXT, true,
-                                    TAG_PUBLIC_KEY_ATTRS), tmp1out);
-                        }
-                        DerOutputStream asn1Key = new DerOutputStream();
-                        asn1Key.write(DerValue.tag_Sequence, outEncodedStream.toByteArray());
-                        // System.out.println("calling asn1Key.toByteArray()");
-                        this.privateKeyBytesEncoded = asn1Key.toByteArray();
-
-                    }
-                } catch (Exception ex) {
-                    // Unable to parse the key bytes. See if OCK can handle it.
-                    // ex.printStackTrace();
-                }
+            DerInputStream paramDerInputStream = inputDerValue[2].getData();
+            byte[] privateKeyParams = paramDerInputStream.toByteArray();
+            
+            // Check against the existing parameters created by PKCS8Key.
+            if (!Arrays.equals(privateKeyParams, encodedParams)) {
+                throw new IOException("Decoding EC private key failed. The params are not the same as PKCS8Key's");
             }
         }
-        this.publicKeyBytes = this.privateKeyBytesEncoded.clone();
+        // The native library needs the ASN.1 DER decoding of the private key to contain the parameters (i.e., the OID).
+        outEncodedStream.write(
+                    DerValue.createTag(DerValue.TAG_CONTEXT, true, TAG_PARAMETERS_ATTRS),
+                    encodedParams);
 
-        // System.out
-        // .println(methodName + "this.privateKeyBytesEncoded=" +
-        // ECUtils.bytesToHex(this.privateKeyBytesEncoded));
-
+        DerOutputStream asn1Key = new DerOutputStream();
+        asn1Key.write(DerValue.tag_Sequence, outEncodedStream.toByteArray());
+        return asn1Key.toByteArray();
     }
 
     /**
-     * Return the privateKeyBytes returned from OCK. The privateKeyBytes format
-     * is SEQUENCE: VERSION: INTEGER PrivateKey: OCTET STRING CONTEXT
-     * CONSTRUCTED 0 OID (named curve) CONTEXT CONSTRUCTED 1 PublicKey:
-     * OCTETSTRING
-     * 
-     * @param privateKeyBytes
-     * @return
+     * Parse the private key encoding to:
+     * - get the key and set it as a BigInteger (i.e., this.s)
+     * - get the public key, if available, and check its tag
+     *
      * @throws IOException
      */
-    private byte[] convertOCKPrivateKeyBytes(byte[] privateKeyBytes) throws IOException {
+    private void parsePrivateKeyEncoding() throws IOException {
+        DerInputStream privKeyBytesEncodedStream = new DerInputStream(this.key);
+        DerValue[] inputDerValue = privKeyBytesEncodedStream.getSequence(4);
 
-        // System.out.println("in ConvertOCKPrivateKeyBytes=" +
-        // ECUtils.bytesToHex(privateKeyBytes));
+        byte[] privateKeyBytes = inputDerValue[1].getOctetString();
+        this.s = new BigInteger(1, privateKeyBytes);
 
-        DerInputStream in = new DerInputStream(privateKeyBytes);
-        DerValue[] inputValue = in.getSequence(4);
-        BigInteger tempVersion = inputValue[0].getBigInteger();
-
-        byte[] privData = null;
-        if (inputValue.length > 1) {
-            privData = inputValue[1].getOctetString();
-            s = new BigInteger(1, privData);
-        } else
-            s = null;
-
-        DerInputStream derInputStream = null;
-        if (inputValue.length > 2) {
-            derInputStream = inputValue[2].getData();
-            // System.out.println ("DerTag=" + derInputStream.tag);
-            // System.out.println ("Context constructed 0");
-            try {
-                ObjectIdentifier oid = derInputStream.getOID();
-                // System.out.println ("oid = " + oid.toString());
-                if (oid != null) {
-                    return privateKeyBytes;
-                } else {
-                    throw new IOException(
-                            " The next encoded structure must be a context constructed OID");
-                }
-            } catch (Exception ex) {
-                // Must be a custom curve.
+        if (inputDerValue.length == 4) {
+            if (!inputDerValue[3].isContextSpecific(TAG_PUBLIC_KEY_ATTRS)) {
+                throw new IOException("Decoding EC private key failed. Last element is not tagged as public key");
             }
         }
-        byte[] publicKeyBit = null;
-        DerInputStream derInputStreamPublicKey = null;
-        if (inputValue.length > 3) {
-            derInputStreamPublicKey = inputValue[3].getData();
-
-            publicKeyBit = derInputStreamPublicKey.getBitString();
-
-        }
-
-        DerOutputStream bytes = new DerOutputStream();
-        DerOutputStream asn1Key = new DerOutputStream();
-        bytes.putInteger(tempVersion);
-        bytes.putOctetString(privData);
-        DerOutputStream tmp1out = null;
-        if (publicKeyBit != null) {
-            tmp1out = new DerOutputStream();
-            tmp1out.putBitString(publicKeyBit);
-            bytes.write(DerValue.createTag(DerValue.TAG_CONTEXT, true, TAG_PUBLIC_KEY_ATTRS),
-                    tmp1out);
-        }
-
-        // System.out.println ("successfully wrote public key");
-        asn1Key.write(DerValue.tag_Sequence, bytes);
-        byte[] customCurve = asn1Key.toByteArray();
-        // System.out.println ("Custom curve bytes = " +
-        // ECUtils.bytesToHex(customCurve));
-        return customCurve;
-
-    }
-
-    private byte[] buildOCKPrivateKeyBytes() throws IOException, InvalidParameterSpecException {
-
-        // System.out.println("In buildOCKPrivateKeyBytes");
-
-        ECParameterSpec params = getParams();
-
-        DerOutputStream bytes = new DerOutputStream();
-        DerOutputStream asn1Key = new DerOutputStream();
-
-        // Encode the version
-        bytes.putInteger(BigInteger.ONE);
-
-        // Encode Private key
-        if (key != null) {
-
-            // The key value is sequence of version, octet string
-            DerInputStream in = new DerInputStream(key);
-            DerValue derValue = in.getDerValue();
-
-            // System.out.println("derValue.getTag=" + derValue.getTag());
-            if (derValue.getTag() != DerValue.tag_Sequence) {
-                throw new IOException(MSG_SEQ);
-            }
-            DerInputStream data = derValue.getData();
-            int version = data.getInteger();
-            // System.out.println("version=" + version);
-            // PKCS8Key contains the decoding logic for all instances of
-            // PrivateKeys.
-            // It is checking that this version is set to one.
-            if (version != 1) {
-                throw new IOException(MSG_VERSION1);
-            }
-
-            byte[] privData = ECParameters.trimZeroes(data.getOctetString());
-
-            bytes.putOctetString(privData);
-        }
-
-        byte[] ecParamEncodedBeforeTrimming = ECParameters.encodeECParameters(params);
-        byte[] myEncodedECParameters = ECParameters.trimZeroes(ecParamEncodedBeforeTrimming);
-        // System.out.println("ecParamEncodedbeforeTrimming= " +
-        // ECUtils.bytesToHex(ecParamEncodedBeforeTrimming));
-        DerValue derValue = new DerValue(myEncodedECParameters);
-        DerOutputStream tmpout = new DerOutputStream();
-        tmpout.putDerValue(derValue);
-        bytes.write(DerValue.createTag(DerValue.TAG_CONTEXT, true, TAG_PARAMETERS_ATTRS), tmpout);
-
-        // encode the OPTIONAL public key
-        if (this.publicKeyBytes != null) {
-            // System.out.println("publicKeyBytes is not null = " +
-            // ECUtils.bytesToHex(this.publicKeyBytes));
-            DerOutputStream tmp1out = new DerOutputStream();
-
-            tmp1out.putBitString(publicKeyBytes);
-
-            bytes.write(DerValue.createTag(DerValue.TAG_CONTEXT, true, TAG_PUBLIC_KEY_ATTRS),
-                    tmp1out);
-            // System.out.println("successfully wrote public key");
-        }
-
-        // wrap everything into a SEQUENCE
-        asn1Key.write(DerValue.tag_Sequence, bytes);
-        // System.out.println("wrote tag sequence=" +
-        // ECKey.bytesToHex(asn1Key.toByteArray()));
-
-        return asn1Key.toByteArray();
     }
 
     public BigInteger getS() {
@@ -586,73 +285,6 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
     protected Object writeReplace() throws java.io.ObjectStreamException {
         checkDestroyed();
         return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PRIVATE, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
-    } 
-
-    /**
-     * Parse the key. Called by PKCS8Key. "key" is a byte array containing the
-     * Der-encoded key which resides within the parent class PKCS8Key. The
-     * PKCS class named PKCS8Key contains the "decode" method for all
-     * PrivateKeys. It expects that the PrivateKey it is decoding contains a
-     * version number, an AlgorithmID (containing the OID and
-     * AlgorithmParameters), and the encoded key itself. It calls parseKeyBits(
-     * ) of the appropriate key class to parse the encoded key.
-     */
-    protected void parseKeyBits() throws IOException {
-        // The variables "algid", "version", and "key" all reside within the
-        // parent
-        // class "PKCS8Key".
-
-        // System.out.println("in parse key bits this.key=" +
-        // ECKey.bytesToHex(this.key));
-
-        try {
-            // Begin parsing "version" and "s" out of "key"
-            DerInputStream in = new DerInputStream(key);
-            DerValue derValue = in.getDerValue();
-
-            // System.out.println("derValue.getTag=" + derValue.getTag());
-            if (derValue.getTag() != DerValue.tag_Sequence) {
-                throw new IOException(MSG_SEQ);
-            }
-            DerInputStream data = derValue.getData();
-            int version = data.getInteger();
-            // System.out.println("version=" + version);
-            // PKCS8Key contains the decoding logic for all instances of
-            // PrivateKeys.
-            // It is checking that this version is set to one.
-            if (version != 1) {
-                throw new IOException(MSG_VERSION1);
-            }
-
-            byte[] privData = data.getOctetString();
-            s = new BigInteger(1, privData);
-
-            // End parsing "version" and "s" out of "key"
-            // System.out.println("s=" + s);
-
-            while (data.available() != 0) {
-                DerValue value = data.getDerValue();
-                if (!((value.isContextSpecific((byte) 0)) || (value.isContextSpecific((byte) 1)))) {
-                    throw new IOException("Unexpected value: " + value);
-                }
-            }
-
-            AlgorithmParameters algParams = this.algid.getParameters();
-            if (algParams == null) {
-                throw new IOException(
-                        "EC domain parameters must be encoded in the algorithm identifier");
-            }
-            // System.out.println("algParams=" + algParams);
-
-            params = algParams.getParameterSpec(ECParameterSpec.class);
-
-        } catch (IOException e) {
-            // e.printStackTrace();
-            throw new IOException("Invalid EC private key");
-        } catch (InvalidParameterSpecException e) {
-            throw new IOException("Invalid EC private key");
-        }
-
     }
 
     /**
@@ -685,5 +317,4 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
             throw new IllegalStateException("This key is no longer valid");
         }
     }
-
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -27,8 +27,11 @@ import java.security.interfaces.ECPrivateKey;
 import java.security.spec.ECGenParameterSpec;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPrivateKeySpec;
+import java.security.spec.EncodedKeySpec;
 import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.PSSParameterSpec;
+import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -840,6 +843,22 @@ public class BaseTestECDSASignature extends BaseTestJunit5Signature {
             System.out.println("Expected exception <java.security.InvalidKeyException> for " +
                                 "ECDSA/SHA256withECDSA/" + curveName + "is caught.");
         }
+    }
+
+    @Test
+    public void testECDSA_ImportedKeys() throws Exception {
+        // Generate keypair.
+        KeyPair keyPair = generateKeyPair("secp256r1");
+
+        // Export encoding and re-import.
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", getProviderName());
+        EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(keyPair.getPrivate().getEncoded());
+        PrivateKey importPrivKey = keyFactory.generatePrivate(privateKeySpec);
+        EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(keyPair.getPublic().getEncoded());
+        PublicKey importPubKey = keyFactory.generatePublic(publicKeySpec);
+
+        // Perform signature operation.
+        doSignVerify("SHA256withECDSA", origMsg, importPrivKey, importPubKey);
     }
 
     private void doTestPositiveSigBytes(String keyAlg, String sigAlg, String providerName)

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyImport.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyImport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -23,12 +23,65 @@ import java.security.spec.EncodedKeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
+import java.util.HexFormat;
 import org.junit.jupiter.api.Test;
+import sun.security.pkcs.PKCS8Key;
+import sun.security.x509.X509Key;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestECKeyImport extends BaseTestJunit5 {
 
     static final byte[] origMsg = "this is the original message to be signed".getBytes();
+
+    // Key encodings to be used in import test.
+    private static final String private_secp256r1 = "308193020100301306072A8648CE3D020106082A8648CE"
+                                                  + "3D030107047930770201010420CF1AEA9582B330909ED7"
+                                                  + "612A6409701E8AF90AC525E3D1CD167FA58A74015455A0"
+                                                  + "0A06082A8648CE3D030107A14403420004F5BE5E630BE2"
+                                                  + "4DF3E88AAC2B2367E6A546D1D5DEF077F1FD9C8F7F693A"
+                                                  + "C665F4DE71F4944327C898680C08E78755D43D88BE501C"
+                                                  + "F01EC5C0A07BFA54EFB80C28";
+    private static final String public_secp256r1 = "3059301306072A8648CE3D020106082A8648CE3D0301070"
+                                                 + "3420004F5BE5E630BE24DF3E88AAC2B2367E6A546D1D5DE"
+                                                 + "F077F1FD9C8F7F693AC665F4DE71F4944327C898680C08E"
+                                                 + "78755D43D88BE501CF01EC5C0A07BFA54EFB80C28";
+
+    private static final String private_secp384r1 = "3081BF020100301006072A8648CE3D020106052B810400"
+                                                  + "220481A73081A4020101043085A782085C553F6A2C3BAA"
+                                                  + "0B59ACDF1D90ADFF73CB702EC97A407DFA86716DA4A3C2"
+                                                  + "C63238DFE4B514BD3F13C31F6589A00706052B81040022"
+                                                  + "A16403620004A71A0D891BFE28D21A5460F8CC8D83D6E8"
+                                                  + "35A7114680F645E6906D54ADF97B7B224927E70BAF0776"
+                                                  + "855405A640AA48BBD8333CFDD4D2B0EA0E5A8E8122FDDE"
+                                                  + "7164A10662067AC4BD00DBB944FC0390E3126FFCD0BE30"
+                                                  + "4AC6C1563CEF5FF4ED69";
+    private static final String public_secp384r1 = "3076301006072A8648CE3D020106052B810400220362000"
+                                                 + "4A71A0D891BFE28D21A5460F8CC8D83D6E835A7114680F6"
+                                                 + "45E6906D54ADF97B7B224927E70BAF0776855405A640AA4"
+                                                 + "8BBD8333CFDD4D2B0EA0E5A8E8122FDDE7164A10662067A"
+                                                 + "C4BD00DBB944FC0390E3126FFCD0BE304AC6C1563CEF5FF"
+                                                 + "4ED69";
+
+    private static final String private_secp521r1 = "3081F7020100301006072A8648CE3D020106052B810400"
+                                                  + "230481DF3081DC0201010442017A35D78CF723F3603EB5"
+                                                  + "F62A9C628C91574062257696E86BB16E7E0AC3A4EA0392"
+                                                  + "3932F9DE388B70143C4CEE7F06241EFA8664148E457190"
+                                                  + "B8587BAC3A454C83E7A00706052B81040023A181890381"
+                                                  + "86000401ABF48EE823860DBE7FEE88F1054C4ED5395EBC"
+                                                  + "F1451FD096389FFA95E670B3FC2D18E2E73D7C89E269B0"
+                                                  + "16671B26FB1A2013AB2DAB048FE2743D226803795D75C9"
+                                                  + "00EF9C57C30FAA2DEF09DDDAD4E8748C442325B8EDB94E"
+                                                  + "F7AA978D4A56F0B601448B0DDFA4CC4B0555EAE67354C4"
+                                                  + "42A3ACE9D04BE186765A1921962FC08D1A58C53A";
+    private static final String public_secp521r1 = "30819B301006072A8648CE3D020106052B8104002303818"
+                                                 + "6000401ABF48EE823860DBE7FEE88F1054C4ED5395EBCF1"
+                                                 + "451FD096389FFA95E670B3FC2D18E2E73D7C89E269B0166"
+                                                 + "71B26FB1A2013AB2DAB048FE2743D226803795D75C900EF"
+                                                 + "9C57C30FAA2DEF09DDDAD4E8748C442325B8EDB94EF7AA9"
+                                                 + "78D4A56F0B601448B0DDFA4CC4B0555EAE67354C442A3AC"
+                                                 + "E9D04BE186765A1921962FC08D1A58C53A";
+    
 
     /**
      * Generate a KeyPair using ECGEenParam and then import the key pair
@@ -139,6 +192,87 @@ public class BaseTestECKeyImport extends BaseTestJunit5 {
 
         assertTrue(Arrays.equals(publicKey2Bytes, publicKeyBytes));
         assertTrue(Arrays.equals(privateKey2Bytes, privKeyBytes));
+    }
+
+    /**
+     * Generate a KeyPair, import the key pair through factory and compare the
+     * encodings.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCreateKeyPairImportCompareEncodings() throws Exception {
+
+        //final String methodName = "testCreateKeyPairImportCompareEncodings";
+
+        KeyPairGenerator keyPairGen = KeyPairGenerator.getInstance("EC", getProviderName());
+        KeyPair keyPair = keyPairGen.generateKeyPair();
+        PrivateKey privateKey = keyPair.getPrivate();
+        PublicKey publicKey = keyPair.getPublic();
+        byte[] originalPubKeyBytes = publicKey.getEncoded();
+        byte[] originalPrivKeyBytes = privateKey.getEncoded();
+
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", getProviderName());
+        EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(originalPrivKeyBytes);
+        PrivateKey importPrivateKey = keyFactory.generatePrivate(privateKeySpec);
+
+        EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(originalPubKeyBytes);
+        PublicKey importPublicKey = keyFactory.generatePublic(publicKeySpec);
+
+        byte[] importPubKeyBytes = importPublicKey.getEncoded();
+        byte[] importPrivKeyBytes = importPrivateKey.getEncoded();
+
+        // Check that the original and factory created keys produce the same encoding.
+        assertArrayEquals(importPubKeyBytes, originalPubKeyBytes, "Public key encodings don't match.");
+        assertArrayEquals(importPrivKeyBytes, originalPrivKeyBytes, "Private key encodings don't match.");
+    }
+
+    /**
+     * Generate a KeyPair, get encoded, import the private key, get the public encoding from it
+     * and compare to original public key encoding.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testImportHardcoded() throws Exception {
+
+        //final String methodName = "testImportHardcoded";
+
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", getProviderName());
+
+        // Import hard-coded encodings
+        // secp256r1
+        EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(HexFormat.of().parseHex(private_secp256r1));
+        PrivateKey importPrivateKey = keyFactory.generatePrivate(privateKeySpec);
+
+        assertTrue(((PKCS8Key) importPrivateKey).getAlgorithmId().toString().contains("secp256r1"), "Curve is not what is expected.");
+
+        EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(HexFormat.of().parseHex(public_secp256r1));
+        PublicKey importPublicKey = keyFactory.generatePublic(publicKeySpec);
+
+        assertTrue(((X509Key) importPublicKey).getAlgorithmId().toString().contains("secp256r1"), "Curve is not what is expected.");
+
+        // secp384r1
+        privateKeySpec = new PKCS8EncodedKeySpec(HexFormat.of().parseHex(private_secp384r1));
+        importPrivateKey = keyFactory.generatePrivate(privateKeySpec);
+
+        assertTrue(((PKCS8Key) importPrivateKey).getAlgorithmId().toString().contains("secp384r1"), "Curve is not what is expected.");
+
+        publicKeySpec = new X509EncodedKeySpec(HexFormat.of().parseHex(public_secp384r1));
+        importPublicKey = keyFactory.generatePublic(publicKeySpec);
+
+        assertTrue(((X509Key) importPublicKey).getAlgorithmId().toString().contains("secp384r1"), "Curve is not what is expected.");
+
+        // secp521r1
+        privateKeySpec = new PKCS8EncodedKeySpec(HexFormat.of().parseHex(private_secp521r1));
+        importPrivateKey = keyFactory.generatePrivate(privateKeySpec);
+
+        assertTrue(((PKCS8Key) importPrivateKey).getAlgorithmId().toString().contains("secp521r1"), "Curve is not what is expected.");
+
+        publicKeySpec = new X509EncodedKeySpec(HexFormat.of().parseHex(public_secp521r1));
+        importPublicKey = keyFactory.generatePublic(publicKeySpec);
+
+        assertTrue(((X509Key) importPublicKey).getAlgorithmId().toString().contains("secp521r1"), "Curve is not what is expected.");
     }
 }
 


### PR DESCRIPTION
The `ECPrivateKey` class is refactored to consolidate a single point of performing encoding operations.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/834

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>