### PR TITLE
Fix initialization issue with debug

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
@@ -1216,12 +1216,6 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
         return providerException;
     }
 
-    void setOCKExceptionCause(Exception exception, Throwable ockException) {
-        if (debug != null) {
-            exception.initCause(ockException);
-        }
-    }
-
     // Get the date from the ImplementationVersion in the manifest file
     private static String getDebugDate(String className) {
         String versionDate = "Unknown";

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -933,12 +933,6 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
         return providerException;
     }
 
-    void setOCKExceptionCause(Exception exception, Throwable ockException) {
-        if (debug != null) {
-            exception.initCause(ockException);
-        }
-    }
-
     // Get the date from the ImplementationVersion in the manifest file
     private static String getDebugDate(String className) {
         String versionDate = "Unknown";

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
@@ -96,5 +96,9 @@ public abstract class OpenJCEPlusProvider extends java.security.Provider {
 
     abstract ProviderException providerException(String message, Throwable ockException);
 
-    abstract void setOCKExceptionCause(Exception exception, Throwable ockException);
+    void setOCKExceptionCause(Exception exception, Throwable ockException) {
+        if ((debug != null) && (exception != null) && (exception.getCause() == null)) {
+            exception.initCause(ockException);
+        }
+    }
 }


### PR DESCRIPTION
This update fixes a double initialization of a stack trace that may occur when the debugging property `java.security.auth.debug` is set.

Fixes: https://github.com/IBM/OpenJCEPlus/issues/878

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/899

Signed-off-by: Jason Katonica <katonica@us.ibm.com>