### PR TITLE
Fix unable to find enum PBKDF2WithHmacSHA1

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/PBES2Parameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PBES2Parameters.java
@@ -79,7 +79,7 @@ import sun.security.util.ObjectIdentifier;
 abstract class PBES2Parameters extends AlgorithmParametersSpi {
 
     private static final ObjectIdentifier pkcs5PBKDF2_OID =
-            ObjectIdentifier.of(KnownOIDs.PBKDF2WithHmacSHA1);
+            ObjectIdentifier.of(KnownOIDs.findMatch("PBKDF2WithHmacSHA1"));
     private static final ObjectIdentifier pkcs5PBES2_OID =
             ObjectIdentifier.of(KnownOIDs.PBES2);
     private static final ObjectIdentifier aes128CBC_OID =


### PR DESCRIPTION
This update fixes the error where enum PBKDF2WithHmacSHA1 cannot be found because of the latest openjdk update.

Fixes: https://github.com/IBM/OpenJCEPlus/issues/943

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/945

Signed-off-by: Dev Agarwal [dev.agarwal@ibm.com](mailto:dev.agarwal@ibm.com)