### PR TITLE
Enforce checkstyle LeftCurly and RightCurly rules

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -27,9 +27,11 @@
             <property name="arrayInitIndent" value="8"/>
             <property name="caseIndent" value="4"/>
         </module>
+        <module name="LeftCurly"/>
         <module name="NoWhitespaceAfter"/>
         <module name="NoWhitespaceBefore"/>
         <module name="RedundantImport"/>
+        <module name="RightCurly"/>
         <module name="StringLiteralEquality"/>
         <module name="StringLiteralEquality"/>
         <module name="UnusedImports"/>

--- a/src/main/java/com/ibm/crypto/plus/provider/AESCCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESCCMCipher.java
@@ -233,8 +233,7 @@ public final class AESCCMCipher extends CipherSpi implements AESConstants, CCMCo
                 throw new ShortBufferException(
                         "The output buffer is too small to hold the encryption result.");
             }
-        } else // decrypting
-        {
+        } else { // decrypting
             if ((output.length - outputOffset) < (input.length - tagLenInBytes)) {
                 throw new ShortBufferException(
                         "The output buffer is too small to hold the decryption result.");
@@ -276,8 +275,7 @@ public final class AESCCMCipher extends CipherSpi implements AESConstants, CCMCo
 
             } else { // else decrypting
 
-                if ((input == null) || (input.length == 0)) // If this doFinal( ) carries no data to be encrypted
-                {
+                if ((input == null) || (input.length == 0)) { // If this doFinal( ) carries no data to be encrypted
                     return 0;
                 }
 
@@ -715,8 +713,7 @@ public final class AESCCMCipher extends CipherSpi implements AESConstants, CCMCo
         if (this.authData == null) {
             this.authData = new byte[src.remaining()];
             src.get(this.authData, 0, this.authData.length);
-        } else // else this.authData != null
-        {
+        } else { // else this.authData != null
             byte[] tempAuthData = new byte[this.authData.length + src.remaining()];
             System.arraycopy(this.authData, 0, tempAuthData, 0, this.authData.length);
             src.get(tempAuthData, this.authData.length, src.remaining());

--- a/src/main/java/com/ibm/crypto/plus/provider/AESGCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESGCMCipher.java
@@ -1051,8 +1051,7 @@ public final class AESGCMCipher extends CipherSpi implements AESConstants, GCMCo
                         // GCMCipher.do_GCM_UpdForUpdateDecrypt=" + outLen);
 
                         // outLen = cipher.decrypt(buffer, 0, len, output, outputOffset);
-                    } // decrypting
-                    else {
+                    } else { // decrypting
                         // OCKDebug.Msg(debPrefix, methodName, "Encrypting");
                         // OCKDebug.Msg(debPrefix, methodName, "FirstUpdate generateIV");
 
@@ -1093,8 +1092,7 @@ public final class AESGCMCipher extends CipherSpi implements AESConstants, GCMCo
                                     tagLenInBytes, buffer, 0, buffered, output, outputOffset,
                                     authData, provider);
                             // outLen = cipher.decrypt(buffer, 0, buffered, output, outputOffset);
-                        } // decrypting
-                        else {
+                        } else { // decrypting
                             outLen = GCMCipher.do_GCM_UpdForUpdateEncrypt(ockContext, Key.getValue(), IV,
                                     tagLenInBytes, buffer, 0, buffered, output, outputOffset,
                                     authData, provider);

--- a/src/main/java/com/ibm/crypto/plus/provider/CCMParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/CCMParameters.java
@@ -111,8 +111,7 @@ public final class CCMParameters extends AlgorithmParametersSpi
                 if (value.getData().available() != 0) {
                     throw new IOException("CCM parameter parsing error:  Extra data is present.");
                 }
-            } else // else no tag length present
-            {
+            } else { // else no tag length present
                 throw new InvalidParameterException(
                         "CCM parameters parsing error:  No tag length is present.");
             }

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeCipher.java
@@ -265,9 +265,7 @@ public final class DESedeCipher extends CipherSpi implements DESConstants {
                                                                          * modeUpperCase.equals("CFB")
                                                                          */) {
             this.mode = modeUpperCase;
-        } /*
-             * else if (modeUpperCase.equals("CFB64")) { this.mode = "CFB"; }
-             */ else {
+        } else {
             throw new NoSuchAlgorithmException("Cipher mode: " + mode + " not found");
         }
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
@@ -112,7 +112,7 @@ final class DHPrivateKey extends PKCS8Key implements javax.crypto.interfaces.DHP
                 id.putDerValue(new DerValue(dhKey.getParameters()));
                 DerValue value = new DerValue(DerValue.tag_Sequence, id.toByteArray());
                 this.algid = AlgorithmId.parse(value);
-            };
+            }
 
             convertOCKPrivateKeyBytes(dhKey.getPrivateKeyBytes());
             this.dhKey = dhKey;

--- a/src/main/java/com/ibm/crypto/plus/provider/PBEKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PBEKey.java
@@ -140,8 +140,7 @@ final class PBEKey implements SecretKey {
      * @throws ClassNotFoundException if a serialized class cannot be loaded
      */
     private void readObject(java.io.ObjectInputStream s)
-         throws IOException, ClassNotFoundException
-    {
+         throws IOException, ClassNotFoundException {
         s.defaultReadObject();
         if (key == null) {
             throw new InvalidObjectException(

--- a/src/main/java/com/ibm/crypto/plus/provider/PBEKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PBEKeyFactory.java
@@ -105,8 +105,7 @@ abstract class PBEKeyFactory extends SecretKeyFactorySpi {
      * is inappropriate for this key factory to produce a public key.
      */
     protected SecretKey engineGenerateSecret(KeySpec keySpec)
-        throws InvalidKeySpecException
-    {
+        throws InvalidKeySpecException {
         if (!(keySpec instanceof PBEKeySpec)) {
             throw new InvalidKeySpecException("Invalid key spec");
         }
@@ -166,8 +165,7 @@ abstract class PBEKeyFactory extends SecretKeyFactorySpi {
      * this key factory.
      */
     protected SecretKey engineTranslateKey(SecretKey key)
-        throws InvalidKeyException
-    {
+        throws InvalidKeyException {
         try {
             if ((key != null) && (key.getFormat() != null) && (key.getFormat().equalsIgnoreCase("RAW"))) {
 

--- a/src/main/java/com/ibm/crypto/plus/provider/PBES2Parameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PBES2Parameters.java
@@ -179,8 +179,7 @@ abstract class PBES2Parameters extends AlgorithmParametersSpi {
     }
 
     protected void engineInit(AlgorithmParameterSpec paramSpec)
-        throws InvalidParameterSpecException
-    {
+        throws InvalidParameterSpecException {
         if (!(paramSpec instanceof PBEParameterSpec)) {
             throw new InvalidParameterSpecException ("Inappropriate parameter specification");
         }
@@ -190,8 +189,7 @@ abstract class PBES2Parameters extends AlgorithmParametersSpi {
     }
 
     protected void engineInit(byte[] encoded)
-        throws IOException
-    {
+        throws IOException {
         DerValue pBES2_params = new DerValue(encoded);
         if (pBES2_params.tag != DerValue.tag_Sequence) {
             throw new IOException("PBE parameter parsing error: "
@@ -318,15 +316,13 @@ abstract class PBES2Parameters extends AlgorithmParametersSpi {
     }
 
     protected void engineInit(byte[] encoded, String decodingMethod)
-        throws IOException
-    {
+        throws IOException {
         engineInit(encoded);
     }
 
     protected <T extends AlgorithmParameterSpec>
             T engineGetParameterSpec(Class<T> paramSpec)
-        throws InvalidParameterSpecException
-    {
+        throws InvalidParameterSpecException {
         if (paramSpec.isAssignableFrom(PBEParameterSpec.class)) {
             return paramSpec.cast(
                 new PBEParameterSpec(this.salt, this.iCount, this.cipherParam));
@@ -379,8 +375,7 @@ abstract class PBES2Parameters extends AlgorithmParametersSpi {
     }
 
     protected byte[] engineGetEncoded(String encodingMethod)
-        throws IOException
-    {
+        throws IOException {
         return engineGetEncoded();
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPSSSignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPSSSignature.java
@@ -381,17 +381,13 @@ public final class RSAPSSSignature extends SignatureSpi {
                             || mgfMessageDigest.equalsIgnoreCase("SHA")) {
                         throwException = false;
                     }
-                }
-
-                else if (messageDigest.equalsIgnoreCase("SHA224")
+                } else if (messageDigest.equalsIgnoreCase("SHA224")
                         || messageDigest.equalsIgnoreCase("SHA-224")) {
                     if (mgfMessageDigest.equalsIgnoreCase("SHA224")
                             || mgfMessageDigest.equalsIgnoreCase("SHA-224")) {
                         throwException = false;
                     }
-                }
-
-                else if (messageDigest.equalsIgnoreCase("SHA256")
+                } else if (messageDigest.equalsIgnoreCase("SHA256")
                         || messageDigest.equalsIgnoreCase("SHA-256")
                         || messageDigest.equalsIgnoreCase("SHA2")) {
                     if (mgfMessageDigest.equalsIgnoreCase("SHA256")
@@ -399,9 +395,7 @@ public final class RSAPSSSignature extends SignatureSpi {
                             || mgfMessageDigest.equalsIgnoreCase("SHA2")) {
                         throwException = false;
                     }
-                }
-
-                else if (messageDigest.equalsIgnoreCase("SHA384")
+                } else if (messageDigest.equalsIgnoreCase("SHA384")
                         || messageDigest.equalsIgnoreCase("SHA-384")
                         || messageDigest.equalsIgnoreCase("SHA3")) {
                     if (mgfMessageDigest.equalsIgnoreCase("SHA384")
@@ -409,9 +403,7 @@ public final class RSAPSSSignature extends SignatureSpi {
                             || mgfMessageDigest.equalsIgnoreCase("SHA3")) {
                         throwException = false;
                     }
-                }
-
-                else if (messageDigest.equalsIgnoreCase("SHA512")
+                } else if (messageDigest.equalsIgnoreCase("SHA512")
                         || messageDigest.equalsIgnoreCase("SHA-512")
                         || messageDigest.equalsIgnoreCase("SHA5")) {
                     if (mgfMessageDigest.equalsIgnoreCase("SHA512")
@@ -419,9 +411,7 @@ public final class RSAPSSSignature extends SignatureSpi {
                             || mgfMessageDigest.equalsIgnoreCase("SHA5")) {
                         throwException = false;
                     }
-                }
-
-                else if (messageDigest.equalsIgnoreCase("SHA512/224")
+                } else if (messageDigest.equalsIgnoreCase("SHA512/224")
                         || messageDigest.equalsIgnoreCase("SHA-512/224")) {
                     if (mgfMessageDigest.equalsIgnoreCase("SHA512/224")
                             || mgfMessageDigest.equalsIgnoreCase("SHA-512/224")) {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAES.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAES.java
@@ -781,9 +781,7 @@ public class BaseTestAES extends BaseTestCipher {
     // Run encrypt/decrypt test using just doFinal calls
     //
     protected void encryptDecryptDoFinal(String algorithm, boolean requireLengthMultipleBlockSize,
-            AlgorithmParameters algParams, byte[] message, Cipher cp) throws Exception
-
-    {
+            AlgorithmParameters algParams, byte[] message, Cipher cp) throws Exception {
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);
         } else {
@@ -914,9 +912,7 @@ public class BaseTestAES extends BaseTestCipher {
     //
     protected void encryptDecryptReuseObject(String algorithm,
             boolean requireLengthMultipleBlockSize, AlgorithmParameters algParams, byte[] message, Cipher cp)
-            throws Exception
-
-    {
+            throws Exception {
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);
         } else {
@@ -960,9 +956,7 @@ public class BaseTestAES extends BaseTestCipher {
     //
     protected void encryptDecryptDoFinalCopySafe(String algorithm,
             boolean requireLengthMultipleBlockSize, AlgorithmParameters algParams, byte[] message, Cipher cp)
-            throws Exception
-
-    {
+            throws Exception {
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);
         } else {
@@ -1007,9 +1001,7 @@ public class BaseTestAES extends BaseTestCipher {
     //
     protected void encryptDecryptUpdateCopySafe(String algorithm,
             boolean requireLengthMultipleBlockSize, AlgorithmParameters algParams, byte[] message, Cipher cp)
-            throws Exception
-
-    {
+            throws Exception {
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);
         } else {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCM.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCM.java
@@ -201,12 +201,12 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println(toHexString(cipherText));
                 }
-            } else // else cipherText == null
-            {
-                if (printJunitTrace)
+            } else { // else cipherText == null
+                if (printJunitTrace) {
                     System.out.println(
                             "BaseTestAESCCM.java:  testAESCCM():   ERROR:  The encrypted text is NULL.    Iteration counter = "
                                     + iterationCounter);
+                }
                 RuntimeException rtex = new RuntimeException();
                 rtex.printStackTrace(System.out);
                 Assertions.fail();
@@ -370,9 +370,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                 // All the encryption was performed on Cipher.doFinal( )
                 cipherText = new byte[cipherText2.length];
                 System.arraycopy(cipherText2, 0, cipherText, 0, cipherText2.length);
-            }
-
-            else if (whichMethod == 1) {
+            } else if (whichMethod == 1) {
                 if (printJunitTrace)
                     System.out.println("BaseTestAESCCM.java:  encrypt():  METHOD CHOSEN = 1");
 
@@ -393,9 +391,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                 // All the encryption was performed on Cipher.doFinal( )
                 cipherText = new byte[cipherText2.length];
                 System.arraycopy(cipherText2, 0, cipherText, 0, cipherText2.length);
-            }
-
-            else if (whichMethod == 2) {
+            } else if (whichMethod == 2) {
                 if (printJunitTrace)
                     System.out.println("BaseTestAESCCM.java:  encrypt():  METHOD CHOSEN = 2");
                 int outputSizeNeeded = cipher.getOutputSize(plaintext.length);
@@ -434,9 +430,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                 // All the encryption was performed on Cipher.doFinal( )
                 cipherText = new byte[cipherText2.length];
                 System.arraycopy(cipherText2, 0, cipherText, 0, cipherText2.length);
-            }
-
-            else if (whichMethod == 3) {
+            } else if (whichMethod == 3) {
                 if (printJunitTrace)
                     System.out.println("BaseTestAESCCM.java:  encrypt():  METHOD CHOSEN = 3");
                 int outputSizeNeeded = cipher.getOutputSize(plaintext.length);
@@ -476,9 +470,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                 // All the encryption was performed on Cipher.doFinal( )
                 cipherText = new byte[cipherText2.length];
                 System.arraycopy(cipherText2, 0, cipherText, 0, cipherText2.length);
-            }
-
-            else if (whichMethod == 4) {
+            } else if (whichMethod == 4) {
                 if (printJunitTrace)
                     System.out.println("BaseTestAESCCM.java:  encrypt():  METHOD CHOSEN = 4");
 
@@ -629,9 +621,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                 // All the decryption was performed on Cipher.doFinal( )
                 decryptedText = new byte[decryptedText2.length];
                 System.arraycopy(decryptedText2, 0, decryptedText, 0, decryptedText2.length);
-            }
-
-            else if (whichMethod == 1) {
+            } else if (whichMethod == 1) {
                 if (printJunitTrace)
                     System.out.println("BaseTestAESCCM.java:  decrypt():  METHOD CHOSEN = 1");
 
@@ -654,9 +644,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                 decryptedText = new byte[decryptedText2.length];
                 System.arraycopy(decryptedText2, 0, decryptedText, 0, decryptedText2.length);
 
-            }
-
-            else if (whichMethod == 2) {
+            } else if (whichMethod == 2) {
                 if (printJunitTrace)
                     System.out.println("BaseTestAESCCM.java:  decrypt():  METHOD CHOSEN = 2");
                 int outputSizeNeeded = cipher.getOutputSize(cipherText.length);
@@ -695,9 +683,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                 // All the decryption was performed on Cipher.doFinal( )
                 decryptedText = new byte[decryptedText2.length];
                 System.arraycopy(decryptedText2, 0, decryptedText, 0, decryptedText2.length);
-            }
-
-            else if (whichMethod == 3) {
+            } else if (whichMethod == 3) {
                 if (printJunitTrace)
                     System.out.println("BaseTestAESCCM.java:  decrypt():  METHOD CHOSEN = 3");
                 int outputSizeNeeded = cipher.getOutputSize(cipherText.length);
@@ -736,9 +722,7 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                 // All the decryption was performed on Cipher.doFinal( )
                 decryptedText = new byte[decryptedText2.length];
                 System.arraycopy(decryptedText2, 0, decryptedText, 0, decryptedText2.length);
-            }
-
-            else if (whichMethod == 4) {
+            } else if (whichMethod == 4) {
                 if (printJunitTrace)
                     System.out.println("BaseTestAESCCM.java:  decrypt():  METHOD CHOSEN = 4");
                 int outputSizeNeeded = cipher.getOutputSize(cipherText.length);
@@ -780,7 +764,6 @@ public class BaseTestAESCCM extends BaseTestJunit5 {
                 decryptedText = new byte[decryptedText2.length];
                 System.arraycopy(decryptedText2, 0, decryptedText, 0, decryptedText2.length);
             }
-
         } catch (AEADBadTagException abte) {
             if (printJunitTrace)
                 System.out.println(

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCM2.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCM2.java
@@ -202,8 +202,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                     if (printJunitTrace)
                         System.out.println(toHexString(cipherText));
                 }
-            } else // else cipherText == null
-            {
+            } else { // else cipherText == null
                 if (printJunitTrace)
                     System.out.println(
                             "BaseTestAESCCM2.java:  testAESCCM():  ERROR:  The encrypted text is NULL.    Iteration counter = "
@@ -387,9 +386,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                 // All the encryption was performed on Cipher.doFinal( )
                 cipherText = new byte[cipherText2.length];
                 System.arraycopy(cipherText2, 0, cipherText, 0, cipherText2.length);
-            }
-
-            else if (whichMethod == 1) {
+            } else if (whichMethod == 1) {
                 if (printJunitTrace)
                     System.out.println("BaseTestAESCCM2.java:  encrypt():  METHOD CHOSEN = 1");
 
@@ -410,9 +407,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                 // All the encryption was performed on Cipher.doFinal( )
                 cipherText = new byte[cipherText2.length];
                 System.arraycopy(cipherText2, 0, cipherText, 0, cipherText2.length);
-            }
-
-            else if (whichMethod == 2) {
+            } else if (whichMethod == 2) {
                 if (printJunitTrace)
                     System.out.println("BaseTestAESCCM2.java:  encrypt():  METHOD CHOSEN = 2");
                 int outputSizeNeeded = cipher.getOutputSize(plaintext.length);
@@ -451,9 +446,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                 // All the encryption was performed on Cipher.doFinal( )
                 cipherText = new byte[cipherText2.length];
                 System.arraycopy(cipherText2, 0, cipherText, 0, cipherText2.length);
-            }
-
-            else if (whichMethod == 3) {
+            } else if (whichMethod == 3) {
                 if (printJunitTrace)
                     System.out.println("BaseTestAESCCM2.java:  encrypt():  METHOD CHOSEN = 3");
                 int outputSizeNeeded = cipher.getOutputSize(plaintext.length);
@@ -493,9 +486,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                 // All the encryption was performed on Cipher.doFinal( )
                 cipherText = new byte[cipherText2.length];
                 System.arraycopy(cipherText2, 0, cipherText, 0, cipherText2.length);
-            }
-
-            else if (whichMethod == 4) {
+            } else if (whichMethod == 4) {
                 if (printJunitTrace)
                     System.out.println("BaseTestAESCCM2.java:  encrypt():  METHOD CHOSEN = 4");
 
@@ -661,9 +652,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                 // All the decryption was performed on Cipher.doFinal( )
                 decryptedText = new byte[decryptedText2.length];
                 System.arraycopy(decryptedText2, 0, decryptedText, 0, decryptedText2.length);
-            }
-
-            else if (whichMethod == 1) {
+            } else if (whichMethod == 1) {
                 if (printJunitTrace)
                     System.out.println("BaseTestAESCCM2.java:  decrypt():  METHOD CHOSEN = 1");
 
@@ -686,9 +675,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                 decryptedText = new byte[decryptedText2.length];
                 System.arraycopy(decryptedText2, 0, decryptedText, 0, decryptedText2.length);
 
-            }
-
-            else if (whichMethod == 2) {
+            } else if (whichMethod == 2) {
                 if (printJunitTrace)
                     System.out.println("BaseTestAESCCM2.java:  decrypt():  METHOD CHOSEN = 2");
                 int outputSizeNeeded = cipher.getOutputSize(cipherText.length);
@@ -727,9 +714,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                 // All the decryption was performed on Cipher.doFinal( )
                 decryptedText = new byte[decryptedText2.length];
                 System.arraycopy(decryptedText2, 0, decryptedText, 0, decryptedText2.length);
-            }
-
-            else if (whichMethod == 3) {
+            } else if (whichMethod == 3) {
                 if (printJunitTrace)
                     System.out.println("BaseTestAESCCM2.java:  decrypt():  METHOD CHOSEN = 3");
                 int outputSizeNeeded = cipher.getOutputSize(cipherText.length);
@@ -768,9 +753,7 @@ public class BaseTestAESCCM2 extends BaseTestJunit5 {
                 // All the decryption was performed on Cipher.doFinal( )
                 decryptedText = new byte[decryptedText2.length];
                 System.arraycopy(decryptedText2, 0, decryptedText, 0, decryptedText2.length);
-            }
-
-            else if (whichMethod == 4) {
+            } else if (whichMethod == 4) {
                 if (printJunitTrace)
                     System.out.println("BaseTestAESCCM2.java:  decrypt():  METHOD CHOSEN = 4");
                 int outputSizeNeeded = cipher.getOutputSize(cipherText.length);

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCMInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCMInteropBC.java
@@ -77,20 +77,19 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
             if (whichEncryptionProvider == 0) {
                 encryptionProvider = getProviderName();
                 decryptionProvider = getInteropProviderName();
-            } else // else whichEncryptionProvider == 1
-            {
+            } else { // else whichEncryptionProvider == 1
                 encryptionProvider = getInteropProviderName();
                 decryptionProvider = getProviderName();
             }
 
-            if (printJunitTrace)
+            if (printJunitTrace) {
                 System.out.println(
                         "BaseTestInteropBC.java:  testAESCCM():  The encryption provider is:  "
                                 + encryptionProvider);
-            if (printJunitTrace)
                 System.out.println(
                         "BaseTestInteropBC.java:  testAESCCM():  The decryption provider is:  "
                                 + decryptionProvider);
+            }
 
 
             // Select which plainText string to encrypt/decrypt.
@@ -226,8 +225,7 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                     if (printJunitTrace)
                         System.out.println(toHexString(cipherText));
                 }
-            } else // else cipherText == null
-            {
+            } else { // else cipherText == null
                 if (printJunitTrace)
                     System.out.println(
                             "BaseTestInteropBC.java:  testAESCCM():   ERROR:  The encrypted text is NULL.    Iteration counter = "
@@ -386,9 +384,7 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                     // All the encryption was performed on Cipher.doFinal( )
                     cipherText = new byte[cipherText2.length];
                     System.arraycopy(cipherText2, 0, cipherText, 0, cipherText2.length);
-                }
-
-                else if (whichMethod == 1) {
+                } else if (whichMethod == 1) {
                     if (printJunitTrace)
                         System.out
                                 .println("BaseTestInteropBC.java:  encrypt():  METHOD CHOSEN = 1");
@@ -398,9 +394,7 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                     // All the encryption was performed on Cipher.doFinal( )
                     cipherText = new byte[cipherText2.length];
                     System.arraycopy(cipherText2, 0, cipherText, 0, cipherText2.length);
-                }
-
-                else if (whichMethod == 2) {
+                } else if (whichMethod == 2) {
                     if (printJunitTrace)
                         System.out
                                 .println("BaseTestInteropBC.java:  encrypt():  METHOD CHOSEN = 2");
@@ -427,9 +421,7 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                     // All the encryption was performed on Cipher.doFinal( )
                     cipherText = new byte[cipherText2.length];
                     System.arraycopy(cipherText2, 0, cipherText, 0, cipherText2.length);
-                }
-
-                else if (whichMethod == 3) {
+                } else if (whichMethod == 3) {
                     if (printJunitTrace)
                         System.out
                                 .println("BaseTestInteropBC.java:  encrypt():  METHOD CHOSEN = 3");
@@ -456,9 +448,7 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                     // All the encryption was performed on Cipher.doFinal( )
                     cipherText = new byte[cipherText2.length];
                     System.arraycopy(cipherText2, 0, cipherText, 0, cipherText2.length);
-                }
-
-                else if (whichMethod == 4) {
+                } else if (whichMethod == 4) {
                     if (printJunitTrace)
                         System.out
                                 .println("BaseTestInteropBC.java:  encrypt():  METHOD CHOSEN = 4");
@@ -516,15 +506,14 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
 
             return cipherText;
 
-        } else // else if the encryption provider is "BC".
-        {
+        } else { // else if the encryption provider is "BC".
             // AES/CCM for BouncyCastle is a proprietary cipher implementation that
             // is dissimilar to cipher implementations developed by Oracle or IBM.
 
-            if (printJunitTrace)
+            if (printJunitTrace) {
                 System.out.println("\nThe plain text to be encoded is:");
-            if (printJunitTrace)
                 System.out.println(toHexString(plaintext));
+            }
 
             org.bouncycastle.crypto.MultiBlockCipher engine = org.bouncycastle.crypto.engines.AESEngine.newInstance();
             org.bouncycastle.crypto.params.AEADParameters params = new org.bouncycastle.crypto.params.AEADParameters(
@@ -640,9 +629,7 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                     // All the decryption was performed on Cipher.doFinal( )
                     decryptedText = new byte[decryptedText2.length];
                     System.arraycopy(decryptedText2, 0, decryptedText, 0, decryptedText2.length);
-                }
-
-                else if (whichMethod == 1) {
+                } else if (whichMethod == 1) {
                     if (printJunitTrace)
                         System.out
                                 .println("BaseTestInteropBC.java:  decrypt():  METHOD CHOSEN = 1");
@@ -654,9 +641,7 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                     // All the decryption was performed on Cipher.doFinal( )
                     decryptedText = new byte[decryptedText2.length];
                     System.arraycopy(decryptedText2, 0, decryptedText, 0, decryptedText2.length);
-                }
-
-                else if (whichMethod == 2) {
+                } else if (whichMethod == 2) {
                     if (printJunitTrace)
                         System.out
                                 .println("BaseTestInteropBC.java:  decrypt():  METHOD CHOSEN = 2");
@@ -683,12 +668,10 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                     // All the decryption was performed on Cipher.doFinal( )
                     decryptedText = new byte[decryptedText2.length];
                     System.arraycopy(decryptedText2, 0, decryptedText, 0, decryptedText2.length);
-                }
-
-                else if (whichMethod == 3) {
-                    if (printJunitTrace)
-                        System.out
-                                .println("BaseTestInteropBC.java:  decrypt():  METHOD CHOSEN = 3");
+                } else if (whichMethod == 3) {
+                    if (printJunitTrace) {
+                        System.out.println("BaseTestInteropBC.java:  decrypt():  METHOD CHOSEN = 3");
+                    }
                     int outputSizeNeeded = cipher.getOutputSize(cipherText.length);
                     if (printJunitTrace)
                         System.out.println(
@@ -712,9 +695,7 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
                     // All the decryption was performed on Cipher.doFinal( )
                     decryptedText = new byte[decryptedText2.length];
                     System.arraycopy(decryptedText2, 0, decryptedText, 0, decryptedText2.length);
-                }
-
-                else if (whichMethod == 4) {
+                } else if (whichMethod == 4) {
                     if (printJunitTrace)
                         System.out
                                 .println("BaseTestInteropBC.java:  decrypt():  METHOD CHOSEN = 4");
@@ -774,8 +755,7 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
 
             return new String(decryptedText);
 
-        } else // else if the decryption provider is "BC".
-        {
+        } else { // else if the decryption provider is "BC".
             // AES/CCM for BouncyCastle is a proprietary cipher implementation that
             // is dissimilar to cipher implementations developed by Oracle or IBM.
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESCipherInputStreamExceptions.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESCipherInputStreamExceptions.java
@@ -249,7 +249,7 @@ public class BaseTestAESCipherInputStreamExceptions extends BaseTestJunit5 {
             fail("IOException expected.");
         } catch (IOException e) {
             // We expect a IOException.
-        };
+        }
     }
 
     /**

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCM.java
@@ -865,9 +865,7 @@ public class BaseTestAESGCM extends BaseTestJunit5 {
     // Run encrypt/decrypt test using just doFinal calls
     //
     protected void encryptDecryptDoFinal(String algorithm, boolean requireLengthMultipleBlockSize,
-            AlgorithmParameters algParams, byte[] message) throws Exception
-
-    {
+            AlgorithmParameters algParams, byte[] message) throws Exception {
         Cipher cp = Cipher.getInstance(algorithm, getProviderName());
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESGCMUpdate.java
@@ -271,9 +271,7 @@ public class BaseTestAESGCMUpdate extends BaseTestJunit5 {
                     //System.out.println ("decryptedText = " + decryptedText);
 
                     assertTrue(Arrays.equals(decryptedText, plainTextBytes));
-                }
-
-                catch (ShortBufferException sxe) {
+                } catch (ShortBufferException sxe) {
                     assertTrue(true);
                 } catch (Exception ex) {
                     ex.printStackTrace();
@@ -409,12 +407,9 @@ public class BaseTestAESGCMUpdate extends BaseTestJunit5 {
             } catch (IllegalStateException ex) {
                 //ex.printStackTrace();
                 assertTrue(true);
-            }
-
-            catch (Exception ex) {
+            } catch (Exception ex) {
                 ex.printStackTrace();
                 assertTrue(false);
-
             }
 
             try {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESInterop.java
@@ -618,9 +618,7 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
     //
     protected void encryptDecryptDoFinal(String algorithm, boolean requireLengthMultipleBlockSize,
             AlgorithmParameters algParams, byte[] message, Cipher cpA, Cipher cpB)
-            throws Exception
-
-    {
+            throws Exception {
         if (algParams == null) {
             cpA.init(Cipher.ENCRYPT_MODE, key);
         } else {
@@ -774,9 +772,7 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
     //
     protected void encryptDecryptReuseObject(String algorithm,
             boolean requireLengthMultipleBlockSize, AlgorithmParameters algParams, byte[] message,
-            Cipher cpA, Cipher cpB) throws Exception
-
-    {
+            Cipher cpA, Cipher cpB) throws Exception {
 
         if (algParams == null) {
             cpA.init(Cipher.ENCRYPT_MODE, key);
@@ -821,9 +817,7 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
     //
     protected void encryptDecryptDoFinalCopySafe(String algorithm,
             boolean requireLengthMultipleBlockSize, AlgorithmParameters algParams, byte[] message,
-            Cipher cpA, Cipher cpB) throws Exception
-
-    {
+            Cipher cpA, Cipher cpB) throws Exception {
         if (algParams == null) {
             cpA.init(Cipher.ENCRYPT_MODE, key);
         } else {
@@ -867,9 +861,7 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
     //
     protected void encryptDecryptUpdateCopySafe(String algorithm,
             boolean requireLengthMultipleBlockSize, AlgorithmParameters algParams, byte[] message,
-            Cipher cpA, Cipher cpB) throws Exception
-
-    {
+            Cipher cpA, Cipher cpB) throws Exception {
         if (algParams == null) {
             cpA.init(Cipher.ENCRYPT_MODE, key);
         } else {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDESede.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDESede.java
@@ -1088,9 +1088,7 @@ public class BaseTestDESede extends BaseTestCipher {
     }
 
     protected void encryptDecryptDoFinal(String algorithm, boolean requireLengthMultipleBlockSize,
-            AlgorithmParameters algParams, byte[] message) throws Exception
-
-    {
+            AlgorithmParameters algParams, byte[] message) throws Exception {
         if (isTransformationValidButUnsupported(algorithm)) {
             return;
         }
@@ -1244,9 +1242,7 @@ public class BaseTestDESede extends BaseTestCipher {
     //
     protected void encryptDecryptReuseObject(String algorithm,
             boolean requireLengthMultipleBlockSize, AlgorithmParameters algParams, byte[] message)
-            throws Exception
-
-    {
+            throws Exception {
         if (isTransformationValidButUnsupported(algorithm)) {
             return;
         }
@@ -1300,9 +1296,7 @@ public class BaseTestDESede extends BaseTestCipher {
     //
     protected void encryptDecryptDoFinalCopySafe(String algorithm,
             boolean requireLengthMultipleBlockSize, AlgorithmParameters algParams, byte[] message)
-            throws Exception
-
-    {
+            throws Exception {
         if (isTransformationValidButUnsupported(algorithm)) {
             return;
         }
@@ -1355,9 +1349,7 @@ public class BaseTestDESede extends BaseTestCipher {
     //
     protected void encryptDecryptUpdateCopySafe(String algorithm,
             boolean requireLengthMultipleBlockSize, AlgorithmParameters algParams, byte[] message)
-            throws Exception
-
-    {
+            throws Exception {
         if (isTransformationValidButUnsupported(algorithm)) {
             return;
         }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDH.java
@@ -268,9 +268,7 @@ public class BaseTestDH extends BaseTestJunit5 {
             throw e;
         }
 
-        try
-
-        {
+        try {
             kpgB.initialize(algParameterSpec);
         } catch (InvalidAlgorithmParameterException e) {
             e.printStackTrace();

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDHInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDHInterop.java
@@ -114,9 +114,7 @@ public class BaseTestDHInterop extends BaseTestJunit5Interop {
             throw e;
         }
 
-        try
-
-        {
+        try {
             kpgB.initialize(algParameterSpec);
         } catch (InvalidAlgorithmParameterException e) {
             e.printStackTrace();

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDH.java
@@ -227,9 +227,7 @@ public class BaseTestECDH extends BaseTestJunit5 {
             throw e;
         }
 
-        try
-
-        {
+        try {
             kpgB.initialize(algParameterSpec);
         } catch (InvalidAlgorithmParameterException e) {
             e.printStackTrace();

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDHInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDHInterop.java
@@ -196,9 +196,7 @@ public class BaseTestECDHInterop extends BaseTestJunit5Interop {
             throw e;
         }
 
-        try
-
-        {
+        try {
             kpgB.initialize(algParameterSpec);
         } catch (InvalidAlgorithmParameterException e) {
             e.printStackTrace();

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHKDF.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHKDF.java
@@ -643,9 +643,7 @@ public class BaseTestHKDF extends BaseTestJunit5 {
             throw e;
         }
 
-        try
-
-        {
+        try {
             kpgB.initialize(algParameterSpec);
         } catch (InvalidAlgorithmParameterException e) {
             e.printStackTrace();

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHKDFInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHKDFInterop.java
@@ -498,9 +498,7 @@ public class BaseTestHKDFInterop extends BaseTestJunit5Interop {
             throw e;
         }
 
-        try
-
-        {
+        try {
             kpgB.initialize(algParameterSpec);
         } catch (InvalidAlgorithmParameterException e) {
             e.printStackTrace();

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestMiniRSAPSS2.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestMiniRSAPSS2.java
@@ -138,9 +138,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                 "================  BEGINNING OF testRSAPSS()  ================================");
 
         int ii = 0;
-        for (; ii < 1; ii++) // For each RSA key size
-        {
-
+        for (; ii < 1; ii++) { // For each RSA key size
             if (signingProviderName.equalsIgnoreCase("OpenJCEPlus")) {
                 if (ii == 0) {
                     rsaKeyPair = rsaKeyPair_OpenJCEPlus[0]; // RSA keylength 3072 
@@ -163,17 +161,14 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
 
 
 
-            for (int jj = 0; jj < 3; jj++) // For each dataToBeSigned string (differing lengths)
-            {
-
+            for (int jj = 0; jj < 3; jj++) { // For each dataToBeSigned string (differing lengths)
                 if (jj == 0) {
                     dataToBeSigned = dataToBeSignedShort;
                 } else if (jj == 1) {
                     dataToBeSigned = dataToBeSignedMedium;
                 } else if (jj == 2) {
                     dataToBeSigned = dataToBeSignedLong;
-                } else // added to make the compiler happy
-                {
+                } else { // added to make the compiler happy
                     dataToBeSigned = dataToBeSignedLong;
                 }
 
@@ -2203,8 +2198,7 @@ public class BaseTestMiniRSAPSS2 extends BaseTestJunit5 {
                         "BaseTestRSAPSS2.java:  doSignature():  NOT PERFORMING KEY TRANSLATION.  signingProviderName = verifyingProviderName");
                 // then no key translation is necessary
                 translatedPublicKey = (RSAPublicKey) (rsaKeyPair.getPublic());
-            } else // else translate the RSA public key for the verifying provider
-            {
+            } else { // else translate the RSA public key for the verifying provider
                 System.out.println(
                         "BaseTestRSAPSS2.java:  doSignature():  PERFORMING KEY TRANSLATION.  signingProviderName != verifyingProviderName");
                 KeyFactory myKeyFactory = KeyFactory.getInstance("RSA", verifyingProviderName);

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInterop.java
@@ -446,9 +446,7 @@ public class BaseTestRSAKeyInterop extends BaseTestJunit5Interop {
             verifyingJCE.initVerify(rsaPubJCE);
             verifyingJCE.update(origMsg);
             assertTrue(verifyingJCE.verify(signedBytesPlus), "Signature verification");
-        }
-
-        catch (Exception ex) {
+        } catch (Exception ex) {
             ex.printStackTrace();
             assertTrue(false, "SignAndVerify failed");
         }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInteropBC.java
@@ -466,9 +466,7 @@ public class BaseTestRSAKeyInteropBC extends BaseTestJunit5Interop {
             verifyingBC.initVerify(rsaPubBC);
             verifyingBC.update(origMsg);
             assertTrue(verifyingBC.verify(signedBytesPlus), "Signature verification");
-        }
-
-        catch (Exception ex) {
+        } catch (Exception ex) {
             ex.printStackTrace();
             assertTrue(false, "SignAndVerify failed");
         }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSS2.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSS2.java
@@ -225,8 +225,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
 
 
         //OpenJCEPlusFIPS and SunRsaSign does not support 512
-        for (int ii = 0; ii <= 5; ii++) // For each RSA key size
-        {
+        for (int ii = 0; ii <= 5; ii++) { // For each RSA key size
 
             if (signingProviderName.equalsIgnoreCase("OpenJCEPlus")) {
                 if (ii == 0) {
@@ -326,8 +325,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
 
 
 
-            for (int jj = 0; jj < 3; jj++) // For each dataToBeSigned string (differing lengths)
-            {
+            for (int jj = 0; jj < 3; jj++) { // For each dataToBeSigned string (differing lengths)
 
                 if (jj == 0) {
                     dataToBeSigned = dataToBeSignedShort;
@@ -335,8 +333,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                     dataToBeSigned = dataToBeSignedMedium;
                 } else if (jj == 2) {
                     dataToBeSigned = dataToBeSignedLong;
-                } else // added to make the compiler happy
-                {
+                } else { // added to make the compiler happy
                     dataToBeSigned = dataToBeSignedLong;
                 }
 
@@ -825,15 +822,13 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -847,8 +842,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 512
-                    {
+                    } else { // else key size > 512
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
@@ -974,15 +968,13 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -996,12 +988,12 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 512
-                    {
-                        if (printJunitTrace)
+                    } else { // else key size > 512
+                        if (printJunitTrace) {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
+                        }
                         Assertions.fail();
                     }
                 }
@@ -2586,15 +2578,13 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -2608,8 +2598,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 512
-                    {
+                    } else { // else key size > 512
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
@@ -2735,15 +2724,13 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -2757,8 +2744,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 512
-                    {
+                    } else { // else key size > 512
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
@@ -2884,15 +2870,13 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 1) //If key size <= 1024
-                    {
+                    if (ii <= 1) { //If key size <= 1024
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 1) //If key size <= 1024
-                    {
+                    if (ii <= 1) { //If key size <= 1024
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -2906,8 +2890,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 1024
-                    {
+                    } else { // else key size > 1024
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
@@ -3032,15 +3015,13 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 2) //If key size <= 2048
-                    {
+                    if (ii <= 2) { //If key size <= 2048
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 2) //If key size <= 2048
-                    {
+                    if (ii <= 2) { //If key size <= 2048
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -3054,8 +3035,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 2048
-                    {
+                    } else { // else key size > 2048
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
@@ -3860,8 +3840,7 @@ public class BaseTestRSAPSS2 extends BaseTestJunit5 {
                             "BaseTestRSAPSS2.java:  doSignature():  NOT PERFORMING KEY TRANSLATION.  signingProviderName = verifyingProviderName");
                 // then no key translation is necessary
                 translatedPublicKey = (RSAPublicKey) (rsaKeyPair.getPublic());
-            } else // else translate the RSA public key for the verifying provider
-            {
+            } else { // else translate the RSA public key for the verifying provider
                 if (printJunitTrace)
                     System.out.println(
                             "BaseTestRSAPSS2.java:  doSignature():  PERFORMING KEY TRANSLATION.  signingProviderName != verifyingProviderName");

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop2.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop2.java
@@ -227,9 +227,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
         //   testRSAPSS(ibm.jceplus.junit.openjceplus.TestRSAPSSInterop2)java.security.InvalidKeyException: java.security.SignatureException: Key is too short, need min 70 
 
         //OpenJCEPlusFIPS and SunRsaSign does not support 512
-        for (int ii = 1; ii <= 5; ii++) // For each RSA key size
-        {
-
+        for (int ii = 1; ii <= 5; ii++) { // For each RSA key size
             if (signingProviderName.equalsIgnoreCase("OpenJCEPlus")) {
                 if (ii == 0) {
                     rsaKeyPair = rsaKeyPair_OpenJCEPlus[0]; // RSA keylength 512
@@ -332,17 +330,14 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
 
 
 
-            for (int jj = 0; jj < 3; jj++) // For each dataToBeSigned string (differing lengths)
-            {
-
+            for (int jj = 0; jj < 3; jj++) { // For each dataToBeSigned string (differing lengths)
                 if (jj == 0) {
                     dataToBeSigned = dataToBeSignedShort;
                 } else if (jj == 1) {
                     dataToBeSigned = dataToBeSignedMedium;
                 } else if (jj == 2) {
                     dataToBeSigned = dataToBeSignedLong;
-                } else // added to make the compiler happy
-                {
+                } else { // added to make the compiler happy
                     dataToBeSigned = dataToBeSignedLong;
                 }
 
@@ -784,15 +779,13 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 0) //if key size <= 512
-                    {
+                    if (ii <= 0) { //if key size <= 512
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 0) //if key size <= 512
-                    {
+                    if (ii <= 0) { //if key size <= 512
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -806,8 +799,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 512
-                    {
+                    } else { // else key size > 512
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
@@ -919,15 +911,13 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 0) //if key size <= 512
-                    {
+                    if (ii <= 0) { //if key size <= 512
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 0) //if key size <= 512
-                    {
+                    if (ii <= 0) { //if key size <= 512
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -941,8 +931,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 512
-                    {
+                    } else { // else key size > 512
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
@@ -2376,15 +2365,13 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 0) //if key size <= 512
-                    {
+                    if (ii <= 0) { //if key size <= 512
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 0) //if key size <= 512
-                    {
+                    if (ii <= 0) { //if key size <= 512
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -2398,8 +2385,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 512
-                    {
+                    } else { // else key size > 512
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
@@ -2511,15 +2497,13 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 0) //if key size <= 512
-                    {
+                    if (ii <= 0) { //if key size <= 512
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 0) //if key size <= 512
-                    {
+                    if (ii <= 0) { //if key size <= 512
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -2533,8 +2517,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 512
-                    {
+                    } else { // else key size > 512
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
@@ -2646,15 +2629,13 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 1) //if key size <= 1024
-                    {
+                    if (ii <= 1) { //if key size <= 1024
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 1) //if key size <= 1024
-                    {
+                    if (ii <= 1) { //if key size <= 1024
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -2668,12 +2649,12 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 1024
-                    {
-                        if (printJunitTrace)
+                    } else { // else key size > 1024
+                        if (printJunitTrace) {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
+                        }
                         Assertions.fail();
                     }
                 }
@@ -2780,15 +2761,13 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 2) //if key size <= 2048
-                    {
+                    if (ii <= 2) { //if key size <= 2048
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 2) //if key size <= 2048
-                    {
+                    if (ii <= 2) { //if key size <= 2048
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -2802,12 +2781,12 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 2048
-                    {
-                        if (printJunitTrace)
+                    } else { // else key size > 2048
+                        if (printJunitTrace) {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
+                        }
                         Assertions.fail();
                     }
                 }
@@ -3255,15 +3234,13 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 0) //if key size <= 512
-                    {
+                    if (ii <= 0) { //if key size <= 512
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 0) //if key size <= 512
-                    {
+                    if (ii <= 0) { //if key size <= 512
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -3277,12 +3254,12 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 512
-                    {
-                        if (printJunitTrace)
+                    } else { // else key size > 512
+                        if (printJunitTrace) {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
+                        }
                         Assertions.fail();
                     }
                 }
@@ -3391,15 +3368,13 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 0) //if key size <= 512
-                    {
+                    if (ii <= 0) { //if key size <= 512
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 0) //if key size <= 512
-                    {
+                    if (ii <= 0) { //if key size <= 512
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -3413,8 +3388,7 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 512
-                    {
+                    } else { // else key size > 512
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
@@ -3485,13 +3459,13 @@ public class BaseTestRSAPSSInterop2 extends BaseTestJunit5 {
 
             // If signingProviderName == verifyingProviderName, then do not perform key translation.
             if (signingProviderName.equalsIgnoreCase(verifyingProviderName)) {
-                if (printJunitTrace)
+                if (printJunitTrace) {
                     System.out.println(
                             "BaseTestRSAPSSInterop2.java:  doSignature():  NOT PERFORMING KEY TRANSLATION.  signingProviderName = verifyingProviderName");
+                }
                 // then no key translation is necessary
                 translatedPublicKey = (RSAPublicKey) (rsaKeyPair.getPublic());
-            } else // else translate the RSA public key for the verifying provider
-            {
+            } else { // else translate the RSA public key for the verifying provider
                 if (printJunitTrace)
                     System.out.println(
                             "BaseTestRSAPSSInterop2.java:  doSignature():  PERFORMING KEY TRANSLATION.  signingProviderName != verifyingProviderName");

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop3.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAPSSInterop3.java
@@ -212,9 +212,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
             System.out.println(
                     "================  BEGINNING OF testRSAPSS()  ================================");
 
-        for (int ii = 0; ii <= 5; ii++) // For each RSA key size
-        {
-
+        for (int ii = 0; ii <= 5; ii++) { // For each RSA key size
             if (signingProviderName.equalsIgnoreCase("OpenJCEPlus")) {
                 if (ii == 0) {
                     rsaKeyPair = rsaKeyPair_OpenJCEPlus[0]; // RSA keylength 512
@@ -317,17 +315,14 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
 
 
 
-            for (int jj = 0; jj < 3; jj++) // For each dataToBeSigned string (differing lengths)
-            {
-
+            for (int jj = 0; jj < 3; jj++) { // For each dataToBeSigned string (differing lengths)
                 if (jj == 0) {
                     dataToBeSigned = dataToBeSignedShort;
                 } else if (jj == 1) {
                     dataToBeSigned = dataToBeSignedMedium;
                 } else if (jj == 2) {
                     dataToBeSigned = dataToBeSignedLong;
-                } else // added to make the compiler happy
-                {
+                } else { // added to make the compiler happy
                     dataToBeSigned = dataToBeSignedLong;
                 }
 
@@ -769,15 +764,13 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -791,8 +784,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 512
-                    {
+                    } else { // else key size > 512
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
@@ -904,15 +896,13 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -926,8 +916,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 512
-                    {
+                    } else { // else key size > 512
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
@@ -2359,15 +2348,13 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -2381,8 +2368,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 512
-                    {
+                    } else { // else key size > 512
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
@@ -2494,15 +2480,13 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -2516,8 +2500,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 512
-                    {
+                    } else { // else key size > 512
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
@@ -2629,15 +2612,13 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 1) //If key size <= 1024
-                    {
+                    if (ii <= 1) { //If key size <= 1024
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 1) //If key size <= 1024
-                    {
+                    if (ii <= 1) { //If key size <= 1024
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -2651,8 +2632,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 1024
-                    {
+                    } else { // else key size > 1024
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
@@ -2763,15 +2743,13 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 2) //If key size <= 2048
-                    {
+                    if (ii <= 2) { //If key size <= 2048
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 2) //If key size <= 2048
-                    {
+                    if (ii <= 2) { //If key size <= 2048
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -2785,8 +2763,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 2048
-                    {
+                    } else { // else key size > 2048
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
@@ -3238,15 +3215,13 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -3260,8 +3235,7 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 512
-                    {
+                    } else { // else key size > 512
                         if (printJunitTrace)
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
@@ -3374,15 +3348,13 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                         System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " = " + result);
                     // For all key sizes and data lengths
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         fail("       testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                 + " => Instead, this test should have produced an InvalidKeyException");
                     }
 
                 } catch (InvalidKeyException ex) {
-                    if (ii <= 0) //If key size <= 512
-                    {
+                    if (ii <= 0) { //If key size <= 512
                         if (ex.getMessage().indexOf("Key is too short") != -1) {
                             if (printJunitTrace)
                                 System.out.println("testRSAPSS(): TEST RESULT #"
@@ -3396,12 +3368,12 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                                         + ex.getMessage());
                             Assertions.fail();
                         }
-                    } else // else key size > 512
-                    {
-                        if (printJunitTrace)
+                    } else { // else key size > 512
+                        if (printJunitTrace) {
                             System.out.println("testRSAPSS(): TEST RESULT #" + (testCaseNumber - 1)
                                     + " => An unexpected exception was thrown with message = "
                                     + ex.getMessage());
+                        }
                         Assertions.fail();
                     }
                 }
@@ -3473,11 +3445,11 @@ public class BaseTestRSAPSSInterop3 extends BaseTestJunit5 {
                             "BaseTestRSAPSSInterop3.java:  doSignature():  NOT PERFORMING KEY TRANSLATION.  signingProviderName = verifyingProviderName");
                 // then no key translation is necessary
                 translatedPublicKey = (RSAPublicKey) (rsaKeyPair.getPublic());
-            } else // else translate the RSA public key for the verifying provider
-            {
-                if (printJunitTrace)
+            } else { // else translate the RSA public key for the verifying provider
+                if (printJunitTrace) {
                     System.out.println(
                             "BaseTestRSAPSSInterop3.java:  doSignature():  PERFORMING KEY TRANSLATION.  signingProviderName != verifyingProviderName");
+                }
                 KeyFactory myKeyFactory = KeyFactory.getInstance("RSA", verifyingProviderName);
                 translatedPublicKey = (RSAPublicKey) (myKeyFactory
                         .translateKey(rsaKeyPair.getPublic()));

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
@@ -172,9 +172,7 @@ public class BaseTestXDH extends BaseTestJunit5 {
             throw e;
         }
 
-        try
-
-        {
+        try {
             kpgB.initialize(algParameterSpec);
         } catch (InvalidAlgorithmParameterException e) {
             e.printStackTrace();

--- a/src/test/java/ibm/jceplus/junit/base/certificateutils/CertAndKeyGen.java
+++ b/src/test/java/ibm/jceplus/junit/base/certificateutils/CertAndKeyGen.java
@@ -795,9 +795,7 @@ public final class CertAndKeyGen {
     public X509Certificate dogetSelfCertificate(X500Name myname, Date firstDate, long validity,
             CertificateExtensions ext)
             throws CertificateException, InvalidKeyException, SignatureException,
-            NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException
-
-    {
+            NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
         X509CertImpl cert;
         Date lastDate;
 

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressAESGCM.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressAESGCM.java
@@ -119,9 +119,7 @@ public class BaseTestMemStressAESGCM extends BaseTestJunit5 {
     // Run encrypt/decrypt test using just doFinal calls
     //
     protected void encryptDecryptDoFinal(String algorithm, boolean requireLengthMultipleBlockSize,
-            AlgorithmParameters algParams, byte[] message) throws Exception
-
-    {
+            AlgorithmParameters algParams, byte[] message) throws Exception {
         cp = Cipher.getInstance(algorithm, getProviderName());
         if (algParams == null) {
             cp.init(Cipher.ENCRYPT_MODE, key);

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressDH.java
@@ -134,9 +134,7 @@ public class BaseTestMemStressDH extends BaseTestJunit5 {
             throw e;
         }
 
-        try
-
-        {
+        try {
             kpgB.initialize(algParameterSpec);
         } catch (InvalidAlgorithmParameterException e) {
             e.printStackTrace();

--- a/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressXDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/memstress/BaseTestMemStressXDH.java
@@ -127,9 +127,7 @@ public class BaseTestMemStressXDH extends BaseTestJunit5 {
             throw e;
         }
 
-        try
-
-        {
+        try {
             kpgB.initialize(algParameterSpec);
         } catch (InvalidAlgorithmParameterException e) {
             e.printStackTrace();


### PR DESCRIPTION
This update makes whitespace only changes to enforce curly bracket location in the code base.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/963

Signed-off-by: Jason Katonica <katonica@us.ibm.com>