### PR TITLE
Change getScalar() to provide clone of key

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyFactory.java
@@ -27,6 +27,7 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.security.spec.XECPrivateKeySpec;
 import java.security.spec.XECPublicKeySpec;
+import java.util.Arrays;
 import java.util.Optional;
 
 class XDHKeyFactory extends KeyFactorySpi {
@@ -169,7 +170,12 @@ class XDHKeyFactory extends KeyFactorySpi {
                     }
 
                     Optional<byte[]> scalar = xecPrivKey.getScalar();
-                    return keySpec.cast(new XECPrivateKeySpec(params, scalar.get()));
+                    byte[] scalarArray = scalar.get();
+                    try {
+                        return keySpec.cast(new XECPrivateKeySpec(params, scalarArray));
+                    } finally {
+                        Arrays.fill(scalarArray, (byte) 0x00);
+                    }
                 } else if (keySpec.isAssignableFrom(pkcs8KeySpec))
                     return keySpec.cast(new PKCS8EncodedKeySpec(key.getEncoded()));
                 else

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
@@ -39,7 +39,6 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
     private static final long serialVersionUID = 6034044314589513430L;
 
     private OpenJCEPlusProvider provider = null;
-    private transient Optional<byte[]> scalar;
     private transient NamedParameterSpec params;
     private CURVE curve;
     private byte[] k; // The raw key bytes, without OctetString or DER encoded
@@ -58,7 +57,6 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
         if (k == null) {
             k = extractPrivateKeyFromOCK(xecKey.getPrivateKeyBytes()); // Extract key from GSKit and sets params
             setPKCS8KeyByte(k);
-            this.scalar = Optional.of(k);
             this.algid = CurveUtil.getAlgId(this.params.getName());
         }
     }
@@ -98,7 +96,6 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
             // to fit with GSKit and sets params
             int curveSize = CurveUtil.getCurveSize(curve);
             this.xecKey = XECKey.createPrivateKey(provider.getOCKContext(), alteredEncoded, curveSize, provider);
-            this.scalar = Optional.of(k);
         } catch (Exception exception) {
             InvalidKeyException ike = new InvalidKeyException("Failed to create XEC private key");
             provider.setOCKExceptionCause(ike, exception);
@@ -137,7 +134,6 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
         // TODO: figure out how to build FFDHE curves from paramspec
 
         this.provider = provider;
-        this.scalar = scalar;
         if (scalar != null)
             k = scalar.get();
         try {
@@ -393,7 +389,7 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
         } catch (Exception exception) {
             this.exception = exception;
         }
-        return scalar;
+        return Optional.of(getKeyBytes());
     }
 
     public byte[] getKeyBytes() {
@@ -539,7 +535,6 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
             if (this.privKeyMaterial != null)
                 Arrays.fill(this.privKeyMaterial, (byte) 0x00);
             this.xecKey = null;
-            this.scalar = null;
             this.params = null;
         }
     }


### PR DESCRIPTION
The `getScalar()` method inherited from the `XECPrivateKey` interface is updated to provide an `Optional` containing a clone of the key byte array instead or a reference to the original one.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1013

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>