### PR TITLE
Fix key compatibility problem in XDHKeyAgreement

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
@@ -15,12 +15,12 @@ import com.ibm.crypto.plus.provider.ock.XECKey;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.Key;
-import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.security.interfaces.XECPrivateKey;
+import java.security.interfaces.XECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.NamedParameterSpec;
-import java.security.spec.XECPrivateKeySpec;
 import javax.crypto.KeyAgreementSpi;
 import javax.crypto.SecretKey;
 import javax.crypto.ShortBufferException;
@@ -65,11 +65,22 @@ abstract class XDHKeyAgreement extends KeyAgreementSpi {
     @Override
     protected Key engineDoPhase(Key key, boolean lastPhase)
             throws InvalidKeyException, IllegalStateException {
-        if (!(key instanceof XDHPublicKeyImpl))
-            throw new InvalidKeyException("Key is not an XDHPublicKeyImpl");
+        if (!(key instanceof XECPublicKey)) {
+            throw new InvalidKeyException("Unsupported key type");
+        }
         if (ockXecKeyPriv == null)
             throw new IllegalStateException(
                     "object is not initialized correctly (private key is not received)");
+
+        if (!(key instanceof XDHPublicKeyImpl)) {
+            try {
+                key = (XDHPublicKeyImpl) XDHKeyFactory.toXECKey(this.provider, this.alg, key);
+            } catch (ClassCastException cce) {
+                throw new InvalidKeyException("Translated key is not an instance of XDHPublicKeyImpl", cce);
+            } catch (Exception exception) {
+                throw new InvalidKeyException("Unable to translate key", exception);
+            }
+        }
 
         XDHPublicKeyImpl xdhPublicKeyImpl = (XDHPublicKeyImpl) key;
 
@@ -218,6 +229,20 @@ abstract class XDHKeyAgreement extends KeyAgreementSpi {
     @Override
     protected void engineInit(Key key, AlgorithmParameterSpec params, SecureRandom random)
             throws InvalidKeyException, InvalidAlgorithmParameterException {
+        
+        if (!(key instanceof XECPrivateKey)) {
+            throw new InvalidKeyException("Unsupported key type");
+        }
+
+        if (!(key instanceof XDHPrivateKeyImpl)) {
+            try {
+                key = (XDHPrivateKeyImpl) XDHKeyFactory.toXECKey(this.provider, this.alg, key);
+            } catch (ClassCastException cce) {
+                throw new InvalidKeyException("Translated key is not an instance of XDHPrivateKeyImpl", cce);
+            } catch (Exception exception) {
+                throw new InvalidKeyException("Unable to translate key", exception);
+            }
+        }
 
         // Check if parameter is a valid NamedParameterSpec instance
         if (params != null) {
@@ -228,17 +253,6 @@ abstract class XDHKeyAgreement extends KeyAgreementSpi {
                 }
             } else {
                 throw new InvalidAlgorithmParameterException("Invalid Parameters: " + params);
-            }
-        }
-
-        if (!(key instanceof XDHPrivateKeyImpl)) {
-            try {
-                KeyFactory kf = KeyFactory.getInstance(this.alg);
-                XECPrivateKeySpec spec = kf.getKeySpec(key, XECPrivateKeySpec.class);
-                key = kf.generatePrivate(spec);
-            } catch (Exception exception) {
-                // should not happen
-                throw new InvalidKeyException("KeyFactory is not working as expected");
             }
         }
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyAgreementInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyAgreementInterop.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright IBM Corp. 2025, 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.junit.base;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import javax.crypto.KeyAgreement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+public class BaseTestXDHKeyAgreementInterop extends BaseTestJunit5Interop {
+    
+    protected KeyPairGenerator kpg1;
+    protected KeyPairGenerator kpg2;
+    protected KeyAgreement ka1;
+    protected KeyAgreement ka2;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        kpg1 = KeyPairGenerator.getInstance("XDH", getInteropProviderName());
+        kpg2 = KeyPairGenerator.getInstance("XDH", getProviderName());
+        ka1 = KeyAgreement.getInstance("XDH", getInteropProviderName());
+        ka2 = KeyAgreement.getInstance("XDH", getProviderName());
+    }
+
+    @Test
+    public void testKey() throws Exception {
+        KeyPair kp1 = kpg1.generateKeyPair();
+        KeyPair kp2 = kpg2.generateKeyPair();
+
+        ka1.init(kp1.getPrivate());
+        ka1.doPhase(kp2.getPublic(), true);
+        
+        ka2.init(kp2.getPrivate());
+        ka2.doPhase(kp1.getPublic(), true);
+
+        byte[] ss1 = ka1.generateSecret();
+        byte[] ss2 = ka2.generateSecret();
+
+        assertArrayEquals(ss1, ss2, "Key Agreement not compatible with different key providers");
+
+        ka1.init(kp2.getPrivate());
+        ka1.doPhase(kp1.getPublic(), true);
+
+        ka2.init(kp1.getPrivate());
+        ka2.doPhase(kp2.getPublic(), true);
+
+        byte[] ss3 = ka1.generateSecret();
+        byte[] ss4 = ka2.generateSecret();
+
+        assertArrayEquals(ss3, ss4, "Key Agreement not compatible with different key providers");
+    }
+}

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAll.java
@@ -146,6 +146,7 @@ import org.junit.platform.suite.api.Suite;
     TestXDH.class,
     TestXDHInterop.class,
     TestXDHInteropBC.class,
+    TestXDHKeyAgreementInterop.class,
     TestXDHKeyImport.class,
     TestXDHKeyPairGenerator.class,
     TestXDHMultiParty.class

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestXDHKeyAgreementInterop.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestXDHKeyAgreementInterop.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright IBM Corp. 2025, 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.junit.openjceplus;
+
+import ibm.jceplus.junit.base.BaseTestXDHKeyAgreementInterop;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestXDHKeyAgreementInterop extends BaseTestXDHKeyAgreementInterop{
+    
+    @BeforeAll
+    public void beforeAll() {
+        Utils.loadProviderTestSuite();
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
+        setInteropProviderName(Utils.PROVIDER_SunEC);
+    }
+}


### PR DESCRIPTION
Update XDHKeyAgreement to handle different providers using XDHKeyFactory.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/723

Signed-off-by: Dev Agarwal dev.agarwal@ibm.com