### PR TITLE
Update parsing/checking private key encoding and equals()

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/ECKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECKeyFactory.java
@@ -82,10 +82,10 @@ public final class ECKeyFactory extends KeyFactorySpi {
             }
 
         } catch (InvalidKeyException e) {
-            throw new InvalidKeySpecException("Inappropriate key specification: " + e.getMessage());
+            throw new InvalidKeySpecException("Inappropriate key specification: ", e);
         } catch (InvalidParameterSpecException e) {
             throw new InvalidKeySpecException(
-                    "Inappropriate Parameter specification: " + e.getMessage());
+                    "Inappropriate Parameter specification: ", e);
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECPrivateKey.java
@@ -103,17 +103,10 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
         this.provider = provider;
 
         try {
-            // Set parameters.
-            AlgorithmParameters algParams = this.algid.getParameters();
-            if (algParams == null) {
-                throw new IOException(
-                        "EC domain parameters must be encoded in the algorithm identifier");
-            }
-            this.params = algParams.getParameterSpec(ECParameterSpec.class);
-
             // Get from the encoding:
             //    * the private key as a BigInteger (this.s)
             //    * the public key, if available (this.pubKeyEncoded)
+            // and set parameters.
             parsePrivateKeyEncoding();
 
             // Create appropriate encoding and create ecKey.
@@ -140,20 +133,13 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
             algidOut.putDerValue(new DerValue(ecKey.getParameters()));
             this.algid = AlgorithmId
                     .parse(new DerValue(DerValue.tag_Sequence, algidOut.toByteArray()));
-
-            AlgorithmParameters algParams = this.algid.getParameters();
-            if (algParams == null) {
-                throw new IOException(
-                        "EC domain parameters must be encoded in the algorithm identifier");
-            }
-            this.params = algParams.getParameterSpec(ECParameterSpec.class);
-
             // Get private key encoding from ECKey.
             this.privKeyMaterial = ecKey.getPrivateKeyBytes();
 
             // Get from the encoding:
             //    * the private key as a BigInteger (this.s)
             //    * the public key, if available (this.pubKeyEncoded)
+            // and set parameters.
             parsePrivateKeyEncoding();
         } catch (Exception exception) {
             throw new InvalidKeyException("Failed to create EC private key", exception);
@@ -181,33 +167,13 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
         DerValue[] inputDerValue = privKeyBytesEncodedStream.getSequence(4);
         DerOutputStream outEncodedStream = new DerOutputStream();
 
-        if (inputDerValue.length < 2) {
-            throw new IOException("Incorrect EC private key encoding");
-        }
         BigInteger tempVersion1 = inputDerValue[0].getBigInteger();
-        if (tempVersion1.compareTo(BigInteger.ONE) != 0) {
-            throw new IOException("Decoding EC private key failed. The version must be 1");
-        }
         outEncodedStream.putInteger(tempVersion1);
 
         byte[] privateKeyBytes = inputDerValue[1].getOctetString();
         outEncodedStream.putOctetString(privateKeyBytes);
 
         byte[] encodedParams = this.getAlgorithmId().getEncodedParams();
-        if (inputDerValue.length > 2) { 
-            if (inputDerValue[2].isContextSpecific(TAG_PARAMETERS_ATTRS)) {
-                DerInputStream paramDerInputStream = inputDerValue[2].getData();
-                byte[] privateKeyParams = paramDerInputStream.toByteArray();
-                // Check against the existing parameters created by PKCS8Key.
-                if (!Arrays.equals(privateKeyParams, encodedParams)) {
-                    throw new IOException("Decoding EC private key failed. The params are not the same as PKCS8Key's");
-                }
-            } else if (!inputDerValue[2].isContextSpecific(TAG_PUBLIC_KEY_ATTRS)) {
-                // Unknown third+ element: we can throw, or ignore.
-                // Keeping old behavior would be to throw; but RFC allows only [0]/[1] here.
-                throw new IOException("Decoding EC private key failed. Unexpected tagged field in ECPrivateKey");
-            }
-        }
         // The native library needs the ASN.1 DER decoding of the private key to contain the parameters (i.e., the OID).
         outEncodedStream.write(
                     DerValue.createTag(DerValue.TAG_CONTEXT, true, TAG_PARAMETERS_ATTRS),
@@ -219,25 +185,69 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
     }
 
     /**
-     * Parse the private key encoding to:
+     * Check that the encoding is correct and at the same time
+     * parse the private key encoding to:
      * - get the key and set it as a BigInteger (i.e., this.s)
+     * - validate the parameters, if available
      * - get the public key, if available, and save its X.509 encoding
      *
-     * @throws IOException
+     * @throws InvalidKeyException
      */
-    private void parsePrivateKeyEncoding() throws IOException {
-        DerInputStream privKeyBytesEncodedStream = new DerInputStream(this.privKeyMaterial);
-        DerValue[] inputDerValue = privKeyBytesEncodedStream.getSequence(4);
-
-        byte[] privateKeyBytes = inputDerValue[1].getOctetString();
-        this.s = new BigInteger(1, privateKeyBytes);
-
-        for (int i = 2; i < inputDerValue.length; i++) {
-            DerValue v = inputDerValue[i];
-            if (v.isContextSpecific(TAG_PUBLIC_KEY_ATTRS)) {
-                DerValue bits = v.withTag(DerValue.tag_BitString);
-                this.pubKeyEncoded = new X509Key(this.algid, bits.data.getUnalignedBitString()).getEncoded();
+    private void parsePrivateKeyEncoding() throws InvalidKeyException {
+        // Parse private key material from PKCS8Key.decode()
+        try {
+            DerInputStream in = new DerInputStream(this.privKeyMaterial);
+            DerValue derValue = in.getDerValue();
+            if (derValue.tag != DerValue.tag_Sequence) {
+                throw new IOException("Not a SEQUENCE");
             }
+            DerInputStream data = derValue.data;
+            int version = data.getInteger();
+            if (version != 1) {
+                throw new IOException("Version must be 1");
+            }
+            byte[] privData = data.getOctetString();
+            this.s = new BigInteger(1, privData);
+
+            // Validate parameters stored from PKCS8Key.decode()
+            AlgorithmParameters algParams = this.algid.getParameters();
+            if (algParams == null) {
+                throw new InvalidKeyException("EC domain parameters must be "
+                    + "encoded in the algorithm identifier");
+            }
+            this.params = algParams.getParameterSpec(ECParameterSpec.class);
+
+            if (data.available() == 0) {
+                return;
+            }
+
+            DerValue value = data.getDerValue();
+            if (value.isContextSpecific(TAG_PARAMETERS_ATTRS)) {
+                byte[] privateKeyParams = value.getDataBytes();
+                byte[] encodedParams = this.getAlgorithmId().getEncodedParams();
+                // Check against the existing parameters created by PKCS8Key.
+                if (!Arrays.equals(privateKeyParams, encodedParams)) {
+                    throw new InvalidKeyException("Decoding EC private key failed. The params are not the same as PKCS8Key's");
+                }
+                if (data.available() == 0) {
+                    return;
+                }
+                value = data.getDerValue();
+            }
+
+            if (value.isContextSpecific(TAG_PUBLIC_KEY_ATTRS)) {
+                DerValue bits = value.withTag(DerValue.tag_BitString);
+                this.pubKeyEncoded = new X509Key(this.algid, bits.data.getUnalignedBitString()).getEncoded();
+            } else {
+                throw new InvalidKeyException("Unexpected value: " + value);
+            }
+
+            if (data.available() != 0) {
+                throw new InvalidKeyException("Encoding has more than 4 values.");
+            }
+
+        } catch (IOException | InvalidParameterSpecException e) {
+            throw new InvalidKeyException("Invalid EC private key", e);
         }
     }
 
@@ -323,5 +333,40 @@ final class ECPrivateKey extends PKCS8Key implements java.security.interfaces.EC
         if (destroyed) {
             throw new IllegalStateException("This key is no longer valid");
         }
+    }
+
+    /**
+     * Compares two private keys.
+     *
+     * The PKCS8Key.equals() method that compares encodings is used first.
+     *
+     * If that fails, we compare the private part of the key and the params to validate equivalence,
+     * since the keys might be equal but have different encodings if one or more of the optional
+     * parts are missing.
+     *
+     * @param object the object with which to compare
+     * @return {@code true} if this key is equal to the object argument; {@code false} otherwise.
+     */
+    @Override
+    public boolean equals(Object object) {
+        boolean sameEncoding = super.equals(object);
+        if (!sameEncoding) {
+            if (!(object instanceof java.security.interfaces.ECPrivateKey ecObj)) {
+                return false;
+            }
+
+            // 1. Compare the secret scalar (S)
+            if (!this.getS().equals(ecObj.getS())) {
+                return false;
+            }
+
+            // 2. Compare the Curve Parameters
+            ECParameterSpec s1 = this.getParams();
+            ECParameterSpec s2 = ecObj.getParams();
+
+            return ECUtils.equals(s1, s2);
+        }
+
+        return true;
     }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyImportInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECKeyImportInterop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2026
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -19,8 +19,10 @@ import java.security.spec.ECFieldFp;
 import java.security.spec.ECGenParameterSpec;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
+import java.security.spec.ECPrivateKeySpec;
 import java.security.spec.EllipticCurve;
 import java.security.spec.EncodedKeySpec;
+import java.security.spec.KeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
@@ -112,6 +114,52 @@ public class BaseTestECKeyImportInterop extends BaseTestJunit5Interop {
         // The original and new keys are the same
         assertTrue(Arrays.equals(publicKey2.getEncoded(), pubKeyBytes));
         assertTrue(Arrays.equals(privateKey2.getEncoded(), privKeyBytes));
+    }
+
+    @Test
+    public void testCreateKeyPairECImportCompareKeys() throws Exception {
+        doCreateKeyPairECImportCompareKeys(getProviderName(), getInteropProviderName());
+        doCreateKeyPairECImportCompareKeys(getInteropProviderName(), getProviderName());
+    }
+
+    private void doCreateKeyPairECImportCompareKeys(String createProviderName,
+            String importProviderName) throws Exception {
+
+        //final String methodName = "testCreateKeyPairECImportCompareKeys";
+
+        KeyPairGenerator keyPairGen = KeyPairGenerator.getInstance("EC", createProviderName);
+
+        keyPairGen.initialize(256);
+        KeyPair keyPair = keyPairGen.generateKeyPair();
+        PrivateKey privateKey = keyPair.getPrivate();
+        PublicKey publicKey = keyPair.getPublic();
+
+        byte[] publicKeyBytes = publicKey.getEncoded();
+        byte[] privKeyBytes = privateKey.getEncoded();
+
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", importProviderName);
+        EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(privKeyBytes);
+        PrivateKey privateKey2 = keyFactory.generatePrivate(privateKeySpec);
+
+        KeySpec privateKeySpec2 = keyFactory.getKeySpec(privateKey, ECPrivateKeySpec.class);
+        PrivateKey privateKey3 = keyFactory.generatePrivate(privateKeySpec2);
+
+        EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(publicKeyBytes);
+        PublicKey publicKey2 = keyFactory.generatePublic(publicKeySpec);
+
+        // The original and new keys are the same
+        boolean same = privateKey.equals(privateKey2);
+        assertTrue(same);
+        same = privateKey.equals(privateKey3);
+        assertTrue(same);
+        same = publicKey.equals(publicKey2);
+        assertTrue(same);
+
+        byte[] publicKey2Bytes = publicKey2.getEncoded();
+        byte[] privateKey2Bytes = privateKey2.getEncoded();
+
+        assertArrayEquals(publicKeyBytes, publicKey2Bytes);
+        assertArrayEquals(privKeyBytes, privateKey2Bytes);
     }
 
     @Test


### PR DESCRIPTION
The method that parses the private key encoding is updated to check the encoding's validity.

An `equals()` method is added that calls the `super.equals()` and, if that fails, directly compares the keys and params.

Several tests are, also, added to test key import, direct and interop, through `ECPrivateKeySpec`.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1091

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>