### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/PrimitiveWrapper.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PrimitiveWrapper.java
@@ -19,6 +19,9 @@ package com.ibm.crypto.plus.provider;
  */
 
 public final class PrimitiveWrapper {
+
+    private PrimitiveWrapper() {}
+    
     public static class Long { 
         long value;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDeterministic.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDeterministic.java
@@ -21,6 +21,7 @@ import java.security.Security;
 import java.security.Signature;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.DSAParameterSpec;
+import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
 import java.util.Arrays;
 import java.util.Objects;
@@ -194,8 +195,8 @@ public class BaseTestDeterministic extends BaseTestJunit5 {
         var sk = generateKeyPair(keyAlg, keyProvider, 0).getPrivate();
         var sig = Signature.getInstance(s.getAlgorithm(), s.getProvider());
         try {
-            if (keyAlg.equals("RSASSA-PSS")) {
-                sig.setParameter(PSSParameterSpec.DEFAULT);
+            if (keyAlg.equals("RSAPSS")) {
+                sig.setParameter(new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1));
             }
             sig.initSign(sk, new SeededSecureRandom(SEED));
             sig.update(new byte[20]);

--- a/src/test/java/ibm/jceplus/junit/base/certificateutils/Debug.java
+++ b/src/test/java/ibm/jceplus/junit/base/certificateutils/Debug.java
@@ -402,42 +402,42 @@ public class Debug {
 
     public void exit(long type, Object loggingClass, String loggingMethod, byte retValue) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "RETURN {0}",
-                new Byte(retValue));
+                Byte.valueOf(retValue));
     }
 
     public void exit(long type, Object loggingClass, String loggingMethod, short retValue) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "RETURN {0}",
-                new Short(retValue));
+                Short.valueOf(retValue));
     }
 
     public void exit(long type, Object loggingClass, String loggingMethod, int retValue) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "RETURN {0}",
-                new Integer(retValue));
+                Integer.valueOf(retValue));
     }
 
     public void exit(long type, Object loggingClass, String loggingMethod, long retValue) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "RETURN {0}",
-                new Long(retValue));
+                Long.valueOf(retValue));
     }
 
     public void exit(long type, Object loggingClass, String loggingMethod, float retValue) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "RETURN {0}",
-                new Float(retValue));
+                Float.valueOf(retValue));
     }
 
     public void exit(long type, Object loggingClass, String loggingMethod, double retValue) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "RETURN {0}",
-                new Double(retValue));
+                Double.valueOf(retValue));
     }
 
     public void exit(long type, Object loggingClass, String loggingMethod, char retValue) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "RETURN {0}",
-                new Character(retValue));
+                Character.valueOf(retValue));
     }
 
     public void exit(long type, Object loggingClass, String loggingMethod, boolean retValue) {
         tl.logp(PlatformLogger.Level.FINER, (String) loggingClass, loggingMethod, "RETURN {0}",
-                new Boolean(retValue));
+                Boolean.valueOf(retValue));
     }
 
     public void exit(long type, Object loggingClass, String loggingMethod, Object retValue) {


### PR DESCRIPTION
This fix resolves warnings that appear when building OpenJCEPlus related to deprecated and missing constructors, as well as deprecated default values used in instantiation.

Signed-off-by: Sabrina Lee <sabrinalee@ibm.com>