### PR TITLE
Remove fallback option for deprecated OAEP parameter functionality

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/OAEPParameters.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OAEPParameters.java
@@ -40,8 +40,6 @@ public final class OAEPParameters extends AlgorithmParametersSpi {
     private static ObjectIdentifier OID_MGF1;
     private static ObjectIdentifier OID_PSpecified;
 
-    private static boolean disableOrderCheck = Boolean.getBoolean("openjceplus.oaep.disableOrderCheck");
-
     static {
         try {
             OID_MGF1 = ObjectIdentifier.of("1.2.840.113549.1.1.8");
@@ -86,117 +84,55 @@ public final class OAEPParameters extends AlgorithmParametersSpi {
     }
 
     protected void engineInit(byte[] encoded) throws IOException {
-        if (disableOrderCheck) {
-            // Deprecated. To be removed in a future release.
-            //
-            // Disable check and revert to old behaviour using
-            // the -Dopenjceplus.oaep.disableOrderCheck flag.
-            DerInputStream der = new DerInputStream(encoded);
-            mdName = "SHA-1";
-            mgfSpec = MGF1ParameterSpec.SHA1;
-            p = new byte[0];
-            DerValue[] datum = der.getSequence(3);
-            for (int i = 0; i < datum.length; i++) {
-                DerValue data = datum[i];
-                if (data.isContextSpecific((byte) 0x00)) {
-                    // hash algid
-                    mdName = AlgorithmId.parse(data.getData().getDerValue()).getName();
-                } else if (data.isContextSpecific((byte) 0x01)) {
-                    // mgf algid
-                    AlgorithmId val = AlgorithmId.parse(data.getData().getDerValue());
-                    if (!val.getOID().equals((Object) OID_MGF1)) {
-                        throw new IOException("Only MGF1 mgf is supported");
-                    }
-                    byte[] encodedParams = val.getEncodedParams();
-                    if (encodedParams == null) {
-                        throw new IOException("Missing MGF1 parameters");
-                    }
-                    AlgorithmId params = AlgorithmId.parse(new DerValue(encodedParams));
-                    String mgfDigestName = params.getName();
-                    if (mgfDigestName.equals("SHA-1")) {
-                        mgfSpec = MGF1ParameterSpec.SHA1;
-                    } else if (mgfDigestName.equals("SHA-224")) {
-                        mgfSpec = MGF1ParameterSpec.SHA224;
-                    } else if (mgfDigestName.equals("SHA-256")) {
-                        mgfSpec = MGF1ParameterSpec.SHA256;
-                    } else if (mgfDigestName.equals("SHA-384")) {
-                        mgfSpec = MGF1ParameterSpec.SHA384;
-                    } else if (mgfDigestName.equals("SHA-512")) {
-                        mgfSpec = MGF1ParameterSpec.SHA512;
-                    } else {
-                        throw new IOException("Unrecognized message digest algorithm");
-                    }
-                } else if (data.isContextSpecific((byte) 0x02)) {
-                    // pSource algid
-                    AlgorithmId val = AlgorithmId.parse(data.getData().getDerValue());
-                    if (!val.getOID().equals((Object) OID_PSpecified)) {
-                        throw new IOException("Wrong OID for pSpecified");
-                    }
-                    byte[] encodedParams = val.getEncodedParams();
-                    if (encodedParams == null) {
-                        throw new IOException("Missing pSpecified label");
-                    }
-
-                    DerInputStream dis = new DerInputStream(encodedParams);
-                    p = dis.getOctetString();
-                    if (dis.available() != 0) {
-                        throw new IOException("Extra data for pSpecified");
-                    }
-                } else {
-                    throw new IOException("Invalid encoded OAEPParameters");
-                }
-            }
+        DerInputStream der = DerValue.wrap(encoded).data();
+        var sub = der.getOptionalExplicitContextSpecific(0);
+        if (sub.isPresent()) {
+            mdName = AlgorithmId.parse(sub.get()).getName();
         } else {
-            DerInputStream der = DerValue.wrap(encoded).data();
-            var sub = der.getOptionalExplicitContextSpecific(0);
-            if (sub.isPresent()) {
-                mdName = AlgorithmId.parse(sub.get()).getName();
-            } else {
-                mdName = "SHA-1";
-            }
-            sub = der.getOptionalExplicitContextSpecific(1);
-            if (sub.isPresent()) {
-                AlgorithmId val = AlgorithmId.parse(sub.get());
-                if (!val.getOID().equals(OID_MGF1)) {
-                    throw new IOException("Only MGF1 mgf is supported");
-                }
-                byte[] encodedParams = val.getEncodedParams();
-                if (encodedParams == null) {
-                    throw new IOException("Missing MGF1 parameters");
-                }
-                AlgorithmId params = AlgorithmId.parse(
-                        new DerValue(encodedParams));
-                mgfSpec = switch (params.getName()) {
-                    case "SHA-1" -> MGF1ParameterSpec.SHA1;
-                    case "SHA-224" -> MGF1ParameterSpec.SHA224;
-                    case "SHA-256" -> MGF1ParameterSpec.SHA256;
-                    case "SHA-384" -> MGF1ParameterSpec.SHA384;
-                    case "SHA-512" -> MGF1ParameterSpec.SHA512;
-                    case "SHA-512/224" -> MGF1ParameterSpec.SHA512_224;
-                    case "SHA-512/256" -> MGF1ParameterSpec.SHA512_256;
-                    default -> throw new IOException(
-                            "Unrecognized message digest algorithm");
-                };
-            } else {
-                mgfSpec = MGF1ParameterSpec.SHA1;
-            }
-            sub = der.getOptionalExplicitContextSpecific(2);
-            if (sub.isPresent()) {
-                AlgorithmId val = AlgorithmId.parse(sub.get());
-                if (!val.getOID().equals(OID_PSpecified)) {
-                    throw new IOException("Wrong OID for pSpecified");
-                }
-                byte[] encodedParams = val.getEncodedParams();
-                if (encodedParams == null) {
-                    throw new IOException("Missing pSpecified label");
-                }
-
-                p = DerValue.wrap(encodedParams).getOctetString();
-            } else {
-                p = new byte[0];
-            }
-            der.atEnd();
+            mdName = "SHA-1";
         }
+        sub = der.getOptionalExplicitContextSpecific(1);
+        if (sub.isPresent()) {
+            AlgorithmId val = AlgorithmId.parse(sub.get());
+            if (!val.getOID().equals(OID_MGF1)) {
+                throw new IOException("Only MGF1 mgf is supported");
+            }
+            byte[] encodedParams = val.getEncodedParams();
+            if (encodedParams == null) {
+                throw new IOException("Missing MGF1 parameters");
+            }
+            AlgorithmId params = AlgorithmId.parse(
+                    new DerValue(encodedParams));
+            mgfSpec = switch (params.getName()) {
+                case "SHA-1" -> MGF1ParameterSpec.SHA1;
+                case "SHA-224" -> MGF1ParameterSpec.SHA224;
+                case "SHA-256" -> MGF1ParameterSpec.SHA256;
+                case "SHA-384" -> MGF1ParameterSpec.SHA384;
+                case "SHA-512" -> MGF1ParameterSpec.SHA512;
+                case "SHA-512/224" -> MGF1ParameterSpec.SHA512_224;
+                case "SHA-512/256" -> MGF1ParameterSpec.SHA512_256;
+                default -> throw new IOException(
+                        "Unrecognized message digest algorithm");
+            };
+        } else {
+            mgfSpec = MGF1ParameterSpec.SHA1;
+        }
+        sub = der.getOptionalExplicitContextSpecific(2);
+        if (sub.isPresent()) {
+            AlgorithmId val = AlgorithmId.parse(sub.get());
+            if (!val.getOID().equals(OID_PSpecified)) {
+                throw new IOException("Wrong OID for pSpecified");
+            }
+            byte[] encodedParams = val.getEncodedParams();
+            if (encodedParams == null) {
+                throw new IOException("Missing pSpecified label");
+            }
+
+            p = DerValue.wrap(encodedParams).getOctetString();
+        } else {
+            p = new byte[0];
+        }
+        der.atEnd();
     }
 
     protected void engineInit(byte[] encoded, String decodingMethod) throws IOException {


### PR DESCRIPTION
After changes to the OAEPParameters class to follow newer expectations, code and a flag to utilize it was left behind for compatibility reasons.

Nobody run into issues or requested to exercise this path, so we can safely remove it.

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>