### PR TITLE
Set private provider field based upon constructor

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Key.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Key.java
@@ -42,6 +42,7 @@ final class ChaCha20Key implements SecretKey, ChaCha20Constants {
             throw new InvalidKeyException("Wrong key size");
         }
 
+        this.provider = provider;
         this.key = new byte[key.length];
         System.arraycopy(key, 0, this.key, 0, key.length);
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeKey.java
@@ -41,6 +41,7 @@ final class DESedeKey implements SecretKey, Destroyable {
             throw new InvalidKeyException("Wrong key size");
         }
 
+        this.provider = provider;
         this.key = new byte[DESedeKeySpec.DES_EDE_KEY_LEN];
         System.arraycopy(key, 0, this.key, 0, DESedeKeySpec.DES_EDE_KEY_LEN);
         DESedeKeyGenerator.setParityBit(key, 0);

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestKeySerialization.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestKeySerialization.java
@@ -22,6 +22,7 @@ import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.ChaCha20ParameterSpec;
 import javax.crypto.spec.PBEKeySpec;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -76,12 +77,20 @@ public class BaseTestKeySerialization extends BaseTestJunit5Signature {
     }
 
     @ParameterizedTest
-    @CsvSource({"AES, 256, AES/CBC/PKCS5Padding", "AES, 256, AES/GCM/NoPadding"})
+    @CsvSource({
+        "AES, 256, AES/CBC/PKCS5Padding",
+        "AES, 256, AES/GCM/NoPadding",
+        "DESede, 168, DESede/CBC/PKCS5Padding",
+        "ChaCha20, 256, ChaCha20/None/NoPadding"})
     public void SerializationSecretKeyTest (String algorithm, int size, String cipherName) throws Exception {
         KeyGenerator keyGen = null;
         SecretKey key = null;
         Cipher cp = null;
 
+        //DESede and ChaCha20 not supported by FIPS provider.
+        if ("OpenJCEPlusFIPS".equalsIgnoreCase(getProviderName()) && (algorithm.equalsIgnoreCase("DESede") || algorithm.equalsIgnoreCase("ChaCha20"))) {
+            return;
+        }
         
         keyGen = KeyGenerator.getInstance(algorithm, getProviderName());
         keyGen.init(size);
@@ -92,7 +101,6 @@ public class BaseTestKeySerialization extends BaseTestJunit5Signature {
         serializeKey(key, keyFile);
         SecretKey deserializedKey = (SecretKey) deserializeKey(keyFile);
 
-
         assertArrayEquals(key.getEncoded(), 
             deserializedKey.getEncoded(),
             "Key deserialized key does not match original");
@@ -100,10 +108,17 @@ public class BaseTestKeySerialization extends BaseTestJunit5Signature {
         cp = Cipher.getInstance(cipherName, getProviderName());
         cp.init(Cipher.ENCRYPT_MODE, key);
         byte[] cipherText = cp.doFinal(plainText);
-        AlgorithmParameters params = cp.getParameters();
-
-        // Verify the text
-        cp.init(Cipher.DECRYPT_MODE, deserializedKey, params);
+        
+        // ChaCha20 requires special handling since it uses ChaCha20ParameterSpec instead of AlgorithmParameters
+        if (algorithm.equalsIgnoreCase("ChaCha20")) {
+            byte[] nonce = cp.getIV();
+            ChaCha20ParameterSpec paramSpec = new ChaCha20ParameterSpec(nonce, 1);
+            cp.init(Cipher.DECRYPT_MODE, deserializedKey, paramSpec);
+        } else {
+            AlgorithmParameters params = cp.getParameters();
+            cp.init(Cipher.DECRYPT_MODE, deserializedKey, params);
+        }
+        
         byte[] newPlainText = cp.doFinal(cipherText, 0, cipherText.length);
         assertArrayEquals(plainText, newPlainText, "Secret keys are different");
     }


### PR DESCRIPTION
The DESedeKey and ChaCha20Key classes do allow for a provider to be used on construction of the key, however the provider is not saved to the private field of the class. This can cause NPE to be visable during serialization operations. This update simply saves the provider to the private field for later use.

Fixes: https://github.com/IBM/OpenJCEPlus/issues/920

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/921

Signed-off-by: Jason Katonica <katonica@us.ibm.com>


