### PR TITLE
Validate output buffer size

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/AESCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESCipher.java
@@ -86,6 +86,12 @@ public final class AESCipher extends CipherSpi implements AESConstants {
         checkCipherInitialized();
 
         try {
+            int outputSize = engineGetOutputSize(inputLen);
+            if ((output == null) || ((output.length - outputOffset) < outputSize)) {
+                throw new ShortBufferException(
+                        "Output buffer must be " + "(at least) " + outputSize + " bytes long");
+            }
+
             if (use_z_fast_command) {
                 int encryptedData = engineUpdate(input, inputOffset, inputLen, output,
                         outputOffset);

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESInterop.java
@@ -26,6 +26,7 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -175,23 +176,26 @@ public class BaseTestAESInterop extends BaseTestJunit5Interop {
 
     @Test
     public void testAESShortBuffer() throws Exception {
-        doTestAESShortBuffer("AES", getProviderName());
-        doTestAESShortBuffer("AES", getInteropProviderName());
+        String msg = doTestAESShortBuffer("AES", getProviderName());
+        String interopMsg = doTestAESShortBuffer("AES", getInteropProviderName());
+        assertEquals(msg, interopMsg);
     }
 
-    private void doTestAESShortBuffer(String algorithm, String providerA) throws Exception {
+    private String doTestAESShortBuffer(String algorithm, String providerA) throws Exception {
+        String msg = null;
         try {
             // Test AES Cipher
-            cpA = Cipher.getInstance(algorithm, getProviderName());
+            cpA = Cipher.getInstance(algorithm, providerA);
 
             // Encrypt the plain text
             cpA.init(Cipher.ENCRYPT_MODE, key);
             byte[] cipherText = new byte[5];
             cpA.doFinal(plainText, 0, plainText.length, cipherText);
-            fail("Expected ShortBufferException did not occur");
+            fail("Expected ShortBufferException did not occur for provider: " + providerA);
         } catch (ShortBufferException ex) {
-            assertTrue(true);
+            msg = ex.getMessage();
         }
+        return msg;
     }
 
     @Test


### PR DESCRIPTION
This update validates the output buffer size. If the buffer is too small a ShortBufferException is thrown with the required buffer length.

Signed-off-by: Dev Agarwal [dev.agarwal@ibm.com](mailto:dev.agarwal@ibm.com)