### PR TITLE
Fix AESGCMCipher key cleanup action

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/PrimitiveWrapper.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PrimitiveWrapper.java
@@ -48,4 +48,19 @@ public final class PrimitiveWrapper {
             this.value = value;
         }
     }
+
+    public static class ByteArray {
+        byte[] value;
+        public ByteArray(byte[] value) {
+            this.value = value;
+        }
+
+        public byte[] getValue(){
+            return this.value;
+        }
+
+        public void setValue(byte[] value) {
+            this.value = value;
+        }
+    }
 }


### PR DESCRIPTION
The cleanup method in AESGCMCipher was not correctly zeroing out the key array due to an incorrect null reference passed as parameter. Putting a wrapper around the key variable fixes this issue.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/970

Signed-off-by: Sabrina Lee <sabrinalee@ibm.com>