### PR TITLE
Set default keysize for ECKeyPairGenerator to match OpenJDK

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/ECKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECKeyPairGenerator.java
@@ -21,8 +21,11 @@ import sun.security.util.ObjectIdentifier;
 
 public final class ECKeyPairGenerator extends KeyPairGeneratorSpi {
 
+    private static final String EC_LEGACY_DEFAULT_KEYSIZE = "openjceplus.ec.legacy.defaultKeysize";
+    private static final boolean legacyECdefault = Boolean.parseBoolean(System.getProperty(EC_LEGACY_DEFAULT_KEYSIZE));
+
     private OpenJCEPlusProvider provider = null;
-    private int keysize = 256;
+    private int keysize = legacyECdefault? 256 : 384;
     private SecureRandom cryptoRandom = null;
     ECParameterSpec ecSpec;
     private ObjectIdentifier oid = null;

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyPairGenerator.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyPairGenerator.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import sun.security.util.InternalPrivateKey;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestECKeyPairGenerator extends BaseTestJunit5 {
@@ -70,6 +71,19 @@ public class BaseTestECKeyPairGenerator extends BaseTestJunit5 {
     @Test
     public void testECKeyGen_521() throws Exception {
         doECKeyGen(521);
+    }
+
+    @Test
+    public void testECKeyGen_default() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", getProviderName());
+        KeyPair kp = kpg.generateKeyPair();
+        ECParameterSpec publicKeyParams = ((ECPublicKey) kp.getPublic()).getParams();
+        // The order of the curve's base point determines the key size
+        assertEquals(384, publicKeyParams.getOrder().bitLength(), "Default keysize is not as expected.");
+    
+        ECParameterSpec privateKeyParams = ((ECPrivateKey) kp.getPrivate()).getParams();
+        // The order of the curve's base point determines the key size
+        assertEquals(384, privateKeyParams.getOrder().bitLength(), "Default keysize is not as expected.");
     }
 
     public void doECKeyGen(int keypairSize) throws Exception {


### PR DESCRIPTION
The default keysize used by the `ECKeyPairGenerator`, if not explicitly initialized is changed from `256` to `384`. This change is made to match `OpenJDK`'s behaviour.

An additional testcase is added to verify the default keysize.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/883

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>