### PR TITLE
Update github action copyright statement to 2026

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,6 +1,6 @@
 ###############################################################################
 #
-# Copyright IBM Corp. 2023, 2025
+# Copyright IBM Corp. 2023, 2026
 #
 # This code is free software; you can redistribute it and/or modify it
 # under the terms provided by IBM in the LICENSE file that accompanied


### PR DESCRIPTION
Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1063

Signed-off-by: Jason Katonica <katonica@us.ibm.com>