### PR TITLE
Implement cleaner in remaining algorithms

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/AESCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESCipher.java
@@ -296,7 +296,7 @@ public final class AESCipher extends CipherSpi implements AESConstants {
         try {
             if ((symmetricCipher == null) || (symmetricCipher.getKeyLength() != rawKey.length)) {
                 symmetricCipher = SymmetricCipher.getInstanceAES(provider.getOCKContext(), mode,
-                        padding, rawKey.length);
+                        padding, rawKey.length, provider);
                 // Check whether used algorithm is CBC and whether hardware supports is available
                 use_z_fast_command = symmetricCipher.getHardwareSupportStatus();
             }

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Cipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Cipher.java
@@ -232,7 +232,7 @@ public final class ChaCha20Cipher extends CipherSpi implements ChaCha20Constants
         try {
             if (symmetricCipher == null) {
                 symmetricCipher = SymmetricCipher.getInstanceChaCha20(provider.getOCKContext(),
-                        padding);
+                        padding, provider);
             }
 
             if (isEncrypt) {

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Poly1305Cipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Poly1305Cipher.java
@@ -328,7 +328,7 @@ public final class ChaCha20Poly1305Cipher extends CipherSpi
         try {
             if (poly1305Cipher == null) {
                 poly1305Cipher = Poly1305Cipher.getInstance(provider.getOCKContext(),
-                        OCK_CHACHA20_POLY1305, padding);
+                        OCK_CHACHA20_POLY1305, padding, provider);
             }
 
             if (this.encrypting) {

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeCipher.java
@@ -240,7 +240,7 @@ public final class DESedeCipher extends CipherSpi implements DESConstants {
         try {
             if (symmetricCipher == null) {
                 symmetricCipher = SymmetricCipher.getInstanceDESede(provider.getOCKContext(), mode,
-                        padding);
+                        padding, provider);
             }
 
             if (isEncrypt) {

--- a/src/main/java/com/ibm/crypto/plus/provider/HASHDRBG.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/HASHDRBG.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -33,7 +33,7 @@ abstract class HASHDRBG extends SecureRandomSpi {
         this.randomAlgo = ockRandomAlgo;
         basicRandom = BasicRandom.getInstance(provider.getOCKContext());
         try {
-            extendedRandom = ExtendedRandom.getInstance(provider.getOCKContext(), ockRandomAlgo);
+            extendedRandom = ExtendedRandom.getInstance(provider.getOCKContext(), ockRandomAlgo, provider);
         } catch (Exception e) {
             throw provider.providerException("Failed to get HASHDRBG algorithm", e);
         }
@@ -89,7 +89,7 @@ abstract class HASHDRBG extends SecureRandomSpi {
         basicRandom = BasicRandom.getInstance(provider.getOCKContext());
         try {
             // Recreate OCK object per tag [SERIALIZATION] in DesignNotes.txt
-            extendedRandom = ExtendedRandom.getInstance(provider.getOCKContext(), randomAlgo);
+            extendedRandom = ExtendedRandom.getInstance(provider.getOCKContext(), randomAlgo, provider);
         } catch (Exception e) {
             throw provider.providerException("Failed to get HASHDRBG algorithm", e);
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/HKDFGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/HKDFGenerator.java
@@ -49,7 +49,7 @@ public class HKDFGenerator extends KeyGeneratorSpi {
         this.provider = provider;
         this.digestAlgorithm = digestAlgorithm;
         try {
-            hkdfObj = HKDF.getInstance(this.provider.getOCKContext(), this.digestAlgorithm);
+            hkdfObj = HKDF.getInstance(this.provider.getOCKContext(), this.digestAlgorithm, provider);
             hkdfLen = hkdfObj.getMacLength();
         } catch (Exception ex) {
             throw new NoSuchAlgorithmException("cannot initialize hkdf");

--- a/src/main/java/com/ibm/crypto/plus/provider/HmacCore.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/HmacCore.java
@@ -25,7 +25,7 @@ abstract class HmacCore extends MacSpi {
     HmacCore(OpenJCEPlusProvider provider, String ockDigestAlgo, int blockLength) {
         try {
             this.provider = provider;
-            this.hmac = HMAC.getInstance(provider.getOCKContext(), ockDigestAlgo);
+            this.hmac = HMAC.getInstance(provider.getOCKContext(), ockDigestAlgo, provider);
         } catch (Exception e) {
             throw provider.providerException("Failure in HmacCore", e);
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
@@ -54,6 +54,12 @@ public abstract class OpenJCEPlusProvider extends java.security.Provider {
         }
     }
 
+    /**
+     * Any primitive instance variable whose value is changed after calling registerCleanable()
+     * in the constructor must be changed to the PrimitiveWrapper type if the variable is passed
+     * as a parameter to the Runnable cleaning method. This is to ensure the variable is passed by
+     * reference instead of by value.
+     */
     public void registerCleanable(Object owner, Runnable cleanAction) {
         Cleaner cleaner = cleaners[Math.abs(count.getAndIncrement() % numCleaners)];
         cleaner.register(owner, cleanAction);

--- a/src/main/java/com/ibm/crypto/plus/provider/PBES2Core.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PBES2Core.java
@@ -141,13 +141,6 @@ abstract class PBES2Core extends CipherSpi {
         } catch (InvalidKeySpecException ikse) {
             throw new InvalidKeyException("Cannot construct PBE key", ikse);
         } finally {
-            if (s != null) {
-                try {
-                    s.finalize();
-                } catch (Throwable e) {
-                   //some error happened
-                }
-            }
             pbeSpec.clearPassword();
         }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/PBKDF2KeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PBKDF2KeyImpl.java
@@ -131,6 +131,8 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
                 Arrays.fill(passwd, '\0');
             }
         }
+
+        this.provider.registerCleanable(this, cleanOCKResources(this.key, this.passwd, this.salt));
     }
 
     public byte[] getEncoded() {
@@ -240,25 +242,24 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
         throw new InvalidObjectException("PBKDF2KeyImpl keys are not directly deserializable");
     }
 
-    /**
-     * Cleans all sensitive information associated with this instance.
-     */
-    protected void finalize() throws Throwable {
-        try {
-            if (this.key != null) {
-                java.util.Arrays.fill(this.key, (byte) 0x00);
-                this.key = null;
+    private Runnable cleanOCKResources(byte[] key, char[] passwd, byte[] salt){
+        return() -> {
+            try {
+                if (key != null) {
+                    java.util.Arrays.fill(key, (byte) 0x00);
+                }
+                if (passwd != null) {
+                    java.util.Arrays.fill(passwd, '0');
+                }
+                if (salt != null) {
+                    java.util.Arrays.fill(salt, (byte) 0x00);
+                }
+            } catch (Exception e){
+                if (OpenJCEPlusProvider.getDebug() != null) {
+                    OpenJCEPlusProvider.getDebug().println("An error occurred while cleaning : " + e.getMessage());
+                    e.printStackTrace();
+                }
             }
-            if (this.passwd != null) {
-                java.util.Arrays.fill(this.passwd, '0');
-                this.passwd = null;
-            }
-            if (this.salt != null) {
-                java.util.Arrays.fill(this.salt, (byte) 0x00);
-                this.salt = null;
-            }
-        } finally {
-            super.finalize();
-        }
+        };
     }
 }

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPSSSignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPSSSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -95,7 +95,7 @@ public final class RSAPSSSignature extends SignatureSpi {
             this.signature = SignatureRSAPSS.getInstance(provider.getOCKContext(),
                     pssParameterSpec.getDigestAlgorithm(), pssParameterSpec.getSaltLength(),
                     pssParameterSpec.getTrailerField(), pssParameterSpec.getMGFAlgorithm(),
-                    mgf1ParamSpec.getDigestAlgorithm());
+                    mgf1ParamSpec.getDigestAlgorithm(), provider);
             engineSetParameter(pssParameterSpec);
         } catch (InvalidAlgorithmParameterException e) {
             throw new ProviderException(e);
@@ -166,7 +166,7 @@ public final class RSAPSSSignature extends SignatureSpi {
                     .getMGFParameters();
             this.signature = SignatureRSAPSS.getInstance(provider.getOCKContext(), ockDigestAlgo,
                     pssParameterSpec.getSaltLength(), pssParameterSpec.getTrailerField(),
-                    pssParameterSpec.getMGFAlgorithm(), mgf1ParamSpec.getDigestAlgorithm());
+                    pssParameterSpec.getMGFAlgorithm(), mgf1ParamSpec.getDigestAlgorithm(), provider);
             //System.out.println("In get Instance " + this.signature);
             engineSetParameter(pssParameterSpec);
 

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/GCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/GCMCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -8,6 +8,7 @@
 
 package com.ibm.crypto.plus.provider.ock;
 
+import com.ibm.crypto.plus.provider.OpenJCEPlusProvider;
 import java.nio.ByteBuffer;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -120,7 +121,7 @@ public final class GCMCipher {
     // except ICC_CTX which is thread safe
     public static int doGCMFinal_Decrypt(OCKContext ockContext, byte[] key, byte[] iv, int tagLen,
             byte[] input, int inputOffset, int inputLen, byte[] output, int outputOffset,
-            byte[] aad) throws OCKException, IllegalStateException, ShortBufferException,
+            byte[] aad, OpenJCEPlusProvider provider) throws OCKException, IllegalStateException, ShortBufferException,
             IllegalBlockSizeException, BadPaddingException, AEADBadTagException {
         //final String methodName="doGCMFinal_Decrypt ";
         int rc = 0;
@@ -159,6 +160,10 @@ public final class GCMCipher {
             throw new IllegalArgumentException("Output range is invalid");
         }
 
+        if (provider == null) {
+            throw new IllegalArgumentException("provider is null");
+        }
+
         // if Encrypting, the output buffer size should be cipherSize + TAG
         // if Decrypting, the output buffer size should be cipherSize - TAG
         int len = getOutputSizeLegacy(inputLen, false /*isEncrypt*/, tagLen);
@@ -192,7 +197,7 @@ public final class GCMCipher {
 
         int aadLen = authenticationData.length;
 
-        long gcmCtx = getGCMContext(false, key.length, ockContext);
+        long gcmCtx = getGCMContext(false, key.length, ockContext, provider);
 
         if (GCMHardwareFunctionPtr == 0)
             GCMHardwareFunctionPtr = NativeInterface
@@ -241,7 +246,7 @@ public final class GCMCipher {
     // except ICC_CTX which is thread safe
     public static int doGCMFinal_Encrypt(OCKContext ockContext, byte[] key, byte[] iv, int tagLen,
             byte[] input, int inputOffset, int inputLen, byte[] output, int outputOffset,
-            byte[] aad) throws OCKException, IllegalStateException, ShortBufferException,
+            byte[] aad, OpenJCEPlusProvider provider) throws OCKException, IllegalStateException, ShortBufferException,
             IllegalBlockSizeException, BadPaddingException {
 
         //final String methodName = "doGCMFinal_Encrypt ";
@@ -277,6 +282,10 @@ public final class GCMCipher {
 
         if ((output == null) || (outputOffset < 0) || (outputOffset > outputBufLen)) {
             throw new IllegalArgumentException("Output range is invalid");
+        }
+
+        if (provider == null) {
+            throw new IllegalArgumentException("provider is null");
         }
 
         // if Encrypting, the output buffer size should be cipherSize + TAG
@@ -317,7 +326,7 @@ public final class GCMCipher {
 
         int aadLen = authenticationData.length;
 
-        long gcmCtx = getGCMContext(true, key.length, ockContext);
+        long gcmCtx = getGCMContext(true, key.length, ockContext, provider);
 
         if (GCMHardwareFunctionPtr == 0)
             GCMHardwareFunctionPtr = NativeInterface
@@ -369,7 +378,7 @@ public final class GCMCipher {
 
     public static int do_GCM_FinalForUpdateDecrypt(OCKContext ockContext, byte[] key, byte[] iv,
             int tagLen, byte[] input, int inputOffset, int inputLen, byte[] output,
-            int outputOffset, byte[] aad)
+            int outputOffset, byte[] aad, OpenJCEPlusProvider provider)
             throws OCKException, IllegalStateException, ShortBufferException,
             IllegalBlockSizeException, BadPaddingException, AEADBadTagException {
         //final String methodName="do_GCM_FinalForUpdateDecrypt ";
@@ -409,6 +418,10 @@ public final class GCMCipher {
             throw new IllegalArgumentException("Output range is invalid");
         }
 
+        if (provider == null) {
+            throw new IllegalArgumentException("provider is null");
+        }
+
         // if Encrypting, the output buffer size should be cipherSize + TAG
         // if Decrypting, the output buffer size should be cipherSize - TAG
         int len = getOutputSize(inputLen, false /*isEncrypt*/, tagLen, true);
@@ -424,7 +437,7 @@ public final class GCMCipher {
 
         int aadLen = authenticationData.length;
 
-        long gcmCtx = getGCMContext(false, key.length, ockContext);
+        long gcmCtx = getGCMContext(false, key.length, ockContext, provider);
         //OCKDebug.Msg(debPrefix,methodName, "gcmCtx = " + gcmCtx );
 
         //OCKDebug.Msg (debPrefix, methodName, "key.length :" + key.length + " iv.length :" + iv.length + " inputOffset :" + inputOffset);
@@ -449,7 +462,7 @@ public final class GCMCipher {
 
     public static int do_GCM_InitForUpdateDecrypt(OCKContext ockContext, byte[] key, byte[] iv,
             int tagLen, byte[] input, int inputOffset, int inputLen, byte[] output,
-            int outputOffset, byte[] aad)
+            int outputOffset, byte[] aad, OpenJCEPlusProvider provider)
             throws OCKException, IllegalStateException, ShortBufferException,
             IllegalBlockSizeException, BadPaddingException, AEADBadTagException {
         //final String methodName="do_GCM_InitForUpdateDecrypt ";
@@ -485,6 +498,10 @@ public final class GCMCipher {
             throw new IllegalArgumentException("Output range is invalid");
         }
 
+        if (provider == null) {
+            throw new IllegalArgumentException("provider is null");
+        }
+
         // if Encrypting, the output buffer size should be cipherSize + TAG
         // if Decrypting, the output buffer size should be cipherSize - TAG
         int len = 0;
@@ -495,7 +512,7 @@ public final class GCMCipher {
 
         int aadLen = authenticationData.length;
 
-        long gcmCtx = getGCMContext(false, key.length, ockContext);
+        long gcmCtx = getGCMContext(false, key.length, ockContext, provider);
         //OCKDebug.Msg(debPrefix,methodName, "gcmCtx = " + gcmCtx );
 
         //To-Do - replace false with actual logic
@@ -518,7 +535,7 @@ public final class GCMCipher {
 
     public static /*synchronized*/ int do_GCM_UpdForUpdateDecrypt(OCKContext ockContext, byte[] key,
             byte[] iv, int tagLen, byte[] input, int inputOffset, int inputLen, byte[] output,
-            int outputOffset, byte[] aad)
+            int outputOffset, byte[] aad, OpenJCEPlusProvider provider)
             throws OCKException, IllegalStateException, ShortBufferException,
             IllegalBlockSizeException, BadPaddingException, AEADBadTagException {
         //final String methodName="do_GCM_UpdForUpdateDecrypt ";
@@ -559,6 +576,10 @@ public final class GCMCipher {
             throw new IllegalArgumentException("Output range is invalid");
         }
 
+        if (provider == null) {
+            throw new IllegalArgumentException("provider is null");
+        }
+
         // if Encrypting, the output buffer size should be cipherSize + TAG
         // if Decrypting, the output buffer size should be cipherSize - TAG
         int len = getOutputSize(inputLen, false /*isEncrypt*/, tagLen, false);
@@ -569,7 +590,7 @@ public final class GCMCipher {
 
         //int aadLen = authenticationData.length;
 
-        long gcmCtx = getGCMContext(false, key.length, ockContext);
+        long gcmCtx = getGCMContext(false, key.length, ockContext, provider);
 
         //OCKDebug.Msg(debPrefix,methodName, "gcmCtx = " + gcmCtx );
 
@@ -592,7 +613,7 @@ public final class GCMCipher {
 
     public static int do_GCM_FinalForUpdateEncrypt(OCKContext ockContext, byte[] key, byte[] iv,
             int tagLen, byte[] input, int inputOffset, int inputLen, byte[] output,
-            int outputOffset, byte[] aad) throws OCKException, IllegalStateException,
+            int outputOffset, byte[] aad, OpenJCEPlusProvider provider) throws OCKException, IllegalStateException,
             ShortBufferException, IllegalBlockSizeException, BadPaddingException {
 
         //final String methodName = "do_GCM_FinalForUpdateEncrypt ";
@@ -627,6 +648,10 @@ public final class GCMCipher {
 
         if ((output == null) || (outputOffset < 0) || (outputOffset > outputBufLen)) {
             throw new IllegalArgumentException("Output range is invalid");
+        }
+
+        if (provider == null) {
+            throw new IllegalArgumentException("provider is null");
         }
 
         // if Encrypting, the output buffer size should be cipherSize + TAG
@@ -669,7 +694,7 @@ public final class GCMCipher {
 
         int aadLen = authenticationData.length;
 
-        long gcmCtx = getGCMContext(true, key.length, ockContext);
+        long gcmCtx = getGCMContext(true, key.length, ockContext, provider);
         //OCKDebug.Msg (debPrefix, methodName, "gcmCtx :" + String.valueOf(gcmCtx));
 
 
@@ -701,7 +726,7 @@ public final class GCMCipher {
     // except ICC_CTX which is thread safe
     public static int do_GCM_UpdForUpdateEncrypt(OCKContext ockContext, byte[] key, byte[] iv,
             int tagLen, byte[] input, int inputOffset, int inputLen, byte[] output,
-            int outputOffset, byte[] aad) throws OCKException, IllegalStateException,
+            int outputOffset, byte[] aad, OpenJCEPlusProvider provider) throws OCKException, IllegalStateException,
             ShortBufferException, IllegalBlockSizeException, BadPaddingException {
 
         //final String methodName = "do_GCM_UpdForUpdateEncrypt ";
@@ -738,6 +763,10 @@ public final class GCMCipher {
             throw new IllegalArgumentException("Output range is invalid");
         }
 
+        if (provider == null) {
+            throw new IllegalArgumentException("provider is null");
+        }
+
         // if Encrypting, the output buffer size should be cipherSize + TAG
         // if Decrypting, the output buffer size should be cipherSize - TAG
         int len = getOutputSize(inputLen, true /* isEncrypt */, tagLen, false);
@@ -762,7 +791,7 @@ public final class GCMCipher {
 
         // int aadLen = authenticationData.length;
 
-        long gcmCtx = getGCMContext(true, key.length, ockContext);
+        long gcmCtx = getGCMContext(true, key.length, ockContext, provider);
         //OCKDebug.Msg(debPrefix, methodName, " gcmCtx " + gcmCtx);
         //To-Do and implement actual logic
 
@@ -788,7 +817,7 @@ public final class GCMCipher {
     // except ICC_CTX which is thread safe
     public static int do_GCM_InitForUpdateEncrypt(OCKContext ockContext, byte[] key, byte[] iv,
             int tagLen, byte[] input, int inputOffset, int inputLen, byte[] output,
-            int outputOffset, byte[] aad) throws OCKException, IllegalStateException,
+            int outputOffset, byte[] aad, OpenJCEPlusProvider provider) throws OCKException, IllegalStateException,
             ShortBufferException, IllegalBlockSizeException, BadPaddingException {
 
         //final String methodName = "do_GCM_InitForUpdateEncrypt ";
@@ -814,6 +843,9 @@ public final class GCMCipher {
             throw new IllegalArgumentException("IV is the wrong size");
         }
 
+        if (provider == null) {
+            throw new IllegalArgumentException("provider is null");
+        }
 
         // if Encrypting, the output buffer size should be cipherSize + TAG
         // if Decrypting, the output buffer size should be cipherSize - TAG
@@ -839,7 +871,7 @@ public final class GCMCipher {
 
         int aadLen = authenticationData.length;
 
-        long gcmCtx = getGCMContext(true, key.length, ockContext);
+        long gcmCtx = getGCMContext(true, key.length, ockContext, provider);
         //OCKDebug.Msg(debPrefix, methodName, " gcmCtx " + gcmCtx);
 
         //OCKDebug.Msg (debPrefix, methodName, "key.length :" + key.length + " iv.length :" + iv.length + " inputOffset :" + inputOffset);
@@ -861,7 +893,7 @@ public final class GCMCipher {
     }
 
 
-    private static long getGCMContext(boolean encrypting, int keyLength, OCKContext ockContext)
+    private static long getGCMContext(boolean encrypting, int keyLength, OCKContext ockContext, OpenJCEPlusProvider provider)
             throws OCKException {
         //// if it is indicated that Java based TLS storage of GCM contexts should be used
         //// we fetch the TLS copy of the gcm context. if uninitialized, create a new one
@@ -891,7 +923,7 @@ public final class GCMCipher {
             }
             gcmCtx = gcmCtxBuffer.get();
             if (gcmCtx == null) {
-                gcmCtx = new GCMContextPointer(ockContext.getId());
+                gcmCtx = new GCMContextPointer(ockContext.getId(), provider);
                 gcmCtxBuffer.set(gcmCtx);
             }
             return gcmCtx.getCtx();
@@ -1033,28 +1065,35 @@ public final class GCMCipher {
     }
 
     static class GCMContextPointer {
-        long gcmCtx = 0;
+        OpenJCEPlusProvider provider;
+        final long gcmCtx;
         long ockContext = 0;
 
-        GCMContextPointer(long ockContext) throws OCKException {
+        GCMContextPointer(long ockContext, OpenJCEPlusProvider provider) throws OCKException {
             this.gcmCtx = NativeInterface.create_GCM_context(ockContext);
             this.ockContext = ockContext;
-        }
+            this.provider = provider;
 
-        @Override
-        protected synchronized void finalize() throws Throwable {
-            try {
-                if (gcmCtx != 0) {
-                    NativeInterface.free_GCM_ctx(ockContext, gcmCtx);
-                    gcmCtx = 0;
-                }
-            } finally {
-                super.finalize();
-            }
+            this.provider.registerCleanable(this, cleanOCKResources(gcmCtx, ockContext));
         }
 
         long getCtx() {
             return gcmCtx;
+        }
+
+        private Runnable cleanOCKResources(long gcmCtx, long ockContext){
+            return() -> {
+                try {
+                    if (gcmCtx != 0) {
+                        NativeInterface.free_GCM_ctx(ockContext, gcmCtx);
+                    }
+                } catch (Exception e) {
+                    if (OpenJCEPlusProvider.getDebug() != null) {
+                        OpenJCEPlusProvider.getDebug().println("An error occurred while cleaning : " + e.getMessage());
+                        e.printStackTrace();
+                    }
+                }
+            };
         }
     }
 
@@ -1076,4 +1115,5 @@ public final class GCMCipher {
 
         return supported;
     }
+
 }


### PR DESCRIPTION
Removes the deprecated finalize() method from the non key algorithms and implements a runnable function to handle native memory cleanup in their places.

Related to: https://github.com/IBM/OpenJCEPlus/pull/845 & https://github.com/IBM/OpenJCEPlus/pull/905

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/944

Signed-off-by: Sabrina Lee <sabrinalee@ibm.com>