### PR TITLE
Set private provider field based upon constructor

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Key.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Key.java
@@ -42,6 +42,7 @@ final class ChaCha20Key implements SecretKey, ChaCha20Constants {
             throw new InvalidKeyException("Wrong key size");
         }
 
+        this.provider = provider;
         this.key = new byte[key.length];
         System.arraycopy(key, 0, this.key, 0, key.length);
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeKey.java
@@ -41,6 +41,7 @@ final class DESedeKey implements SecretKey, Destroyable {
             throw new InvalidKeyException("Wrong key size");
         }
 
+        this.provider = provider;
         this.key = new byte[DESedeKeySpec.DES_EDE_KEY_LEN];
         System.arraycopy(key, 0, this.key, 0, DESedeKeySpec.DES_EDE_KEY_LEN);
         DESedeKeyGenerator.setParityBit(key, 0);


### PR DESCRIPTION
The DESedeKey and ChaCha20Key classes do allow for a provider to be used
on construction of the key, however the provider is not saved to the
private field of the class. This can cause NPE to be visable during
serialization operations. This update simply saves the provider to the
private field for later use.

Fixes: https://github.com/IBM/OpenJCEPlus/issues/920

Signed-off-by: Jason Katonica <katonica@us.ibm.com>