### PR TITLE
Update GitHub Actions to use latest Temurin GA release

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Temurin JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '25.0.0+36.0.LTS'
+          java-version: '25.0.1+8.0.LTS'
           distribution: 'temurin'
           architecture: 'x64'
       # Uncomment to capture all files in the runner for debugging purposes.          


### PR DESCRIPTION
Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/954

Signed-off-by: Dev Agarwal [dev.agarwal@ibm.com](mailto:dev.agarwal@ibm.com)