### PR TITLE
Update junit version and use tree view runner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,13 @@
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
                   <version>3.5.3</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>me.fabriciorby</groupId>
+                      <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                      <version>1.5.1</version>
+                    </dependency>
+                  </dependencies>
                   <configuration>
                     <useModulePath>false</useModulePath>
                     <!-- Could add -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0.0.0.0:8787 for debug -->
@@ -205,6 +212,21 @@
                         **/ibm/jceplus/junit/TestMultithreadFIPS.java
                       </include>
                     </includes>
+                    <reportFormat>plain</reportFormat>
+                    <consoleOutputReporter>
+                      <disable>true</disable>
+                    </consoleOutputReporter>
+                    <statelessTestsetInfoReporter
+                      implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">
+                      <printStacktraceOnError>true</printStacktraceOnError>
+                      <printStacktraceOnFailure>true</printStacktraceOnFailure>
+                      <printStdoutOnError>true</printStdoutOnError>
+                      <printStdoutOnFailure>true</printStdoutOnFailure>
+                      <printStdoutOnSuccess>false</printStdoutOnSuccess>
+                      <printStderrOnError>true</printStderrOnError>
+                      <printStderrOnFailure>true</printStderrOnFailure>
+                      <printStderrOnSuccess>false</printStderrOnSuccess>
+                    </statelessTestsetInfoReporter>
                   </configuration>
                 </plugin>
                 <plugin>
@@ -292,6 +314,13 @@
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
                   <version>3.5.3</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>me.fabriciorby</groupId>
+                      <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                      <version>1.5.1</version>
+                    </dependency>
+                  </dependencies>
                   <configuration>
                     <useModulePath>false</useModulePath>
                     <trimStackTrace>false</trimStackTrace>
@@ -313,6 +342,21 @@
                         **/ibm/jceplus/junit/TestMultithreadFIPS.java
                       </include>
                     </includes>
+                    <reportFormat>plain</reportFormat>
+                    <consoleOutputReporter>
+                      <disable>true</disable>
+                    </consoleOutputReporter>
+                    <statelessTestsetInfoReporter
+                      implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">
+                      <printStacktraceOnError>true</printStacktraceOnError>
+                      <printStacktraceOnFailure>true</printStacktraceOnFailure>
+                      <printStdoutOnError>true</printStdoutOnError>
+                      <printStdoutOnFailure>true</printStdoutOnFailure>
+                      <printStdoutOnSuccess>false</printStdoutOnSuccess>
+                      <printStderrOnError>true</printStderrOnError>
+                      <printStderrOnFailure>true</printStderrOnFailure>
+                      <printStderrOnSuccess>false</printStderrOnSuccess>
+                    </statelessTestsetInfoReporter>
                   </configuration>
                 </plugin>
               </plugins>
@@ -662,25 +706,25 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-suite</artifactId>
-            <version>1.13.0-M3</version>
+            <version>1.14.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.13.0-M3</version>
+            <version>5.14.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.13.0-M3</version>
+            <version>5.14.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.13.0-M3</version>
+            <version>5.14.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
As mentioned at the bottom of the maven surefire plugin a treeview is available to format the output of our Junit tests as they are executed.

This is setup to suppress any output that is not part of a test that has failed.

The treeview is able to allow easier view of tests that are actually run during a given execution along with any tests that have failed or are being skipped entirely. This will make it much easier to view what tests are really running to avoid accidental tests being skipped or not run at all.

Tests that are parameterized will print their parameters in the log.

Junit was updated to the latest Junit 5 version available.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1029

Signed-off-by: Jason Katonica <katonica@us.ibm.com>