### PR TITLE
Support multithread JMH test execution

### DIFF
--- a/JenkinsfilePerformance
+++ b/JenkinsfilePerformance
@@ -395,7 +395,8 @@ pipeline {
         string(name: 'ADDITIONAL_CMD_ARGS', defaultValue: '', description: '\
             Additional command line arguments that one might want to add to the mvn command.<br> \
             The contents of this will directly be appended to the mvn command, so write exactly as \
-            you would if running this manually in a command line (e.g., -Dflag1=true -Dflag2=false ...).')
+            you would if running this manually in a command line (e.g., -Dflag1=true -Dflag2=false ...).<br> \
+            Note: You can use -Djmh.threads=X to specify the number of threads for JMH benchmarks (-Djmh.threads=16).')
         string(name: 'TIMEOUT_TIME', defaultValue: '48', description: '\
             Overall build timeout (HOURS)')
     }

--- a/src/test/java/ibm/jceplus/jmh/JMHBase.java
+++ b/src/test/java/ibm/jceplus/jmh/JMHBase.java
@@ -35,15 +35,29 @@ abstract public class JMHBase {
         String ockLibraryPath = System.getProperty("ock.library.path");
         String jgskitLibraryPath = System.getProperty("jgskit.library.path");
         String osName = System.getProperty("os.name").toLowerCase();
+        String threadsProperty = System.getProperty("jmh.threads", "1");
+        int threads;
+        try {
+            threads = Integer.parseInt(threadsProperty);
+            if (threads < 1) {
+                throw new IllegalArgumentException("Thread count must be at least 1, got: " + threads);
+            }
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid thread count <" + threadsProperty + ">. Must be an integer.", e);
+        }
         System.out.println("Home dir: " + projectHomeDir);
         System.out.println("JGSkit Library Path: " + jgskitLibraryPath);
         System.out.println("Regex of classes to run: " + regexClassName);
         System.out.println("OS Name: " + osName);
+        System.out.println("Thread count: " + threads);
+
+        String logFileWithThreads = logFileRoot + "-" + threads + "t";
 
         OptionsBuilder optionsBuilder = new OptionsBuilder();
+        optionsBuilder.threads(threads);
         optionsBuilder.include(regexClassName);
         optionsBuilder.resultFormat(org.openjdk.jmh.results.format.ResultFormatType.JSON);
-        optionsBuilder.result(projectHomeDir + "/target/jmh-results/" + logFileRoot + ".json");
+        optionsBuilder.result(projectHomeDir + "/target/jmh-results/" + logFileWithThreads + ".json");
         optionsBuilder.addProfiler(StackProfiler.class);
         optionsBuilder.addProfiler(GCProfiler.class);
         optionsBuilder.addProfiler(ClassloaderProfiler.class);
@@ -56,7 +70,7 @@ abstract public class JMHBase {
                 "-Dock.library.path=" + ockLibraryPath,
                 "-Djgskit.library.path=" + jgskitLibraryPath);
         optionsBuilder.forks(1);
-        optionsBuilder.output(projectHomeDir + "/target/jmh-results/" + logFileRoot + ".txt");
+        optionsBuilder.output(projectHomeDir + "/target/jmh-results/" + logFileWithThreads + ".txt");
 
         //TODO Most Jenkins systems dont seem to work with this. Must be admin.
         /*


### PR DESCRIPTION
The included JMH benchmarks now can optionally be executed with a specific thread count. The default is 1.

The log file name is also updated to include the thread count set during a given execution.

An example of how to set the thread count is included in the performance test job to make this more obvious.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1035

Signed-off-by: Jason Katonica <katonica@us.ibm.com>