### PR TITLE
Update GitHub Actions to use latest Temurin GA release

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -79,8 +79,8 @@ jobs:
       - name: Setup Semeru JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '11.0.27+6'
-          distribution: 'semeru'
+          java-version: '11.0.29+7'
+          distribution: 'temurin'
           architecture: 'x64'
       # Uncomment to capture all files in the runner for debugging purposes.          
       # - name: List Files In Entire Runner


### PR DESCRIPTION
Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/954

Signed-off-by: Dev Agarwal [dev.agarwal@ibm.com](mailto:dev.agarwal@ibm.com)