### PR TITLE
Pass constructor parameters in Service initialization

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/DHParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHParameters.java
@@ -24,8 +24,6 @@ import sun.security.util.DerValue;
 public final class DHParameters extends AlgorithmParametersSpi implements java.io.Serializable {
     private static final long serialVersionUID = 7137508373627164657L;
 
-    private OpenJCEPlusProvider provider;
-
     // The prime (p)
     private BigInteger p;
 
@@ -35,9 +33,7 @@ public final class DHParameters extends AlgorithmParametersSpi implements java.i
     // The private-value length (l)
     private int l;
 
-    public DHParameters(OpenJCEPlusProvider provider) {
-        this.provider = provider;
-    }
+    public DHParameters() {}
 
     @Override
     protected void engineInit(AlgorithmParameterSpec paramSpec)
@@ -143,7 +139,7 @@ public final class DHParameters extends AlgorithmParametersSpi implements java.i
 
     @Override
     protected String engineToString() {
-        StringBuffer strbuf = new StringBuffer(provider.getName() + " Diffie-Hellman Parameters:\n"
+        StringBuffer strbuf = new StringBuffer("OpenJCEPlusProvider Diffie-Hellman Parameters:\n"
                 + "p:\n" + this.p.toString() + "\n" + "g:\n" + this.g.toString());
         if (this.l != 0)
             strbuf.append("\nl:\n" + "    " + this.l);

--- a/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
@@ -79,7 +79,7 @@ final class DHPrivateKey extends PKCS8Key implements javax.crypto.interfaces.DHP
         this.x = x;
 
         if (dhp == null) {
-            this.dhParams = new DHParameters(provider);
+            this.dhParams = new DHParameters();
             try {
                 this.dhParams.engineInit(new DHParameterSpec(p, g, l));
             } catch (InvalidParameterSpecException e) {
@@ -194,7 +194,7 @@ final class DHPrivateKey extends PKCS8Key implements javax.crypto.interfaces.DHP
             this.key = val.getData().getOctetString();
             parseKeyBits();
 
-            dhParams = new DHParameters(provider);
+            dhParams = new DHParameters();
             dhParams.engineInit((l == -1) ? new DHParameterSpec(p, g, x.bitLength())
                     : new DHParameterSpec(p, g, l));
 

--- a/src/main/java/com/ibm/crypto/plus/provider/DHPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHPublicKey.java
@@ -55,7 +55,7 @@ final class DHPublicKey extends X509Key
             int l) throws InvalidKeyException {
         this.provider = provider;
         this.y = y;
-        dhParams = new DHParameters(provider);
+        dhParams = new DHParameters();
         try {
             dhParams.engineInit(new DHParameterSpec(p, g, l));
             byte[] keyArray = new DerValue(DerValue.tag_Integer, this.y.toByteArray()).toByteArray();
@@ -198,7 +198,7 @@ final class DHPublicKey extends X509Key
                 throw new InvalidKeyException("Excess key data");
             }
 
-            dhParams = new DHParameters(provider);
+            dhParams = new DHParameters();
             dhParams.engineInit((l == -1) ? new DHParameterSpec(p, g, y.bitLength())
                     : new DHParameterSpec(p, g, l));
 

--- a/src/main/java/com/ibm/crypto/plus/provider/HKDFKeyDerivation.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/HKDFKeyDerivation.java
@@ -290,6 +290,11 @@ public class HKDFKeyDerivation extends KDFSpi {
     }
 
     public static final class HKDFSHA256 extends HKDFKeyDerivation {
+        public HKDFSHA256(OpenJCEPlusProvider provider, KDFParameters kdfParameters)
+                throws InvalidAlgorithmParameterException {
+            super(provider, SupportedHmac.SHA256, kdfParameters);
+        }
+
         public HKDFSHA256(OpenJCEPlusProvider provider)
                 throws InvalidAlgorithmParameterException {
             super(provider, SupportedHmac.SHA256, null);
@@ -297,6 +302,11 @@ public class HKDFKeyDerivation extends KDFSpi {
     }
 
     public static final class HKDFSHA384 extends HKDFKeyDerivation {
+        public HKDFSHA384(OpenJCEPlusProvider provider, KDFParameters kdfParameters)
+                throws InvalidAlgorithmParameterException {
+            super(provider, SupportedHmac.SHA384, kdfParameters);
+        }
+
         public HKDFSHA384(OpenJCEPlusProvider provider)
                 throws InvalidAlgorithmParameterException {
             super(provider, SupportedHmac.SHA384, null);
@@ -304,6 +314,11 @@ public class HKDFKeyDerivation extends KDFSpi {
     }
 
     public static final class HKDFSHA512 extends HKDFKeyDerivation {
+        public HKDFSHA512(OpenJCEPlusProvider provider, KDFParameters kdfParameters)
+                throws InvalidAlgorithmParameterException {
+            super(provider, SupportedHmac.SHA512, kdfParameters);
+        }
+
         public HKDFSHA512(OpenJCEPlusProvider provider)
                 throws InvalidAlgorithmParameterException {
             super(provider, SupportedHmac.SHA512, null);

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
@@ -10,19 +10,11 @@ package com.ibm.crypto.plus.provider;
 
 import com.ibm.crypto.plus.provider.ock.OCKContext;
 import com.ibm.crypto.plus.provider.ock.OCKException;
-import java.lang.reflect.Constructor;
-import java.security.InvalidParameterException;
-import java.security.Key;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.ProviderException;
-import java.security.PublicKey;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import javax.crypto.SecretKey;
 
 public final class OpenJCEPlus extends OpenJCEPlusProvider {
 
@@ -1178,115 +1170,6 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
 
         putService(new OpenJCEPlusService(jce, "Signature", "ML-DSA-87",
                "com.ibm.crypto.plus.provider.PQCSignatureImpl$MLDSA87", aliases));
-    }
-
-    private static class OpenJCEPlusService extends Service {
-
-        OpenJCEPlusService(Provider provider, String type, String algorithm, String className,
-                String[] aliases) {
-            this(provider, type, algorithm, className, aliases, null);
-        }
-
-        OpenJCEPlusService(Provider provider, String type, String algorithm, String className,
-                String[] aliases, Map<String, String> attributes) {
-            super(provider, type, algorithm, className, toList(aliases), attributes);
-
-            if (debug != null) {
-                debug.println("Constructing OpenJCEPlusService: " + provider + ", " + type
-                            + ", " + algorithm + ", " + className);
-            }
-        }
-
-        private static List<String> toList(String[] aliases) {
-            return (aliases == null) ? null : Arrays.asList(aliases);
-        }
-
-        @Override
-        public Object newInstance(Object constructorParameter) throws NoSuchAlgorithmException {
-            Provider provider = getProvider();
-            String className = getClassName();
-            try {
-                Class<?> cls = Class.forName(className);
-
-                // Call the constructor that takes an OpenJCEPlusProvider if
-                // available
-                //
-                try {
-                    Class<?>[] parameters = new Class<?>[1];
-                    parameters[0] = Class
-                            .forName("com.ibm.crypto.plus.provider.OpenJCEPlusProvider");
-                    Constructor<?> constr = cls.getConstructor(parameters);
-
-                    return constr.newInstance(new Object[] {provider});
-                } catch (java.lang.NoSuchMethodException e) {
-                }
-            } catch (Exception clex) {
-                throw new NoSuchAlgorithmException(clex);
-            }
-
-            return super.newInstance(constructorParameter);
-        }
-
-        @Override
-        public boolean supportsParameter(Object parameter) {
-
-            if (parameter == null) {
-                return false;
-            }
-            if (parameter instanceof Key == false) {
-                throw new InvalidParameterException("Parameter must be a Key");
-            }
-            Key key = (Key) parameter;
-
-            if (key instanceof SecretKey) {
-
-                String keyType = ((SecretKey) key).getFormat();
-                if (keyType == null) {
-                    // this happens when encoding is not supported
-                    return true;
-                }
-                if (keyType.equalsIgnoreCase("RAW") || keyType.equalsIgnoreCase("PKCS5_DERIVED_KEY")
-                        || keyType.equalsIgnoreCase("PKCS5_KEY")) {
-                    return true;
-                } else {
-                    return false;
-                }
-
-            } else if (key instanceof PrivateKey) {
-                String keyType = ((PrivateKey) key).getFormat();
-                if (keyType == null) {
-                    // this happens when encoding is not supported
-                    return true;
-                }
-                if (keyType.equalsIgnoreCase("PKCS#8")) {
-                    return true;
-                } else {
-                    return false;
-                }
-            } else if (key instanceof PublicKey) {
-                String keyType = ((PublicKey) key).getFormat();
-                if (keyType == null) {
-                    // this happens when encoding is not supported
-                    return true;
-                }
-                if (keyType.equalsIgnoreCase("X.509")) {
-                    return true;
-                } else {
-                    return false;
-                }
-            }
-
-            return false;
-        }
-
-        @Override
-        public String toString() {
-
-            return (super.toString() + "\n" + "provider = " + this.getProvider().getName() + "\n"
-                    + "algorithm = " + this.getAlgorithm());
-
-        }
-
     }
 
     // Return the instance of this class or create one if needed.

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -10,19 +10,12 @@ package com.ibm.crypto.plus.provider;
 
 import com.ibm.crypto.plus.provider.ock.OCKContext;
 import com.ibm.crypto.plus.provider.ock.OCKException;
-import java.lang.reflect.Constructor;
-import java.security.InvalidParameterException;
-import java.security.Key;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.ProviderException;
-import java.security.PublicKey;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.crypto.SecretKey;
 
 public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
 
@@ -695,115 +688,6 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
         putService(new OpenJCEPlusService(jce, "Signature", "RSAPSS",
                 "com.ibm.crypto.plus.provider.RSAPSSSignature", aliases));
 
-    }
-
-    private static class OpenJCEPlusService extends Service {
-
-        OpenJCEPlusService(Provider provider, String type, String algorithm, String className,
-                String[] aliases) {
-            this(provider, type, algorithm, className, aliases, null);
-        }
-
-        OpenJCEPlusService(Provider provider, String type, String algorithm, String className,
-                String[] aliases, Map<String, String> attributes) {
-            super(provider, type, algorithm, className, toList(aliases), attributes);
-
-            if (debug != null) {
-                debug.println("Constructing OpenJCEPlusService: " + provider + ", " + type
-                        + ", " + algorithm + ", " + className);
-            }
-        }
-
-        private static List<String> toList(String[] aliases) {
-            return (aliases == null) ? null : Arrays.asList(aliases);
-        }
-
-        @Override
-        public Object newInstance(Object constructorParameter) throws NoSuchAlgorithmException {
-            Provider provider = getProvider();
-            String className = getClassName();
-            try {
-                Class<?> cls = Class.forName(className);
-
-                // Call the constructor that takes an OpenJCEPlusProvider if
-                // available
-                //
-                try {
-                    Class<?>[] parameters = new Class<?>[1];
-                    parameters[0] = Class
-                            .forName("com.ibm.crypto.plus.provider.OpenJCEPlusProvider");
-                    Constructor<?> constr = cls.getConstructor(parameters);
-
-                    return constr.newInstance(new Object[] {provider});
-                } catch (java.lang.NoSuchMethodException e) {
-                }
-            } catch (Exception clex) {
-                throw new NoSuchAlgorithmException(clex);
-            }
-
-            return super.newInstance(constructorParameter);
-        }
-
-        @Override
-        public boolean supportsParameter(Object parameter) {
-
-            if (parameter == null) {
-                return false;
-            }
-            if (parameter instanceof Key == false) {
-                throw new InvalidParameterException("Parameter must be a Key");
-            }
-            Key key = (Key) parameter;
-
-            if (key instanceof SecretKey) {
-
-                String keyType = ((SecretKey) key).getFormat();
-                if (keyType == null) {
-                    // this happens when encoding is not supported
-                    return true;
-                }
-                if (keyType.equalsIgnoreCase("RAW") || keyType.equalsIgnoreCase("PKCS5_DERIVED_KEY")
-                        || keyType.equalsIgnoreCase("PKCS5_KEY")) {
-                    return true;
-                } else {
-                    return false;
-                }
-
-            } else if (key instanceof PrivateKey) {
-                String keyType = ((PrivateKey) key).getFormat();
-                if (keyType == null) {
-                    // this happens when encoding is not supported
-                    return true;
-                }
-                if (keyType.equalsIgnoreCase("PKCS#8")) {
-                    return true;
-                } else {
-                    return false;
-                }
-            } else if (key instanceof PublicKey) {
-                String keyType = ((PublicKey) key).getFormat();
-                if (keyType == null) {
-                    // this happens when encoding is not supported
-                    return true;
-                }
-                if (keyType.equalsIgnoreCase("X.509")) {
-                    return true;
-                } else {
-                    return false;
-                }
-            }
-
-            return false;
-
-        }
-
-        @Override
-        public String toString() {
-
-            return (super.toString() + "\n" + "provider = " + this.getProvider().getName() + "\n"
-                    + "algorithm = " + this.getAlgorithm());
-
-        }
     }
 
     // Return the instance of this class or create one if needed.

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHKDF.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHKDF.java
@@ -25,6 +25,7 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.KDF;
+import javax.crypto.KDFParameters;
 import javax.crypto.KeyAgreement;
 import javax.crypto.KeyGenerator;
 import javax.crypto.NoSuchPaddingException;
@@ -34,6 +35,7 @@ import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseTestHKDF extends BaseTestJunit5 {
 
@@ -202,6 +204,31 @@ public class BaseTestHKDF extends BaseTestJunit5 {
         String plainStr = decrypt(calcOkm, encryptedBytes, "AES/ECB/PKCS5Padding");
         assertTrue(plainStr.equals(strToEncrypt));
     }
+
+
+    @Test
+    public void testConstructorParameters() throws NoSuchAlgorithmException, NoSuchProviderException {
+        try {
+            KDF.getInstance("HKDF-SHA256", new MyKDFParameters());
+            fail("Expected InvalidAlgorithmParameterException not thrown.");
+        } catch (InvalidAlgorithmParameterException iape) {
+            String expectedMessage = "The KDFParameters supplied could not be used in combination with the "
+                    + "supplied algorithm for the selected Provider";
+            assertTrue(expectedMessage.equals(iape.getMessage()), "Exception doesn't have expected message");
+        }
+
+        try {
+            KDF.getInstance("HKDF-SHA256", new MyKDFParameters2(), getProviderName());
+            fail("Expected InvalidAlgorithmParameterException not thrown.");
+        } catch (InvalidAlgorithmParameterException iape) {
+            String expectedMessage = "HmacSHA256 does not support parameters";
+            assertTrue(expectedMessage.equals(iape.getMessage()), "Exception doesn't have expected message");
+        }
+    }
+    
+    private static class MyKDFParameters implements KDFParameters {}
+
+    private static class MyKDFParameters2 implements KDFParameters {}
 
     private void aesHKDF(int aesKeySize, String hashAlg, String extractAlg, String expandAlg,
             String providerName) throws NoSuchAlgorithmException, NoSuchProviderException,


### PR DESCRIPTION
Current code ignores parameters that need to be passed to the constructor of a service that needs to be initialized.

This change is rectifying this and ensuring parameters are appropriately forwarded to the service's constructor.

A test to verify this is added using KDF services, which is currently the only one that seems to take advantage of this.

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>