### PR TITLE
Whitespace only clang format changes

### DIFF
--- a/src/main/native/AESKeyWrap.c
+++ b/src/main/native/AESKeyWrap.c
@@ -45,7 +45,8 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_CIPHER_1KeyWraporUnwrap(
         env, input, &isCopy));
 
     if (NULL == inputNative) {
-        throwOCKException(env, 0, "Input is NULL from GetPrimitiveArrayCritical!");
+        throwOCKException(env, 0,
+                          "Input is NULL from GetPrimitiveArrayCritical!");
         return retOutBytes;
     }
 
@@ -55,7 +56,8 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_CIPHER_1KeyWraporUnwrap(
     if (NULL == KEKNative) {
         (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative,
                                               JNI_ABORT);
-        throwOCKException(env, 0, "KEK is NULL from GetPrimitiveArrayCritical!");
+        throwOCKException(env, 0,
+                          "KEK is NULL from GetPrimitiveArrayCritical!");
         return retOutBytes;
     }
 
@@ -82,8 +84,9 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_CIPHER_1KeyWraporUnwrap(
                     (unsigned char *)((*env)->GetPrimitiveArrayCritical(
                         env, outBytes, &isCopy));
                 if (outBytesNative == NULL) {
-                    throwOCKException(env, 0,
-                                      "Output is NULL from GetPrimitiveArrayCritical");
+                    throwOCKException(
+                        env, 0,
+                        "Output is NULL from GetPrimitiveArrayCritical");
                 } else {
                     memcpy(outBytesNative, outputLocal, outputlen);
                     retOutBytes = outBytes;

--- a/src/main/native/CCM.c
+++ b/src/main/native/CCM.c
@@ -145,8 +145,7 @@ void handleIV_CCM(int ivLength, int keyLen, int blockSize, int J0Offset,
         }
 
         // Appending IV.length
-        putLongtoByteArray_CCM(ivLengthOG * 8, (char*)&lastIV,
-                               lastIVLen - 8);
+        putLongtoByteArray_CCM(ivLengthOG * 8, (char*)&lastIV, lastIVLen - 8);
         z_kimd_native_CCM((signed char*)&lastIV, lastIVLen, 0,
                           (signed char*)&ghashParamBlock, 65);
 

--- a/src/main/native/GCM.c
+++ b/src/main/native/GCM.c
@@ -963,8 +963,7 @@ void handleIV(int ivLength, int keyLen, int blockSize, int J0Offset, char* iv,
         }
 
         // Appending IV.length
-        putLongtoByteArray(ivLengthOG * 8, (char*)&lastIV,
-                           lastIVLen - 8);
+        putLongtoByteArray(ivLengthOG * 8, (char*)&lastIV, lastIVLen - 8);
         z_kimd_native((signed char*)&lastIV, lastIVLen, 0,
                       (signed char*)&ghashParamBlock, 65);
 
@@ -1693,8 +1692,8 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_create_1GCM_1context(
             gslogMessage("ICC_AES_GCM_CTX_new failed to create a new context.");
         }
 #endif
-        throwOCKException(env, 0,
-                          "ICC_AES_GCM_CTX_new failed to create a new context.");
+        throwOCKException(
+            env, 0, "ICC_AES_GCM_CTX_new failed to create a new context.");
     }
     if (debug) {
         gslogFunctionExit(functionName);

--- a/src/main/native/Utils.c
+++ b/src/main/native/Utils.c
@@ -28,7 +28,7 @@ void com_ibm_crypto_plus_provider_initialize(void) {
 #if DEBUG
         /*if( getenv("JICC.debug") != NULL ) {*/
         debug = 1;  // FIXME;
-        /*}*/
+                    /*}*/
 #endif
         initialized = 1;
     }


### PR DESCRIPTION
This update applies the .clang-format rules to the current C code base. These updates should be whitespace only in nature.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/964

Signed-off-by: Jason Katonica <katonica@us.ibm.com>