### PR TITLE
Fix key compatibility problem in XDHKeyAgreement

### DIFF
--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyAgreementInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDHKeyAgreementInterop.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright IBM Corp. 2025, 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.junit.base;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import javax.crypto.KeyAgreement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+public class BaseTestXDHKeyAgreementInterop extends BaseTestJunit5Interop {
+    
+    protected KeyPairGenerator kpg1;
+    protected KeyPairGenerator kpg2;
+    protected KeyAgreement ka1;
+    protected KeyAgreement ka2;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        kpg1 = KeyPairGenerator.getInstance("XDH", getInteropProviderName());
+        kpg2 = KeyPairGenerator.getInstance("XDH", getProviderName());
+        ka1 = KeyAgreement.getInstance("XDH", getInteropProviderName());
+        ka2 = KeyAgreement.getInstance("XDH", getProviderName());
+    }
+
+    @Test
+    public void testKey() throws Exception {
+        KeyPair kp1 = kpg1.generateKeyPair();
+        KeyPair kp2 = kpg2.generateKeyPair();
+
+        ka1.init(kp1.getPrivate());
+        ka1.doPhase(kp2.getPublic(), true);
+        
+        ka2.init(kp2.getPrivate());
+        ka2.doPhase(kp1.getPublic(), true);
+
+        byte[] ss1 = ka1.generateSecret();
+        byte[] ss2 = ka2.generateSecret();
+
+        assertArrayEquals(ss1, ss2, "Key Agreement not compatible with different key providers");
+
+        ka1.init(kp2.getPrivate());
+        ka1.doPhase(kp1.getPublic(), true);
+
+        ka2.init(kp1.getPrivate());
+        ka2.doPhase(kp2.getPublic(), true);
+
+        byte[] ss3 = ka1.generateSecret();
+        byte[] ss4 = ka2.generateSecret();
+
+        assertArrayEquals(ss3, ss4, "Key Agreement not compatible with different key providers");
+    }
+}

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestAll.java
@@ -137,6 +137,7 @@ import org.junit.platform.suite.api.Suite;
     TestXDH.class,
     TestXDHInterop.class,
     TestXDHInteropBC.class,
+    TestXDHKeyAgreementInterop.class,
     TestXDHKeyImport.class,
     TestXDHKeyPairGenerator.class,
     TestXDHMultiParty.class

--- a/src/test/java/ibm/jceplus/junit/openjceplus/TestXDHKeyAgreementInterop.java
+++ b/src/test/java/ibm/jceplus/junit/openjceplus/TestXDHKeyAgreementInterop.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright IBM Corp. 2025, 2025
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.junit.openjceplus;
+
+import ibm.jceplus.junit.base.BaseTestXDHKeyAgreementInterop;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestXDHKeyAgreementInterop extends BaseTestXDHKeyAgreementInterop{
+    
+    @BeforeAll
+    public void beforeAll() {
+        Utils.loadProviderTestSuite();
+        setProviderName(Utils.TEST_SUITE_PROVIDER_NAME);
+        setInteropProviderName(Utils.PROVIDER_SunEC);
+    }
+}


### PR DESCRIPTION
Update XDHKeyAgreement to handle different providers using XDHKeyFactory.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/723

Signed-off-by: Dev Agarwal [dev.agarwal@ibm.com](mailto:dev.agarwal@ibm.com)