### PR TITLE
Fix serialization and cast warnings

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
@@ -41,7 +41,7 @@ public abstract class OpenJCEPlusProvider extends java.security.Provider {
 
     static final String DEBUG_VALUE = "jceplus";
 
-    private final Cleaner[] cleaners;
+    private final transient Cleaner[] cleaners;
 
     private final int DEFAULT_NUM_CLEANERS = 2;
 

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDeterministic.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDeterministic.java
@@ -329,6 +329,7 @@ public class BaseTestDeterministic extends BaseTestJunit5 {
     public static class SeededSecureRandom extends SecureRandom {
 
         private final Random rnd;
+        private static final long serialVersionUID = 1L;
 
         public static long seed() {
             String value = System.getProperty("secure.random.seed");


### PR DESCRIPTION
This fix resolves warnings related to serialization that appear when building OpenJCEPlus.

This version does not have cast related warnings as in the 25 and main branches.

Backported-from: https://github.com/IBM/OpenJCEPlus/pull/996
Signed-off-by: Sabrina Lee <sabrinalee@ibm.com>