### PR TITLE
Fix serialization and cast warnings

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
@@ -44,7 +44,7 @@ public abstract class OpenJCEPlusProvider extends java.security.Provider {
 
     static final boolean allowLegacyHKDF = Boolean.getBoolean("openjceplus.allowLegacyHKDF");
 
-    private final Cleaner[] cleaners;
+    private final transient Cleaner[] cleaners;
 
     private final int DEFAULT_NUM_CLEANERS = 2;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDeterministic.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDeterministic.java
@@ -329,6 +329,7 @@ public class BaseTestDeterministic extends BaseTestJunit5 {
     public static class SeededSecureRandom extends SecureRandom {
 
         private final Random rnd;
+        private static final long serialVersionUID = 1L;
 
         public static long seed() {
             String value = System.getProperty("secure.random.seed");

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestHKDFInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestHKDFInterop.java
@@ -117,9 +117,9 @@ public class BaseTestHKDFInterop extends BaseTestJunit5Interop {
             HKDFParameters hkdfParametersBC = new HKDFParameters(ikmArray, saltArray,
                     infoArray);
             hkdfBytesGeneratorBC.init(hkdfParametersBC);
-            byte[] okmBC = new byte[(int) okmLength];
+            byte[] okmBC = new byte[okmLength];
 
-            hkdfBytesGeneratorBC.generateBytes(okmBC, 0, (int) okmLength);
+            hkdfBytesGeneratorBC.generateBytes(okmBC, 0, okmLength);
 
             assertArrayEquals(calcOkmArray, okmBC, "OpenJCEPlus and BC results don't match");
         }
@@ -159,9 +159,9 @@ public class BaseTestHKDFInterop extends BaseTestJunit5Interop {
                 HKDFParameters hkdfParametersBC = new HKDFParameters(ikmArray, saltArray,
                         infoArray);
                 hkdfBytesGeneratorBC.init(hkdfParametersBC);
-                byte[] okmBC = new byte[(int) okmLength];
+                byte[] okmBC = new byte[okmLength];
 
-                hkdfBytesGeneratorBC.generateBytes(okmBC, 0, (int) okmLength);
+                hkdfBytesGeneratorBC.generateBytes(okmBC, 0, okmLength);
                 assertArrayEquals(calcOkmArray, okmBC, "OpenJCEPlus and BC results don't match");
             }
         } catch (NoSuchAlgorithmException e) {


### PR DESCRIPTION
This fix resolves warnings related to serialization and redundant casts that appear when building OpenJCEPlus.

Backported-from: https://github.com/IBM/OpenJCEPlus/pull/996
Signed-off-by: Sabrina Lee <sabrinalee@ibm.com>