### PR TITLE
Pass constructor parameters in Service initialization

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/DHParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHParameters.java
@@ -24,8 +24,6 @@ import sun.security.util.DerValue;
 public final class DHParameters extends AlgorithmParametersSpi implements java.io.Serializable {
     private static final long serialVersionUID = 7137508373627164657L;
 
-    private OpenJCEPlusProvider provider;
-
     // The prime (p)
     private BigInteger p;
 
@@ -35,9 +33,7 @@ public final class DHParameters extends AlgorithmParametersSpi implements java.i
     // The private-value length (l)
     private int l;
 
-    public DHParameters(OpenJCEPlusProvider provider) {
-        this.provider = provider;
-    }
+    public DHParameters() {}
 
     @Override
     protected void engineInit(AlgorithmParameterSpec paramSpec)
@@ -143,7 +139,7 @@ public final class DHParameters extends AlgorithmParametersSpi implements java.i
 
     @Override
     protected String engineToString() {
-        StringBuffer strbuf = new StringBuffer(provider.getName() + " Diffie-Hellman Parameters:\n"
+        StringBuffer strbuf = new StringBuffer("OpenJCEPlusProvider Diffie-Hellman Parameters:\n"
                 + "p:\n" + this.p.toString() + "\n" + "g:\n" + this.g.toString());
         if (this.l != 0)
             strbuf.append("\nl:\n" + "    " + this.l);

--- a/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
@@ -80,7 +80,7 @@ final class DHPrivateKey extends PKCS8Key implements javax.crypto.interfaces.DHP
         this.x = x;
 
         if (dhp == null) {
-            this.dhParams = new DHParameters(provider);
+            this.dhParams = new DHParameters();
             try {
                 this.dhParams.engineInit(new DHParameterSpec(p, g, l));
             } catch (InvalidParameterSpecException e) {
@@ -203,7 +203,7 @@ final class DHPrivateKey extends PKCS8Key implements javax.crypto.interfaces.DHP
             this.key = val.getData().getOctetString();
             parseKeyBits();
 
-            dhParams = new DHParameters(provider);
+            dhParams = new DHParameters();
             dhParams.engineInit((l == -1) ? new DHParameterSpec(p, g, x.bitLength())
                     : new DHParameterSpec(p, g, l));
 

--- a/src/main/java/com/ibm/crypto/plus/provider/DHPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHPublicKey.java
@@ -55,7 +55,7 @@ final class DHPublicKey extends X509Key
             int l) throws InvalidKeyException {
         this.provider = provider;
         this.y = y;
-        dhParams = new DHParameters(provider);
+        dhParams = new DHParameters();
         try {
             dhParams.engineInit(new DHParameterSpec(p, g, l));
             byte[] keyArray = new DerValue(DerValue.tag_Integer, this.y.toByteArray()).toByteArray();
@@ -204,7 +204,7 @@ final class DHPublicKey extends X509Key
                 throw new InvalidKeyException("Excess key data");
             }
 
-            dhParams = new DHParameters(provider);
+            dhParams = new DHParameters();
             dhParams.engineInit((l == -1) ? new DHParameterSpec(p, g, y.bitLength())
                     : new DHParameterSpec(p, g, l));
 

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
@@ -10,20 +10,12 @@ package com.ibm.crypto.plus.provider;
 
 import com.ibm.crypto.plus.provider.ock.OCKContext;
 import com.ibm.crypto.plus.provider.ock.OCKException;
-import java.lang.reflect.Constructor;
 import java.security.AccessController;
-import java.security.InvalidParameterException;
-import java.security.Key;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.ProviderException;
-import java.security.PublicKey;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import javax.crypto.SecretKey;
 
 @SuppressWarnings({"removal", "deprecation"})
 public final class OpenJCEPlus extends OpenJCEPlusProvider {
@@ -973,115 +965,6 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
                 "1.2.840.113549.1.1.10"};
         putService(new OpenJCEPlusService(jce, "Signature", "RSAPSS",
                 "com.ibm.crypto.plus.provider.RSAPSSSignature", aliases));
-
-    }
-
-    private static class OpenJCEPlusService extends Service {
-
-        OpenJCEPlusService(Provider provider, String type, String algorithm, String className,
-                String[] aliases) {
-            this(provider, type, algorithm, className, aliases, null);
-        }
-
-        OpenJCEPlusService(Provider provider, String type, String algorithm, String className,
-                String[] aliases, Map<String, String> attributes) {
-            super(provider, type, algorithm, className, toList(aliases), attributes);
-
-            if (debug != null) {
-                debug.println("Constructing OpenJCEPlusService: " + provider + ", " + type
-                            + ", " + algorithm + ", " + className);
-            }
-        }
-
-        private static List<String> toList(String[] aliases) {
-            return (aliases == null) ? null : Arrays.asList(aliases);
-        }
-
-        @Override
-        public Object newInstance(Object constructorParameter) throws NoSuchAlgorithmException {
-            Provider provider = getProvider();
-            String className = getClassName();
-            try {
-                Class<?> cls = Class.forName(className);
-
-                // Call the constructor that takes an OpenJCEPlusProvider if
-                // available
-                //
-                try {
-                    Class<?>[] parameters = new Class<?>[1];
-                    parameters[0] = Class
-                            .forName("com.ibm.crypto.plus.provider.OpenJCEPlusProvider");
-                    Constructor<?> constr = cls.getConstructor(parameters);
-
-                    return constr.newInstance(new Object[] {provider});
-                } catch (java.lang.NoSuchMethodException e) {
-                }
-            } catch (Exception clex) {
-                throw new NoSuchAlgorithmException(clex);
-            }
-
-            return super.newInstance(constructorParameter);
-        }
-
-        @Override
-        public boolean supportsParameter(Object parameter) {
-
-            if (parameter == null) {
-                return false;
-            }
-            if (parameter instanceof Key == false) {
-                throw new InvalidParameterException("Parameter must be a Key");
-            }
-            Key key = (Key) parameter;
-
-            if (key instanceof SecretKey) {
-
-                String keyType = ((SecretKey) key).getFormat();
-                if (keyType == null) {
-                    // this happens when encoding is not supported
-                    return true;
-                }
-                if (keyType.equalsIgnoreCase("RAW") || keyType.equalsIgnoreCase("PKCS5_DERIVED_KEY")
-                        || keyType.equalsIgnoreCase("PKCS5_KEY")) {
-                    return true;
-                } else {
-                    return false;
-                }
-
-            } else if (key instanceof PrivateKey) {
-                String keyType = ((PrivateKey) key).getFormat();
-                if (keyType == null) {
-                    // this happens when encoding is not supported
-                    return true;
-                }
-                if (keyType.equalsIgnoreCase("PKCS#8")) {
-                    return true;
-                } else {
-                    return false;
-                }
-            } else if (key instanceof PublicKey) {
-                String keyType = ((PublicKey) key).getFormat();
-                if (keyType == null) {
-                    // this happens when encoding is not supported
-                    return true;
-                }
-                if (keyType.equalsIgnoreCase("X.509")) {
-                    return true;
-                } else {
-                    return false;
-                }
-            }
-
-            return false;
-        }
-
-        @Override
-        public String toString() {
-
-            return (super.toString() + "\n" + "provider = " + this.getProvider().getName() + "\n"
-                    + "algorithm = " + this.getAlgorithm());
-
-        }
 
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -10,20 +10,13 @@ package com.ibm.crypto.plus.provider;
 
 import com.ibm.crypto.plus.provider.ock.OCKContext;
 import com.ibm.crypto.plus.provider.ock.OCKException;
-import java.lang.reflect.Constructor;
 import java.security.AccessController;
-import java.security.InvalidParameterException;
-import java.security.Key;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.ProviderException;
-import java.security.PublicKey;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.crypto.SecretKey;
 
 @SuppressWarnings({"removal", "deprecation"})
 public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
@@ -696,115 +689,6 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
         putService(new OpenJCEPlusService(jce, "Signature", "RSAPSS",
                 "com.ibm.crypto.plus.provider.RSAPSSSignature", aliases));
 
-    }
-
-    private static class OpenJCEPlusService extends Service {
-
-        OpenJCEPlusService(Provider provider, String type, String algorithm, String className,
-                String[] aliases) {
-            this(provider, type, algorithm, className, aliases, null);
-        }
-
-        OpenJCEPlusService(Provider provider, String type, String algorithm, String className,
-                String[] aliases, Map<String, String> attributes) {
-            super(provider, type, algorithm, className, toList(aliases), attributes);
-
-            if (debug != null) {
-                debug.println("Constructing OpenJCEPlusService: " + provider + ", " + type
-                        + ", " + algorithm + ", " + className);
-            }
-        }
-
-        private static List<String> toList(String[] aliases) {
-            return (aliases == null) ? null : Arrays.asList(aliases);
-        }
-
-        @Override
-        public Object newInstance(Object constructorParameter) throws NoSuchAlgorithmException {
-            Provider provider = getProvider();
-            String className = getClassName();
-            try {
-                Class<?> cls = Class.forName(className);
-
-                // Call the constructor that takes an OpenJCEPlusProvider if
-                // available
-                //
-                try {
-                    Class<?>[] parameters = new Class<?>[1];
-                    parameters[0] = Class
-                            .forName("com.ibm.crypto.plus.provider.OpenJCEPlusProvider");
-                    Constructor<?> constr = cls.getConstructor(parameters);
-
-                    return constr.newInstance(new Object[] {provider});
-                } catch (java.lang.NoSuchMethodException e) {
-                }
-            } catch (Exception clex) {
-                throw new NoSuchAlgorithmException(clex);
-            }
-
-            return super.newInstance(constructorParameter);
-        }
-
-        @Override
-        public boolean supportsParameter(Object parameter) {
-
-            if (parameter == null) {
-                return false;
-            }
-            if (parameter instanceof Key == false) {
-                throw new InvalidParameterException("Parameter must be a Key");
-            }
-            Key key = (Key) parameter;
-
-            if (key instanceof SecretKey) {
-
-                String keyType = ((SecretKey) key).getFormat();
-                if (keyType == null) {
-                    // this happens when encoding is not supported
-                    return true;
-                }
-                if (keyType.equalsIgnoreCase("RAW") || keyType.equalsIgnoreCase("PKCS5_DERIVED_KEY")
-                        || keyType.equalsIgnoreCase("PKCS5_KEY")) {
-                    return true;
-                } else {
-                    return false;
-                }
-
-            } else if (key instanceof PrivateKey) {
-                String keyType = ((PrivateKey) key).getFormat();
-                if (keyType == null) {
-                    // this happens when encoding is not supported
-                    return true;
-                }
-                if (keyType.equalsIgnoreCase("PKCS#8")) {
-                    return true;
-                } else {
-                    return false;
-                }
-            } else if (key instanceof PublicKey) {
-                String keyType = ((PublicKey) key).getFormat();
-                if (keyType == null) {
-                    // this happens when encoding is not supported
-                    return true;
-                }
-                if (keyType.equalsIgnoreCase("X.509")) {
-                    return true;
-                } else {
-                    return false;
-                }
-            }
-
-            return false;
-
-        }
-
-        @Override
-        public String toString() {
-
-            return (super.toString() + "\n" + "provider = " + this.getProvider().getName() + "\n"
-                    + "algorithm = " + this.getAlgorithm());
-
-        }
     }
 
     // Return the instance of this class or create one if needed.

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
@@ -10,8 +10,20 @@ package com.ibm.crypto.plus.provider;
 
 import com.ibm.crypto.plus.provider.ock.OCKContext;
 import java.lang.ref.Cleaner;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.security.InvalidParameterException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.ProviderException;
+import java.security.PublicKey;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.crypto.SecretKey;
 import sun.security.util.Debug;
 
 // Internal interface for OpenJCEPlus and OpenJCEPlus implementation classes.
@@ -104,5 +116,166 @@ public abstract class OpenJCEPlusProvider extends java.security.Provider {
         if ((debug != null) && (exception != null) && (exception.getCause() == null)) {
             exception.initCause(ockException);
         }
+    }
+
+    protected static class OpenJCEPlusService extends Service {
+        private static Class<?> openjceplusClass;
+
+        OpenJCEPlusService(Provider provider, String type, String algorithm, String className,
+                String[] aliases) {
+            this(provider, type, algorithm, className, aliases, null);
+        }
+
+        OpenJCEPlusService(Provider provider, String type, String algorithm, String className,
+                String[] aliases, Map<String, String> attributes) {
+            super(provider, type, algorithm, className, toList(aliases), attributes);
+
+            if (debug != null) {
+                debug.println("Constructing OpenJCEPlusService: " + provider + ", " + type
+                            + ", " + algorithm + ", " + className);
+            }
+        }
+
+        private static List<String> toList(String[] aliases) {
+            return (aliases == null) ? null : Arrays.asList(aliases);
+        }
+
+        private Class<?> getParameterClass(String type) {
+            // No parameter class is supported for this version yet.
+            return null;
+        }
+
+        @Override
+        public Object newInstance(Object constructorParameter) throws NoSuchAlgorithmException {
+            Provider provider = getProvider();
+            String className = getClassName();
+            String type = getType();
+            String algorithm = getAlgorithm();
+
+            // AlgorithmParameters instances don't need the provider as a parameter,
+            // so the superclass constructor can be used.
+            if ("AlgorithmParameters".equalsIgnoreCase(type)) {
+                return super.newInstance(constructorParameter);
+            }
+
+            Class<?> cls;
+            try {
+                cls = Class.forName(className);
+            } catch (ClassNotFoundException e) {
+                throw new NoSuchAlgorithmException("class configured for " + type + " (provider: "
+                        + provider.getName() + ") cannot be found.", e);
+            }
+
+            // Call the constructor that takes an OpenJCEPlusProvider if
+            // available
+            //
+            try {
+                Class<?>[] parameters;
+                Class<?> ctrParamClz = null;
+                if (constructorParameter != null) {
+                    ctrParamClz = getParameterClass(type);
+                }
+                if (ctrParamClz != null) {
+                    parameters = new Class<?>[2];
+                    
+                    Class<?> argClass = constructorParameter.getClass();
+                    if (!ctrParamClz.isAssignableFrom(argClass)) {
+                        throw new InvalidParameterException("constructorParameter must be "
+                            + "instanceof " + ctrParamClz.getName().replace('$', '.')
+                            + " for type " + type);
+                    }
+
+                    parameters[1] = ctrParamClz;
+                } else {
+                    parameters = new Class<?>[1];
+                }
+                if (openjceplusClass == null) {
+                    openjceplusClass = Class
+                            .forName("com.ibm.crypto.plus.provider.OpenJCEPlusProvider");
+                }
+                parameters[0] = openjceplusClass;
+                Constructor<?> constr = cls.getConstructor(parameters);
+
+                Object[] ctrParams;
+                if ((constructorParameter != null) && (ctrParamClz != null)) {
+                    ctrParams = new Object[2];
+                    ctrParams[1] = constructorParameter;
+                } else {
+                    ctrParams = new Object[1];
+                }
+                ctrParams[0] = provider;
+
+                return constr.newInstance(ctrParams);
+            } catch (InvocationTargetException e) {
+                throw new NoSuchAlgorithmException("Error constructing implementation (algorithm: "
+                    + algorithm + ", provider: " + provider.getName()
+                    + ", class: " + className + ")", e.getCause());
+            } catch (Exception e) {
+                throw new NoSuchAlgorithmException("Error constructing implementation (algorithm: "
+                    + algorithm + ", provider: " + provider.getName()
+                    + ", class: " + className + ")", e);
+            }
+        }
+
+        @Override
+        public boolean supportsParameter(Object parameter) {
+
+            if (parameter == null) {
+                return false;
+            }
+            if (parameter instanceof Key == false) {
+                throw new InvalidParameterException("Parameter must be a Key");
+            }
+            Key key = (Key) parameter;
+
+            if (key instanceof SecretKey) {
+
+                String keyType = ((SecretKey) key).getFormat();
+                if (keyType == null) {
+                    // this happens when encoding is not supported
+                    return true;
+                }
+                if (keyType.equalsIgnoreCase("RAW") || keyType.equalsIgnoreCase("PKCS5_DERIVED_KEY")
+                        || keyType.equalsIgnoreCase("PKCS5_KEY")) {
+                    return true;
+                } else {
+                    return false;
+                }
+
+            } else if (key instanceof PrivateKey) {
+                String keyType = ((PrivateKey) key).getFormat();
+                if (keyType == null) {
+                    // this happens when encoding is not supported
+                    return true;
+                }
+                if (keyType.equalsIgnoreCase("PKCS#8")) {
+                    return true;
+                } else {
+                    return false;
+                }
+            } else if (key instanceof PublicKey) {
+                String keyType = ((PublicKey) key).getFormat();
+                if (keyType == null) {
+                    // this happens when encoding is not supported
+                    return true;
+                }
+                if (keyType.equalsIgnoreCase("X.509")) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+
+            return false;
+        }
+
+        @Override
+        public String toString() {
+
+            return (super.toString() + "\n" + "provider = " + this.getProvider().getName() + "\n"
+                    + "algorithm = " + this.getAlgorithm());
+
+        }
+
     }
 }


### PR DESCRIPTION
Current code ignores parameters that need to be passed to the constructor of a service that needs to be initialized.

This change is rectifying this and ensuring parameters are appropriately forwarded to the service's constructor.

Currently no service in this version supports it, so it cannot be tested.

Backported-from: https://github.com/IBM/OpenJCEPlus/pull/971

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>