### PR TITLE
Silence compilation warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -502,6 +502,7 @@
                     <compilerArgs>
                         <arg>-XDignore.symbol.file</arg>
                         <arg>-Xlint:all</arg>
+                        <arg>-Xlint:-processing</arg>
                         <arg>--add-exports </arg>
                         <arg>java.base/sun.security.internal.spec=openjceplus</arg>
                         <arg>--add-exports </arg>

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
@@ -52,6 +52,7 @@ public abstract class OpenJCEPlusProvider extends java.security.Provider {
 
     private AtomicInteger count = new AtomicInteger(0);
 
+    @SuppressWarnings("exports")
     protected static final Debug debug = Debug.getInstance(DEBUG_VALUE); 
 
     OpenJCEPlusProvider(String name, String info) {
@@ -80,6 +81,7 @@ public abstract class OpenJCEPlusProvider extends java.security.Provider {
         cleaner.register(owner, cleanAction);
     }
 
+    @SuppressWarnings("exports")
     public static Debug getDebug() {
         return debug;
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeInterface.java
@@ -170,6 +170,7 @@ final class NativeInterface {
         }
     }
 
+    @SuppressWarnings("restricted")
     private static boolean loadIfExists(File libraryFile) {
         String libraryName = libraryFile.getAbsolutePath();
 

--- a/src/main/java/ibm/security/internal/spec/RawKeySpec.java
+++ b/src/main/java/ibm/security/internal/spec/RawKeySpec.java
@@ -25,7 +25,8 @@ public class RawKeySpec implements KeySpec {
     /**
      * @param key contains the key as a byte array
      */
-
+    
+    @SuppressWarnings("this-escape")
     public RawKeySpec(byte[] key) {
         keyBytes = key.clone();
         cleaner.register(this, cleanOCKResources(keyBytes));


### PR DESCRIPTION
This fix silences warnings that appear in necessary code paths.

Backported-from: https://github.com/IBM/OpenJCEPlus/pull/998

Signed-off-by: Sabrina Lee <sabrinalee@ibm.com>