### PR TITLE
Implement cleaner in key algorithms

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/DHKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHKeyPairGenerator.java
@@ -133,12 +133,12 @@ public final class DHKeyPairGenerator extends KeyPairGeneratorSpi {
                 AlgorithmParameters algParams = algParmGen.generateParameters();
                 this.params = algParams.getParameterSpec(DHParameterSpec.class);
 
-                dhKey = DHKey.generateKeyPair(provider.getOCKContext(), algParams.getEncoded());
+                dhKey = DHKey.generateKeyPair(provider.getOCKContext(), algParams.getEncoded(), provider);
             } else {
                 AlgorithmParameters algParams = AlgorithmParameters.getInstance("DH", provider);
                 algParams.init(params);
 
-                dhKey = DHKey.generateKeyPair(provider.getOCKContext(), algParams.getEncoded());
+                dhKey = DHKey.generateKeyPair(provider.getOCKContext(), algParams.getEncoded(), provider);
             }
 
             javax.crypto.interfaces.DHPrivateKey privKey = new DHPrivateKey(provider, dhKey);

--- a/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -92,7 +92,7 @@ final class DHPrivateKey extends PKCS8Key implements javax.crypto.interfaces.DHP
         try {
             this.key = new DerValue(DerValue.tag_Integer, this.x.toByteArray()).toByteArray();
             this.encodedKey = getEncoded();
-            this.dhKey = DHKey.createPrivateKey(provider.getOCKContext(), encodedKey);
+            this.dhKey = DHKey.createPrivateKey(provider.getOCKContext(), encodedKey, provider);
         } catch (IOException e) {
             throw new InvalidKeyException("Cannot produce ASN.1 encoding");
         } catch (OCKException e) {
@@ -123,7 +123,7 @@ final class DHPrivateKey extends PKCS8Key implements javax.crypto.interfaces.DHP
 
             buildOCKPrivateKeyBytes();
             this.dhKey = DHKey.createPrivateKey(provider.getOCKContext(),
-                    encoded /*privateKeyBytes*/);
+                    encoded /*privateKeyBytes*/, provider);
         } catch (Exception e) {
             throw new InvalidKeyException("Failure in DHPrivateKey");
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/DHPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -126,7 +126,7 @@ final class DHPublicKey extends X509Key
             // + ECUtils.bytesToHex(publicKeyBytes));
 
             this.dhKey = DHKey.createPublicKey(provider.getOCKContext(),
-                    /* publicKeyBytes */ this.encodedKey);
+                    /* publicKeyBytes */ this.encodedKey, provider);
 
             // System.err.println("Afte OCK: " + ECUtils.bytesToHex(this.key));
 

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAKeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -145,12 +145,12 @@ public final class DSAKeyPairGenerator extends KeyPairGenerator
                 AlgorithmParameters algParams = algParmGen.generateParameters();
                 this.params = algParams.getParameterSpec(DSAParameterSpec.class);
 
-                dsaKey = DSAKey.generateKeyPair(provider.getOCKContext(), algParams.getEncoded());
+                dsaKey = DSAKey.generateKeyPair(provider.getOCKContext(), algParams.getEncoded(), provider);
             } else {
                 AlgorithmParameters algParams = AlgorithmParameters.getInstance("DSA", provider);
                 algParams.init(params);
 
-                dsaKey = DSAKey.generateKeyPair(provider.getOCKContext(), algParams.getEncoded());
+                dsaKey = DSAKey.generateKeyPair(provider.getOCKContext(), algParams.getEncoded(), provider);
             }
 
             java.security.interfaces.DSAPrivateKey privKey = new DSAPrivateKey(provider, dsaKey);

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -68,7 +68,7 @@ final class DSAPrivateKey extends PKCS8Key
 
         try {
             byte[] privateKeyBytes = buildOCKPrivateKeyBytes();
-            this.dsaKey = DSAKey.createPrivateKey(provider.getOCKContext(), privateKeyBytes);
+            this.dsaKey = DSAKey.createPrivateKey(provider.getOCKContext(), privateKeyBytes, provider);
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create DSA private key",
                     exception);
@@ -90,7 +90,7 @@ final class DSAPrivateKey extends PKCS8Key
         try {
             parseKeyBits();
             byte[] privateKeyBytes = buildOCKPrivateKeyBytes();
-            this.dsaKey = DSAKey.createPrivateKey(provider.getOCKContext(), privateKeyBytes);
+            this.dsaKey = DSAKey.createPrivateKey(provider.getOCKContext(), privateKeyBytes, provider);
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create DSA private key",
                     exception);

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -70,7 +70,7 @@ final class DSAPublicKey extends X509Key
 
         try {
             byte[] publicKeyBytes = buildOCKPublicKeyBytes();
-            this.dsaKey = DSAKey.createPublicKey(provider.getOCKContext(), publicKeyBytes);
+            this.dsaKey = DSAKey.createPublicKey(provider.getOCKContext(), publicKeyBytes, provider);
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create DSA public key");
             provider.setOCKExceptionCause(ike, exception);
@@ -91,7 +91,7 @@ final class DSAPublicKey extends X509Key
 
         try {
             byte[] publicKeyBytes = buildOCKPublicKeyBytes();
-            this.dsaKey = DSAKey.createPublicKey(provider.getOCKContext(), publicKeyBytes);
+            this.dsaKey = DSAKey.createPublicKey(provider.getOCKContext(), publicKeyBytes, provider);
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create DSA public key");
             provider.setOCKExceptionCause(ike, exception);

--- a/src/main/java/com/ibm/crypto/plus/provider/ECKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECKeyPairGenerator.java
@@ -109,7 +109,7 @@ public final class ECKeyPairGenerator extends KeyPairGeneratorSpi {
 
             if (this.oid != null) {
                 ecKey = ECKey.generateKeyPair(provider.getOCKContext(), this.oid.toString(),
-                        cryptoRandom);
+                        cryptoRandom, provider);
             } else if (this.ecSpec != null) {
 
                 byte[] encodedCustomCurveParameters = ECParameters.encodeECParameters(this.ecSpec);
@@ -117,10 +117,10 @@ public final class ECKeyPairGenerator extends KeyPairGeneratorSpi {
                 // specification encodedParameters=" +
                 // ECUtils.bytesToHex(encodedCustomCurveParameters));
                 ecKey = ECKey.generateKeyPair(provider.getOCKContext(),
-                        encodedCustomCurveParameters, cryptoRandom);
+                        encodedCustomCurveParameters, cryptoRandom, provider);
             } else if (this.keysize > 0 && (ecSpec == null)) {
 
-                ecKey = ECKey.generateKeyPair(provider.getOCKContext(), this.keysize, cryptoRandom);
+                ecKey = ECKey.generateKeyPair(provider.getOCKContext(), this.keysize, cryptoRandom, provider);
             }
 
             java.security.interfaces.ECPrivateKey privKey = new ECPrivateKey(provider, ecKey);

--- a/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -82,7 +82,7 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
             byte[] privateKeyBytes = createEncodedPrivateKeyWithParams();
             byte[] paramBytes = ECParameters.encodeECParameters(this.params);
             this.ecKey = ECKey.createPrivateKey(provider.getOCKContext(), privateKeyBytes,
-                    paramBytes);
+                    paramBytes, provider);
         } catch (Exception exception) {
             throw new InvalidKeyException("Failed to create EC private key", exception);
         }
@@ -116,7 +116,7 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
             byte[] privateKeyBytes = createEncodedPrivateKeyWithParams();
             byte[] paramBytes = ECParameters.encodeECParameters(params);
             this.ecKey = ECKey.createPrivateKey(provider.getOCKContext(), privateKeyBytes,
-                    paramBytes);
+                    paramBytes, provider);
         } catch (Exception exception) {
             throw new InvalidKeyException("Failed to create EC private key", exception);
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/ECPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -66,7 +66,7 @@ final class ECPublicKey extends X509Key
             // this.ecKey = ECKey.createPublicKey(IBMJCEPlus.getOCKContext(), w,
             // ecParams);
             this.ecKey = ECKey.createPublicKey(provider.getOCKContext(), publicKeyBytes,
-                    parameterBytes);
+                    parameterBytes, provider);
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create EC public key");
             provider.setOCKExceptionCause(ike, exception);
@@ -90,7 +90,7 @@ final class ECPublicKey extends X509Key
             byte[] parameterBytes = ECParameters.encodeECParameters(this.params);
             // System.out.println ("Calling ECKey createPublicKey");
             this.ecKey = ECKey.createPublicKey(provider.getOCKContext(), publicKeyBytes,
-                    parameterBytes);
+                    parameterBytes, provider);
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create EC public key");
             provider.setOCKExceptionCause(ike, exception);

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAKeyPairGenerator.java
@@ -102,7 +102,7 @@ abstract class EdDSAKeyPairGenerator extends KeyPairGeneratorSpi {
         try {
             int keySize = CurveUtil.getCurveSize(curve);
             XECKey xecKey = XECKey.generateKeyPair(provider.getOCKContext(),
-                    this.curve.ordinal(), keySize);
+                    this.curve.ordinal(), keySize, provider);
             EdDSAPublicKeyImpl pubKey = new EdDSAPublicKeyImpl(provider, xecKey,
                     this.curve);
             EdDSAPrivateKeyImpl privKey = new EdDSAPrivateKeyImpl(provider, xecKey);

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAPrivateKeyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -95,13 +95,13 @@ final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKey {
             if (this.key == null) {
                 int keySize = CurveUtil.getCurveSize(curve);
                 this.xecKey = XECKey.generateKeyPair(provider.getOCKContext(),
-                        this.curve.ordinal(), keySize);
+                        this.curve.ordinal(), keySize, provider);
             } else {
                 this.algid = CurveUtil.getAlgId(this.curve);
                 byte[] der = buildOCKPrivateKeyBytes();
                 int encodingSize = CurveUtil.getDEREncodingSize(curve);
                 this.xecKey = XECKey.createPrivateKey(provider.getOCKContext(), der,
-                        encodingSize);
+                        encodingSize, provider);
             }
         } catch (Exception exception) {
             InvalidParameterException ike = new InvalidParameterException(
@@ -123,7 +123,7 @@ final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKey {
             checkLength(this.curve);
             int encodingSize = CurveUtil.getDEREncodingSize(curve);
             this.xecKey = XECKey.createPrivateKey(provider.getOCKContext(), alteredEncoded,
-                    encodingSize);
+                    encodingSize, provider);
 
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create XEC private key");

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAPublicKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAPublicKeyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -114,7 +114,7 @@ final class EdDSAPublicKeyImpl extends X509Key implements EdECPublicKey {
             byte[] der = buildOCKPublicKeyBytes();
             byte[] alteredEncoded = alterEncodedPublicKey(der); // Alters encoded to fit GSKit, and sets params
 
-            this.xecKey = XECKey.createPublicKey(provider.getOCKContext(), alteredEncoded);
+            this.xecKey = XECKey.createPublicKey(provider.getOCKContext(), alteredEncoded, provider);
 
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create EdDSA public key");
@@ -147,7 +147,7 @@ final class EdDSAPublicKeyImpl extends X509Key implements EdECPublicKey {
             this.point = new EdECPoint(xOdd, y);
 
             byte[] der = buildOCKPublicKeyBytes();
-            this.xecKey = XECKey.createPublicKey(provider.getOCKContext(), der);
+            this.xecKey = XECKey.createPublicKey(provider.getOCKContext(), der, provider);
 
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create EdDSA public key");

--- a/src/main/java/com/ibm/crypto/plus/provider/PBEKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PBEKey.java
@@ -44,6 +44,10 @@ final class PBEKey implements SecretKey {
             passwd = new char[0];
         }
 
+        if (provider == null) {
+            throw new IllegalArgumentException("provider is null");
+        }
+
         for (char c : passwd) {
             if (Character.isISOControl(c))
                 throw new InvalidKeySpecException("Invalid Password.");
@@ -53,6 +57,8 @@ final class PBEKey implements SecretKey {
         Arrays.fill(passwd, '\0');
         type = keytype;
         this.provider = provider;
+
+        this.provider.registerCleanable(this, cleanOCKResources(this.key));
     }
 
     public byte[] getEncoded() {
@@ -176,11 +182,19 @@ final class PBEKey implements SecretKey {
         }
     }
 
-    protected void finalize() throws Throwable {
-        try {
-            destroy();
-        } finally {
-            super.finalize();
-        }
+
+    private Runnable cleanOCKResources(byte[] key) {
+        return() -> {
+            try {
+                if (key != null) {
+                    Arrays.fill(key, (byte) 0x00);
+                }
+            } catch (Exception e){
+                if (OpenJCEPlusProvider.getDebug() != null) {
+                    OpenJCEPlusProvider.getDebug().println("An error occurred while cleaning : " + e.getMessage());
+                    e.printStackTrace();
+                }
+            }
+        };
     }
 }

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCKeyPairGenerator.java
@@ -52,13 +52,13 @@ abstract class PQCKeyPairGenerator extends KeyPairGeneratorSpi {
     @Override
     public KeyPair generateKeyPair() {
         try {
-            PQCKey mlkemKey = PQCKey.generateKeyPair(provider.getOCKContext(), mlkemAlg);
+            PQCKey mlkemKey = PQCKey.generateKeyPair(provider.getOCKContext(), mlkemAlg, provider);
             byte[] privKeyBytes = mlkemKey.getPrivateKeyBytes();
             PQCPrivateKey privKey = new PQCPrivateKey(provider, PQCKey.createPrivateKey(provider.getOCKContext(),
-                                                        mlkemAlg, privKeyBytes));
+                                                        mlkemAlg, privKeyBytes, provider));
             byte[] pubKeyBytes = mlkemKey.getPublicKeyBytes();
             PQCPublicKey pubKey = new PQCPublicKey(provider, PQCKey.createPublicKey(provider.getOCKContext(),
-                                                        mlkemAlg, pubKeyBytes));
+                                                        mlkemAlg, pubKeyBytes, provider));
             return new KeyPair(pubKey, privKey);
         } catch (Exception e) {
             throw provider.providerException("Failure in generateKeyPair - " +e.getCause(), e);

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCPrivateKey.java
@@ -60,7 +60,7 @@ final class PQCPrivateKey extends PKCS8Key {
             try {
                 pkOct = new DerValue(DerValue.tag_OctetString, key);
                 this.pqcKey = PQCKey.createPrivateKey(provider.getOCKContext(), 
-                                   this.name, pkOct.toByteArray());
+                                this.name, pkOct.toByteArray(), provider);
                 this.key = pkOct.toByteArray();
             } finally {
                 pkOct.clear();
@@ -126,7 +126,7 @@ final class PQCPrivateKey extends PKCS8Key {
             }
 
             this.pqcKey = PQCKey.createPrivateKey(provider.getOCKContext(), 
-                                   this.name, this.key);
+                                this.name, this.key, provider);
         } catch (Exception e) {
             throw new InvalidKeyException("Invalid key " + e.getMessage(), e);
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCPublicKey.java
@@ -49,7 +49,7 @@ final class PQCPublicKey extends X509Key
             byte[] b = tmp.toByteArray();
             tmp.close();
 
-            this.pqcKey = PQCKey.createPublicKey(provider.getOCKContext(), algName, b);
+            this.pqcKey = PQCKey.createPublicKey(provider.getOCKContext(), algName, b, provider);
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create public key");
             provider.setOCKExceptionCause(ike, exception);
@@ -86,7 +86,7 @@ final class PQCPublicKey extends X509Key
             byte[] b = tmp.toByteArray();
             tmp.close();
             
-            this.pqcKey = PQCKey.createPublicKey(provider.getOCKContext(), name, b);
+            this.pqcKey = PQCKey.createPublicKey(provider.getOCKContext(), name, b, provider);
         } catch (Exception e) {
             throw provider.providerException("Failure in PublicKey -"+e.getMessage(), e);
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/PrimitiveWrapper.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PrimitiveWrapper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright IBM Corp. 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package com.ibm.crypto.plus.provider;
+
+/**
+ * This class is used by some algorithms that use the cleaner to clean up
+ * native resources. Primitive type variables are passed by value instead
+ * of reference as parameters. There are some cases where a primitive member
+ * variable is modified after registering the instance to the cleaner, in 
+ * which case the cleaner may not have the updated value of the variable.
+ * To handle this scenario, one of the inner classes of PrimitiveWrapper 
+ * is used to allow the passing of a primitive variable by reference.
+ */
+
+public final class PrimitiveWrapper {
+    public static class Long { 
+        long value;
+        public Long(long value) {
+            this.value = value;
+        }
+
+        public long getValue(){
+            return this.value;
+        }
+
+        public void setValue(long value) {
+            this.value = value;
+        }
+    }
+
+    public static class Bool {
+        boolean value;
+        public Bool(boolean value) {
+            this.value = value;
+        }
+
+        public boolean getValue(){
+            return this.value;
+        }
+
+        public void setValue(boolean value) {
+            this.value = value;
+        }
+    }
+}

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAKeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -117,7 +117,7 @@ abstract class RSAKeyPairGenerator extends KeyPairGeneratorSpi {
     public KeyPair generateKeyPair() {
         try {
             RSAKey rsaKey = RSAKey.generateKeyPair(provider.getOCKContext(), this.keysize,
-                    this.publicExponent);
+                    this.publicExponent, provider);
             java.security.interfaces.RSAPrivateKey privKey = new RSAPrivateCrtKey(rsaId, provider, rsaKey);
             java.security.interfaces.RSAPublicKey pubKey = new RSAPublicKey(rsaId, provider, rsaKey);
             return new KeyPair(pubKey, privKey);

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateCrtKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateCrtKey.java
@@ -112,7 +112,7 @@ final class RSAPrivateCrtKey extends PKCS8Key
         }
 
         try {
-            this.rsaKey = RSAKey.createPrivateKey(provider.getOCKContext(), this.key);
+            this.rsaKey = RSAKey.createPrivateKey(provider.getOCKContext(), this.key, provider);
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create RSA private key");
             provider.setOCKExceptionCause(ike, exception);
@@ -137,7 +137,7 @@ final class RSAPrivateCrtKey extends PKCS8Key
         RSAKeyFactory.checkRSAProviderKeyLengths(provider, modulus.bitLength(), publicExponent);
 
         try {
-            this.rsaKey = RSAKey.createPrivateKey(provider.getOCKContext(), this.key);
+            this.rsaKey = RSAKey.createPrivateKey(provider.getOCKContext(), this.key, provider);
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create RSA private key");
             provider.setOCKExceptionCause(ike, exception);

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -70,7 +70,7 @@ final class RSAPrivateKey extends PKCS8Key
         }
 
         try {
-            this.rsaKey = RSAKey.createPrivateKey(provider.getOCKContext(), this.key);
+            this.rsaKey = RSAKey.createPrivateKey(provider.getOCKContext(), this.key, provider);
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create RSA private key");
             provider.setOCKExceptionCause(ike, exception);
@@ -93,7 +93,7 @@ final class RSAPrivateKey extends PKCS8Key
         RSAKeyFactory.checkRSAProviderKeyLengths(provider, modulus.bitLength(), null);
 
         try {
-            this.rsaKey = RSAKey.createPrivateKey(provider.getOCKContext(), this.key);
+            this.rsaKey = RSAKey.createPrivateKey(provider.getOCKContext(), this.key, provider);
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create RSA private key");
             provider.setOCKExceptionCause(ike, exception);

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -73,7 +73,7 @@ final class RSAPublicKey extends X509Key
         }
 
         try {
-            this.rsaKey = RSAKey.createPublicKey(provider.getOCKContext(), getKey().toByteArray());
+            this.rsaKey = RSAKey.createPublicKey(provider.getOCKContext(), getKey().toByteArray(), provider);
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create RSA public key");
             provider.setOCKExceptionCause(ike, exception);
@@ -91,7 +91,7 @@ final class RSAPublicKey extends X509Key
         checkExponentRange();
 
         try {
-            this.rsaKey = RSAKey.createPublicKey(provider.getOCKContext(), getKey().toByteArray());
+            this.rsaKey = RSAKey.createPublicKey(provider.getOCKContext(), getKey().toByteArray(), provider);
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create RSA public key");
             provider.setOCKExceptionCause(ike, exception);

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -126,7 +126,7 @@ abstract class XDHKeyPairGenerator extends KeyPairGeneratorSpi {
     public KeyPair generateKeyPair() {
         try {
             int keySize = CurveUtil.getCurveSize(serviceCurve);
-            XECKey xecKey = XECKey.generateKeyPair(provider.getOCKContext(), this.serviceCurve.ordinal(), keySize);
+            XECKey xecKey = XECKey.generateKeyPair(provider.getOCKContext(), this.serviceCurve.ordinal(), keySize, provider);
             XDHPrivateKeyImpl privKey = new XDHPrivateKeyImpl(provider, xecKey);
             XDHPublicKeyImpl pubKey = new XDHPublicKeyImpl(provider, xecKey, this.serviceCurve);
             return new KeyPair(pubKey, privKey);

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -95,7 +95,7 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
             byte[] alteredEncoded = processEncodedPrivateKey(encoded); // Sets params, key, and algid, and alters encoded
             // to fit with GSKit and sets params
             int encodingSize = CurveUtil.getDEREncodingSize(curve);
-            this.xecKey = XECKey.createPrivateKey(provider.getOCKContext(), alteredEncoded, encodingSize);
+            this.xecKey = XECKey.createPrivateKey(provider.getOCKContext(), alteredEncoded, encodingSize, provider);
             this.scalar = Optional.of(k);
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create XEC private key");
@@ -141,12 +141,12 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
         try {
             if (k == null) {
                 int keySize = CurveUtil.getCurveSize(curve);
-                this.xecKey = XECKey.generateKeyPair(provider.getOCKContext(), this.curve.ordinal(), keySize);
+                this.xecKey = XECKey.generateKeyPair(provider.getOCKContext(), this.curve.ordinal(), keySize, provider);
             } else {
                 this.algid = CurveUtil.getAlgId(this.params.getName());
                 byte[] der = buildOCKPrivateKeyBytes();
                 int encodingSize = CurveUtil.getDEREncodingSize(curve);
-                this.xecKey = XECKey.createPrivateKey(provider.getOCKContext(), der, encodingSize);
+                this.xecKey = XECKey.createPrivateKey(provider.getOCKContext(), der, encodingSize, provider);
             }
             setPKCS8KeyByte(k);
         } catch (Exception exception) {

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -129,7 +129,7 @@ final class XDHPublicKeyImpl extends X509Key implements XECPublicKey, Destroyabl
             this.u = new BigInteger(1, reverseKey); // u is the public key reversed
 
             byte[] alteredEncoded = alterEncodedPublicKey(encoded); // Alters encoded to fit GSKit, and sets params
-            this.xecKey = XECKey.createPublicKey(provider.getOCKContext(), alteredEncoded);
+            this.xecKey = XECKey.createPublicKey(provider.getOCKContext(), alteredEncoded, provider);
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create XEC public key");
             provider.setOCKExceptionCause(ike, exception);
@@ -173,7 +173,7 @@ final class XDHPublicKeyImpl extends X509Key implements XECPublicKey, Destroyabl
         try {
             if (u == null) {
                 int keySize = CurveUtil.getCurveSize(curve);
-                this.xecKey = XECKey.generateKeyPair(provider.getOCKContext(), curve.ordinal(), keySize);
+                this.xecKey = XECKey.generateKeyPair(provider.getOCKContext(), curve.ordinal(), keySize, provider);
                 setFieldsFromXeckey();
             } else {
 
@@ -207,7 +207,7 @@ final class XDHPublicKeyImpl extends X509Key implements XECPublicKey, Destroyabl
                 byte[] der = buildICCPublicKeyBytes();
                 checkKeySize();
 
-                this.xecKey = XECKey.createPublicKey(provider.getOCKContext(), der);
+                this.xecKey = XECKey.createPublicKey(provider.getOCKContext(), der, provider);
             }
         } catch (InvalidKeyException ex) {
             throw ex;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/Digest.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/Digest.java
@@ -9,6 +9,7 @@
 package com.ibm.crypto.plus.provider.ock;
 
 import com.ibm.crypto.plus.provider.OpenJCEPlusProvider;
+import com.ibm.crypto.plus.provider.PrimitiveWrapper;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -30,7 +31,7 @@ public final class Digest implements Cloneable {
     // -2   : Not a SHA* digest algorithm
     private int algIndx = -1;
 
-    private BoolWrapper needsReinit = new BoolWrapper(false);
+    private PrimitiveWrapper.Bool needsReinit = new PrimitiveWrapper.Bool(false);
 
     private boolean contextFromQueue = false;
 
@@ -144,22 +145,6 @@ public final class Digest implements Cloneable {
     /* end digest caching mechanism
      * ===========================================================================
      */
-
-    /* This wrapper is used to pass a primitive variable as a parameter by reference instead of by value to the cleaner. */
-    public class BoolWrapper {
-        boolean value;
-        public BoolWrapper(boolean value) {
-            this.value = value;
-        }
-
-        public boolean getValue(){
-            return this.value;
-        }
-
-        public void setValue(boolean value) {
-            this.value = value;
-        }
-    }
 
     private OCKContext ockContext = null;
     private int digestLength = 0;
@@ -365,7 +350,7 @@ public final class Digest implements Cloneable {
     }
 
     private Runnable cleanOCKResources(long digestId, int algIndx, boolean contextFromQueue,
-            BoolWrapper needsReinit, OCKContext ockContext) {
+            PrimitiveWrapper.Bool needsReinit, OCKContext ockContext) {
         return () -> {
             try {
                 if (digestId == 0) {

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/RSAKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/RSAKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -8,6 +8,8 @@
 
 package com.ibm.crypto.plus.provider.ock;
 
+import com.ibm.crypto.plus.provider.OpenJCEPlusProvider;
+import com.ibm.crypto.plus.provider.PrimitiveWrapper;
 import java.math.BigInteger;
 import java.util.Arrays;
 
@@ -18,16 +20,17 @@ public final class RSAKey implements AsymmetricKey {
     //
     static final byte[] unobtainedKeyBytes = new byte[0];
 
+    private OpenJCEPlusProvider provider;
     private OCKContext ockContext;
-    private long rsaKeyId;
-    private long pkeyId;
+    private final long rsaKeyId;
+    private PrimitiveWrapper.Long pkeyId;
     private byte[] privateKeyBytes;
     private byte[] publicKeyBytes;
     private int keySize;
     private final static String badIdMsg = "RSA Key Identifier is not valid";
     private final static String debPrefix = "RSAKey";
 
-    public static RSAKey generateKeyPair(OCKContext ockContext, int numBits, BigInteger e)
+    public static RSAKey generateKeyPair(OCKContext ockContext, int numBits, BigInteger e, OpenJCEPlusProvider provider)
             throws OCKException {
         //final String methodName = "generateKeyPair ";
         if (ockContext == null) {
@@ -38,12 +41,16 @@ public final class RSAKey implements AsymmetricKey {
             throw new IllegalArgumentException("key length is invalid");
         }
 
+        if (provider == null) {
+            throw new IllegalArgumentException("provider is null");
+        }
+
         long rsaKeyId = NativeInterface.RSAKEY_generate(ockContext.getId(), numBits, e.longValue());
         //OCKDebug.Msg (debPrefix, methodName,  "numBits=" + numBits + " rsaKeyId=" + rsaKeyId);
-        return new RSAKey(ockContext, rsaKeyId, unobtainedKeyBytes, unobtainedKeyBytes);
+        return new RSAKey(ockContext, rsaKeyId, unobtainedKeyBytes, unobtainedKeyBytes, provider);
     }
 
-    public static RSAKey createPrivateKey(OCKContext ockContext, byte[] privateKeyBytes)
+    public static RSAKey createPrivateKey(OCKContext ockContext, byte[] privateKeyBytes, OpenJCEPlusProvider provider)
             throws OCKException {
         //final String methodName = "createPrivateKey ";
         if (ockContext == null) {
@@ -54,13 +61,17 @@ public final class RSAKey implements AsymmetricKey {
             throw new IllegalArgumentException("key bytes is null");
         }
 
+        if (provider == null) {
+            throw new IllegalArgumentException("provider is null");
+        }
+
         long rsaKeyId = NativeInterface.RSAKEY_createPrivateKey(ockContext.getId(),
                 privateKeyBytes);
         //OCKDebug.Msg (debPrefix, methodName,  "rsaKeyId :" + rsaKeyId);
-        return new RSAKey(ockContext, rsaKeyId, privateKeyBytes.clone(), null);
+        return new RSAKey(ockContext, rsaKeyId, privateKeyBytes.clone(), null, provider);
     }
 
-    public static RSAKey createPublicKey(OCKContext ockContext, byte[] publicKeyBytes)
+    public static RSAKey createPublicKey(OCKContext ockContext, byte[] publicKeyBytes, OpenJCEPlusProvider provider)
             throws OCKException {
         //final String methodName = "createPublicKey ";
         if (ockContext == null) {
@@ -71,19 +82,26 @@ public final class RSAKey implements AsymmetricKey {
             throw new IllegalArgumentException("key bytes is null");
         }
 
+        if (provider == null) {
+            throw new IllegalArgumentException("provider is null");
+        }
+
         long rsaKeyId = NativeInterface.RSAKEY_createPublicKey(ockContext.getId(), publicKeyBytes);
         //OCKDebug.Msg (debPrefix, methodName,  "rsaKeyId :" + rsaKeyId);
-        return new RSAKey(ockContext, rsaKeyId, null, publicKeyBytes.clone());
+        return new RSAKey(ockContext, rsaKeyId, null, publicKeyBytes.clone(), provider);
     }
 
     private RSAKey(OCKContext ockContext, long rsaKeyId, byte[] privateKeyBytes,
-            byte[] publicKeyBytes) {
+            byte[] publicKeyBytes, OpenJCEPlusProvider provider) {
         this.ockContext = ockContext;
         this.rsaKeyId = rsaKeyId;
-        this.pkeyId = 0;
+        this.pkeyId = new PrimitiveWrapper.Long(0);
         this.privateKeyBytes = privateKeyBytes;
         this.publicKeyBytes = publicKeyBytes;
         this.keySize = 0;
+        this.provider = provider;
+
+        this.provider.registerCleanable(this, cleanOCKResources(privateKeyBytes, rsaKeyId, pkeyId, ockContext));
     }
 
     @Override
@@ -98,11 +116,11 @@ public final class RSAKey implements AsymmetricKey {
     @Override
     public long getPKeyId() throws OCKException {
         //final String methodName = "getPkeyId :";
-        if (pkeyId == 0) {
+        if (pkeyId.getValue() == 0) {
             obtainPKeyId();
         }
         //OCKDebug.Msg(debPrefix, methodName,   this.pkeyId);
-        return pkeyId;
+        return pkeyId.getValue();
     }
 
     public int getKeySize() throws OCKException {
@@ -139,11 +157,11 @@ public final class RSAKey implements AsymmetricKey {
         // to getPKeyId at the same time, we only want to call the native
         // code one time.
         //
-        if (pkeyId == 0) {
+        if (pkeyId.getValue() == 0) {
             if (!validId(rsaKeyId)) {
                 throw new OCKException(badIdMsg);
             }
-            this.pkeyId = NativeInterface.RSAKEY_createPKey(ockContext.getId(), rsaKeyId);
+            this.pkeyId.setValue(NativeInterface.RSAKEY_createPKey(ockContext.getId(), rsaKeyId));
         }
     }
 
@@ -188,34 +206,33 @@ public final class RSAKey implements AsymmetricKey {
         }
     }
 
-    @Override
-    protected synchronized void finalize() throws Throwable {
-        //final String methodName = "finalize ";
-        //OCKDebug.Msg(debPrefix, methodName, "rsaKeyId=" + rsaKeyId + " pkeyId=" + pkeyId);
-        try {
-            if ((privateKeyBytes != null) && (privateKeyBytes != unobtainedKeyBytes)) {
-                Arrays.fill(privateKeyBytes, (byte) 0x00);
-            }
-
-            if (rsaKeyId != 0) {
-                NativeInterface.RSAKEY_delete(ockContext.getId(), rsaKeyId);
-                rsaKeyId = 0;
-            }
-
-            if (pkeyId != 0) {
-                NativeInterface.PKEY_delete(ockContext.getId(), pkeyId);
-                pkeyId = 0;
-            }
-        } finally {
-            super.finalize();
-        }
-    }
-
     /* At some point we may enhance this function to do other validations */
     protected static boolean validId(long id) {
         //final String methodName = "validId";
         //OCKDebug.Msg(debPrefix, methodName, id);
         return (id != 0L);
+    }
+
+    private Runnable cleanOCKResources(byte[] privateKeyBytes, long rsaKeyId, PrimitiveWrapper.Long pkeyId, OCKContext ockContext) {
+        return() -> {
+            try {
+                if ((privateKeyBytes != null) && (privateKeyBytes != unobtainedKeyBytes)) {
+                    Arrays.fill(privateKeyBytes, (byte) 0x00);
+                }
+                if (rsaKeyId != 0) {
+                    NativeInterface.RSAKEY_delete(ockContext.getId(), rsaKeyId);
+                }
+
+                if (pkeyId.getValue() != 0) {
+                    NativeInterface.PKEY_delete(ockContext.getId(), pkeyId.getValue());
+                }
+            } catch (Exception e) {
+                if (OpenJCEPlusProvider.getDebug() != null) {
+                    OpenJCEPlusProvider.getDebug().println("An error occurred while cleaning : " + e.getMessage());
+                    e.printStackTrace();
+                }
+            }
+        };
     }
 
 }


### PR DESCRIPTION
Removes the deprecated finalize() methods from the key classes and implements a runnable function to handle native memory cleanup in their place.

Related to: https://github.com/IBM/OpenJCEPlus/pull/845

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/905

Signed-off-by: Sabrina Lee <sabrinalee@ibm.com>