### PR TITLE
Update Java version used to build

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,6 +1,6 @@
 ###############################################################################
 #
-# Copyright IBM Corp. 2023, 2025
+# Copyright IBM Corp. 2023, 2026
 #
 # This code is free software; you can redistribute it and/or modify it
 # under the terms provided by IBM in the LICENSE file that accompanied
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Temurin JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '25.0.1+8.0.LTS'
+          java-version: '26-ea'
           distribution: 'temurin'
           architecture: 'x64'
       # Uncomment to capture all files in the runner for debugging purposes.          

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2024, 2025
+ * Copyright IBM Corp. 2024, 2026
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -208,7 +208,7 @@ def run(platform) {
 
             // Some OSes have some further specific requirements.
             if (software == "aix") {
-                // Java 25 requires C++17.1 runtime. Otherwise crashes occur.
+                // Java 25+ requires C++17.1 runtime. Otherwise crashes occur.
                 nodeTags = "hw.arch.${node_hardware}&&sw.os.aix.7_2&&sw.tool.c++runtime.17_1&&ci.role.build"
             } else {
 
@@ -235,7 +235,10 @@ def run(platform) {
                     externalLibrary = load("./utils.groovy")
                 }
                 try {
-                    externalLibrary.getJava(hardware, software)
+                    withCredentials([usernamePassword(credentialsId: '7c1c2c28-650f-49e0-afd1-ca6b60479546', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
+                        externalLibrary.getJava(hardware, software)
+                    }
+                    
                     echo "Java fetched"
                     externalLibrary.getBinaries(hardware, software)
                     echo "Binaries fetched"
@@ -322,7 +325,7 @@ pipeline {
             Typically this will use https://github.com/IBM/OpenJCEPlus')
         string(name: 'OPENJCEPLUS_BRANCH', defaultValue: '', description: '\
             The OpenJCEPlus branch to be used. When not specified this will default to the branch scanned by this multibranch pipeline.')
-        choice(name: 'JAVA_VERSION', choices: ['25', '24', '23', '22', '21', '17', '11'], description: '\
+        choice(name: 'JAVA_VERSION', choices: ['26', '25', '24', '23', '22', '21', '17', '11'], description: '\
             Specify the Java version your branch uses to build.')
         string(name: 'JAVA_RELEASE', defaultValue: '', description: '\
             Indicate a specific Java release that you want to use to build your branch.<br> \

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <!--
 ###############################################################################
 #
-# Copyright IBM Corp. 2023, 2025
+# Copyright IBM Corp. 2023, 2026
 #
 # This code is free software; you can redistribute it and/or modify it
 # under the terms provided by IBM in the LICENSE file that accompanied
@@ -12,7 +12,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>OpenJCEPlus</artifactId>
-    <version>25</version>
+    <version>26</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -197,30 +197,12 @@
             </properties>
           </profile>
           <profile>
-            <id>Profile for JDK 23 Build</id>
+            <id>Profile for JDK 26 Build</id>
             <activation>
-              <jdk>23</jdk>
+              <jdk>26</jdk>
             </activation>
             <properties>
-                <jdk.build.target>23</jdk.build.target>
-            </properties>
-          </profile>
-          <profile>
-            <id>Profile for JDK 24 Build</id>
-            <activation>
-              <jdk>24</jdk>
-            </activation>
-            <properties>
-                <jdk.build.target>24</jdk.build.target>
-            </properties>
-          </profile>
-          <profile>
-            <id>Profile for JDK 25 Build</id>
-            <activation>
-              <jdk>25</jdk>
-            </activation>
-            <properties>
-                <jdk.build.target>25</jdk.build.target>
+                <jdk.build.target>26</jdk.build.target>
             </properties>
           </profile>
           <!--
@@ -476,8 +458,8 @@
                         <message>"Property ock.library.path is not set, perhaps this required property is missing from the command line?"</message>
                       </requireProperty>
                       <requireJavaVersion>
-                        <version>[25,26]</version>
-                        <message>"Java 25 or 26 required to build OpenJCEPlus."</message>
+                        <version>[26,27]</version>
+                        <message>"Java 26 or 27 required to build OpenJCEPlus."</message>
                       </requireJavaVersion>
                       <requireEnvironmentVariable>
                         <variableName>JAVA_HOME</variableName>
@@ -637,7 +619,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.13</version>
+                <version>0.8.14</version>
                 <executions>
                     <execution>
                         <id>start-agent</id>
@@ -886,7 +868,7 @@
         <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.13</version>
+            <version>0.8.14</version>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>

--- a/utils.groovy
+++ b/utils.groovy
@@ -114,14 +114,32 @@ def getJava(hardware, software) {
 
     def java_link = ""
     if (JAVA_RELEASE == "") {
-        java_link = "https://api.adoptopenjdk.net/v3/binary/latest/${JAVA_VERSION}/ga/${software}/${hardware}/jdk/openj9/normal/ibm?project=jdk"
+        if (software == "windows") {
+            java_link = "https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/openjceplusworkaround050126/ibm-semeru-open-jdk_x64_windows_JDK26U_2026-01-02-02-41.zip"
+        } else if ((software == "linux") && (hardware == "aarch64")) {
+            java_link = "https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/openjceplusworkaround050126/ibm-semeru-open-jdk_aarch64_linux_JDK26U_2026-01-03-18-27.tar.gz"
+        } else if ((software == "linux") && (hardware == "ppc64le")) {
+            java_link = "https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/openjceplusworkaround050126/ibm-semeru-open-jdk_ppc64le_linux_JDK26U_2026-01-03-18-27.tar.gz"
+        } else if ((software == "linux") && (hardware == "x64")) {
+            java_link = "https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/openjceplusworkaround050126/ibm-semeru-open-jdk_x64_linux_JDK26U_2026-01-02-02-41.tar.gz"
+        } else if ((software == "linux") && (hardware == "s390x")) {
+            java_link = "https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/openjceplusworkaround050126/ibm-semeru-open-jdk_s390x_linux_JDK26U_2026-01-03-18-27.tar.gz"
+        } else if ((software == "mac") && (hardware == "aarch64")) {
+            java_link = "https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/openjceplusworkaround050126/ibm-semeru-open-jdk_aarch64_mac_JDK26U_2026-01-03-18-27.tar.gz"
+        } else if ((software == "mac") && (hardware == "x64")) {
+            java_link = "https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/openjceplusworkaround050126/ibm-semeru-open-jdk_x64_mac_JDK26U_2026-01-03-18-27.tar.gz"
+        } else if (software == "aix") {
+            java_link = "https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/openjceplusworkaround050126/ibm-semeru-open-jdk_ppc64_aix_JDK26U_2026-01-03-18-27.tar.gz"
+        } else {
+            echo "No Java SDK downloaded!!!"
+        }
     } else {
         def java_release_link = JAVA_RELEASE.replace("+", "%2B")
         java_link = "https://api.adoptopenjdk.net/v3/binary/version/${java_release_link}/${software}/${hardware}/jdk/openj9/normal/ibm?project=jdk"
     }
 
     dir("java") {
-        sh "curl -LJkO ${java_link}"
+        sh "curl -u $ARTIFACTORY_USERNAME:$ARTIFACTORY_PASSWORD ${java_link} > java.tar.gz"
         def java_file = sh (
             script: 'ls | grep \'tar\\|zip\'',
             returnStdout: true


### PR DESCRIPTION
The Java version used in the Github actions and Jenkins pipeline is updated to be 26.

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>