### PR TITLE
Whitespace only clang format changes

### DIFF
--- a/src/main/native/AESKeyWrap.c
+++ b/src/main/native/AESKeyWrap.c
@@ -45,7 +45,8 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_CIPHER_1KeyWraporUnwrap(
         env, input, &isCopy));
 
     if (NULL == inputNative) {
-        throwOCKException(env, 0, "Input is NULL from GetPrimitiveArrayCritical!");
+        throwOCKException(env, 0,
+                          "Input is NULL from GetPrimitiveArrayCritical!");
         return retOutBytes;
     }
 
@@ -55,7 +56,8 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_CIPHER_1KeyWraporUnwrap(
     if (NULL == KEKNative) {
         (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative,
                                               JNI_ABORT);
-        throwOCKException(env, 0, "KEK is NULL from GetPrimitiveArrayCritical!");
+        throwOCKException(env, 0,
+                          "KEK is NULL from GetPrimitiveArrayCritical!");
         return retOutBytes;
     }
 
@@ -82,8 +84,9 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_CIPHER_1KeyWraporUnwrap(
                     (unsigned char *)((*env)->GetPrimitiveArrayCritical(
                         env, outBytes, &isCopy));
                 if (outBytesNative == NULL) {
-                    throwOCKException(env, 0,
-                                      "Output is NULL from GetPrimitiveArrayCritical");
+                    throwOCKException(
+                        env, 0,
+                        "Output is NULL from GetPrimitiveArrayCritical");
                 } else {
                     memcpy(outBytesNative, outputLocal, outputlen);
                     retOutBytes = outBytes;

--- a/src/main/native/CCM.c
+++ b/src/main/native/CCM.c
@@ -145,8 +145,7 @@ void handleIV_CCM(int ivLength, int keyLen, int blockSize, int J0Offset,
         }
 
         // Appending IV.length
-        putLongtoByteArray_CCM(ivLengthOG * 8, (char*)&lastIV,
-                               lastIVLen - 8);
+        putLongtoByteArray_CCM(ivLengthOG * 8, (char*)&lastIV, lastIVLen - 8);
         z_kimd_native_CCM((signed char*)&lastIV, lastIVLen, 0,
                           (signed char*)&ghashParamBlock, 65);
 

--- a/src/main/native/GCM.c
+++ b/src/main/native/GCM.c
@@ -963,8 +963,7 @@ void handleIV(int ivLength, int keyLen, int blockSize, int J0Offset, char* iv,
         }
 
         // Appending IV.length
-        putLongtoByteArray(ivLengthOG * 8, (char*)&lastIV,
-                           lastIVLen - 8);
+        putLongtoByteArray(ivLengthOG * 8, (char*)&lastIV, lastIVLen - 8);
         z_kimd_native((signed char*)&lastIV, lastIVLen, 0,
                       (signed char*)&ghashParamBlock, 65);
 
@@ -1693,8 +1692,8 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_create_1GCM_1context(
             gslogMessage("ICC_AES_GCM_CTX_new failed to create a new context.");
         }
 #endif
-        throwOCKException(env, 0,
-                          "ICC_AES_GCM_CTX_new failed to create a new context.");
+        throwOCKException(
+            env, 0, "ICC_AES_GCM_CTX_new failed to create a new context.");
     }
     if (debug) {
         gslogFunctionExit(functionName);

--- a/src/main/native/KEM.c
+++ b/src/main/native/KEM.c
@@ -28,15 +28,14 @@ JNIEXPORT void JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeInterface_KEM_1encapsulate(
     JNIEnv *env, jclass thisObj, jlong ockContextId, jlong ockPKeyId,
     jbyteArray wrappedKey, jbyteArray randomKey) {
+    ICC_CTX          *ockCtx          = (ICC_CTX *)((intptr_t)ockContextId);
+    ICC_EVP_PKEY_CTX *evp_pk          = NULL;
+    ICC_EVP_PKEY     *pa              = (ICC_EVP_PKEY *)((intptr_t)ockPKeyId);
+    size_t            wrappedkeylen   = 0;
+    size_t            genkeylen       = 0;
+    unsigned char    *wrappedKeyLocal = NULL;
+    unsigned char    *genkeylocal     = NULL;
 
-    ICC_CTX          *ockCtx           = (ICC_CTX *)((intptr_t)ockContextId);
-    ICC_EVP_PKEY_CTX *evp_pk           = NULL;
-    ICC_EVP_PKEY     *pa               = (ICC_EVP_PKEY *)((intptr_t)ockPKeyId);
-    size_t            wrappedkeylen    = 0;
-    size_t            genkeylen        = 0;
-    unsigned char    *wrappedKeyLocal  = NULL;
-    unsigned char    *genkeylocal      = NULL;
- 
     evp_pk = ICC_EVP_PKEY_CTX_new_from_pkey(ockCtx, NULL, pa, NULL);
     if (!evp_pk) {
         throwOCKException(env, 0, "ICC_EVP_PKEY_CTX_new_from_pkey failed");
@@ -117,19 +116,18 @@ JNIEXPORT jbyteArray JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeInterface_KEM_1decapsulate(
     JNIEnv *env, jclass thisObj, jlong ockContextId, jlong ockPKeyId,
     jbyteArray wrappedKey) {
-
-    ICC_CTX                 *ockCtx    = (ICC_CTX *)((intptr_t)ockContextId);
-    ICC_EVP_PKEY            *ockPKey   = (ICC_EVP_PKEY *)((intptr_t)ockPKeyId);
-    ICC_EVP_PKEY_CTX        *evp_pk    = NULL;
-    int                      rc        = -1;
-    jboolean                 isCopy    = 0;
-    jbyteArray               randomKey = NULL;
-    jbyteArray               retRndKeyBytes   = NULL;
-    size_t                   wrappedkeylen    = 0;
-    size_t                   genkeylen        = 0;
-    unsigned char           *wrappedKeyNative = NULL;
-    unsigned char           *genkeylocal      = NULL;
-    unsigned char           *genKeyNative     = NULL;
+    ICC_CTX          *ockCtx           = (ICC_CTX *)((intptr_t)ockContextId);
+    ICC_EVP_PKEY     *ockPKey          = (ICC_EVP_PKEY *)((intptr_t)ockPKeyId);
+    ICC_EVP_PKEY_CTX *evp_pk           = NULL;
+    int               rc               = -1;
+    jboolean          isCopy           = 0;
+    jbyteArray        randomKey        = NULL;
+    jbyteArray        retRndKeyBytes   = NULL;
+    size_t            wrappedkeylen    = 0;
+    size_t            genkeylen        = 0;
+    unsigned char    *wrappedKeyNative = NULL;
+    unsigned char    *genkeylocal      = NULL;
+    unsigned char    *genKeyNative     = NULL;
 
     evp_pk = ICC_EVP_PKEY_CTX_new(ockCtx, ockPKey, NULL);
     if (!evp_pk) {

--- a/src/main/native/MLKey.c
+++ b/src/main/native/MLKey.c
@@ -70,8 +70,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_MLKEY_1generate(
             gslogMessage("ICC_OBJ_txt2nid failed- %s", algoChars);
         }
 #endif
-        throwOCKException(env, 0,
-                          "Key generation failed - ICC_OBJ_txt2nid");
+        throwOCKException(env, 0, "Key generation failed - ICC_OBJ_txt2nid");
         (*env)->ReleaseStringUTFChars(env, cipherName, algoChars);
         return 0;
     }
@@ -142,7 +141,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_MLKEY_1generate(
         throwOCKException(env, 0,
                           "ICC_i2d_PublicKey failure. Unable to get public key "
                           "length for encoding");
-        
+
         if (evp_sp) {
             ICC_EVP_PKEY_CTX_free(ockCtx, evp_sp);
         }
@@ -150,7 +149,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_MLKEY_1generate(
             ICC_EVP_PKEY_free(ockCtx, pa);
         }
         (*env)->ReleaseStringUTFChars(env, cipherName, algoChars);
-        
+
         return mlkeyId;
     }
 
@@ -218,7 +217,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_MLKEY_1generate(
 
     /* public */
     const unsigned char *cpp = pubdata;
-    len = publen;
+    len                      = publen;
 
     /* Reconstruct public key from encoding and type */
     npa = ICC_d2i_PublicKey(ockCtx, nid, &npa, &cpp, len);
@@ -276,7 +275,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_MLKEY_1generate(
     npa     = NULL;
 
     /* private */
-    cpp  = privData;
+    cpp = privData;
     len = privlen;
     npa = ICC_d2i_PrivateKey(ockCtx, nid, &npa, &cpp, len);
     if (!npa) {
@@ -308,7 +307,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_MLKEY_1generate(
                 gslogMessage("warning - key size mismatch %d != %d\n",
                              (int)keylen, (int)kl);
             }
-#endif        
+#endif
             if (evp_sp) {
                 ICC_EVP_PKEY_CTX_free(ockCtx, evp_sp);
             }
@@ -492,7 +491,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_MLKEY_1createPublicKey(
     }
 
     (*env)->ReleaseStringUTFChars(env, cipherName, algoChars);
-    
+
     if (keyBytesNative != NULL) {
         (*env)->ReleasePrimitiveArrayCritical(env, publicKeyBytes,
                                               keyBytesNative, JNI_ABORT);

--- a/src/main/native/SignaturePQC.c
+++ b/src/main/native/SignaturePQC.c
@@ -26,7 +26,6 @@ JNIEXPORT jbyteArray JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeInterface_PQC_1SIGNATURE_1sign(
     JNIEnv *env, jclass thisObj, jlong ockContextId, jlong ockPKeyId,
     jbyteArray data) {
-
     ICC_CTX          *ockCtx         = (ICC_CTX *)((intptr_t)ockContextId);
     ICC_EVP_PKEY     *ockPKey        = (ICC_EVP_PKEY *)((intptr_t)ockPKeyId);
     ICC_EVP_PKEY_CTX *skc            = NULL;
@@ -149,7 +148,6 @@ JNIEXPORT jboolean JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeInterface_PQC_1SIGNATURE_1verify(
     JNIEnv *env, jclass thisObj, jlong ockContextId, jlong ockPKeyId,
     jbyteArray sigBytes, jbyteArray data) {
-
     ICC_CTX          *ockCtx         = (ICC_CTX *)((intptr_t)ockContextId);
     ICC_EVP_PKEY     *ockPKey        = (ICC_EVP_PKEY *)((intptr_t)ockPKeyId);
     ICC_EVP_PKEY_CTX *evp_pk         = NULL;
@@ -179,7 +177,8 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_PQC_1SIGNATURE_1verify(
             env, data, &isCopy));
 
         if (dataNative == NULL) {
-            (*env)->ReleasePrimitiveArrayCritical(env, data, dataNative, JNI_ABORT);
+            (*env)->ReleasePrimitiveArrayCritical(env, data, dataNative,
+                                                  JNI_ABORT);
             throwOCKException(env, 0, "GetPrimitiveArrayCritical failed");
             return verified;
         }

--- a/src/main/native/Utils.c
+++ b/src/main/native/Utils.c
@@ -30,7 +30,7 @@ void com_ibm_crypto_plus_provider_initialize(void) {
 #if DEBUG
         /*if( getenv("JICC.debug") != NULL ) {*/
         debug = 1;  // FIXME;
-        /*}*/
+                    /*}*/
 #endif
         initialized = 1;
     }


### PR DESCRIPTION
This update applies the .clang-format rules to the current C code base. These updates should be whitespace only in nature.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/964

Signed-off-by: Jason Katonica <katonica@us.ibm.com>
