### PR TITLE
Cleanup Java versions and update JaCoCo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2024, 2025
+ * Copyright IBM Corp. 2024, 2026
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -208,7 +208,7 @@ def run(platform) {
 
             // Some OSes have some further specific requirements.
             if (software == "aix") {
-                // Java 25 requires C++17.1 runtime. Otherwise crashes occur.
+                // Java 25+ requires C++17.1 runtime. Otherwise crashes occur.
                 nodeTags = "hw.arch.${node_hardware}&&sw.os.aix.7_2&&sw.tool.c++runtime.17_1&&ci.role.build"
             } else {
 
@@ -322,7 +322,7 @@ pipeline {
             Typically this will use https://github.com/IBM/OpenJCEPlus')
         string(name: 'OPENJCEPLUS_BRANCH', defaultValue: '', description: '\
             The OpenJCEPlus branch to be used. When not specified this will default to the branch scanned by this multibranch pipeline.')
-        choice(name: 'JAVA_VERSION', choices: ['25', '24', '23', '22', '21', '17', '11'], description: '\
+        string(name: 'JAVA_VERSION', defaultValue: '25', description: '\
             Specify the Java version your branch uses to build.')
         string(name: 'JAVA_RELEASE', defaultValue: '', description: '\
             Indicate a specific Java release that you want to use to build your branch.<br> \

--- a/JenkinsfilePerformance
+++ b/JenkinsfilePerformance
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -301,7 +301,7 @@ pipeline {
             Typically this will use https://github.com/IBM/OpenJCEPlus')
         string(name: 'OPENJCEPLUS_BRANCH', defaultValue: '', description: '\
             The OpenJCEPlus branch to be used. When not specified this will default to the branch scanned by this multibranch pipeline.')
-        choice(name: 'JAVA_VERSION', choices: ['25', '24', '23', '22', '21', '17', '11'], description: '\
+        string(name: 'JAVA_VERSION', defaultValue: '25', description: '\
             Specify the Java version your branch uses to build.')
         string(name: 'JAVA_RELEASE', defaultValue: '', description: '\
             Indicate a specific Java release that you want to use to build your branch.<br> \

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <!--
 ###############################################################################
 #
-# Copyright IBM Corp. 2023, 2025
+# Copyright IBM Corp. 2023, 2026
 #
 # This code is free software; you can redistribute it and/or modify it
 # under the terms provided by IBM in the LICENSE file that accompanied
@@ -194,24 +194,6 @@
                 <build.native.file>${basedir}/buildNativeMac.sh</build.native.file>
                 <build.platform.value>x86_64-mac</build.platform.value>
                 <build.target.jgskitlib.dir>${project.basedir}/target/jgskit-x86_64-mac/</build.target.jgskitlib.dir>
-            </properties>
-          </profile>
-          <profile>
-            <id>Profile for JDK 23 Build</id>
-            <activation>
-              <jdk>23</jdk>
-            </activation>
-            <properties>
-                <jdk.build.target>23</jdk.build.target>
-            </properties>
-          </profile>
-          <profile>
-            <id>Profile for JDK 24 Build</id>
-            <activation>
-              <jdk>24</jdk>
-            </activation>
-            <properties>
-                <jdk.build.target>24</jdk.build.target>
             </properties>
           </profile>
           <profile>
@@ -637,7 +619,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.13</version>
+                <version>0.8.14</version>
                 <executions>
                     <execution>
                         <id>start-agent</id>
@@ -886,7 +868,7 @@
         <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.13</version>
+            <version>0.8.14</version>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>


### PR DESCRIPTION
Remove unnecessary Java versions from Jenkins scripts and mvn profiles.

Update JaCoCo to the latest version.

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>