### PR TITLE
Update GitHub action to OCKC 8.9.18

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: IBM/OpenCryptographyKitC
-          ref: 3688bdffd5fa2a39590e92b563826407c21a53de # Branch V_8.9.14 on Sept 18th 2025.
+          ref: f3dde51a02675270adf994dc22c7f2853dc86ba6 # Branch V_8.9.18 on Jan 2nd 2026.
           path: ${{ github.workspace }}/OpenCryptographyKitC
       - name: Compile Open Cryptography Kit C
         run: |


### PR DESCRIPTION
Update the github action to use the latest OCKC version 8.9.18.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1055

Signed-off-by: Jason Katonica <katonica@us.ibm.com>
