### PR TITLE
Restrict RSA paddings allowed through OpenJCEPlusFIPS

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -26,6 +26,8 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
 
     private static final boolean printFipsDeveloperModeWarning = Boolean.parseBoolean(System.getProperty("openjceplus.fips.devmodewarn", "true"));
 
+    private static final boolean allowNonOAEPFIPS = Boolean.parseBoolean(System.getProperty("com.ibm.openjceplusfips.allowNonOAEP", "false"));
+
     private static final String info = "OpenJCEPlusFIPS Provider implements the following:\n" +
 
             "Algorithm parameter                : AES, DiffieHellman, DSA, EC, GCM, OAEP, RSAPSS\n"
@@ -219,8 +221,21 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
                 "com.ibm.crypto.plus.provider.AESCipher", aliases));
 
         aliases = null;
+        Map<String, String> rsaAttr = new HashMap<>();
+
+        String supportedPaddings = "OAEPPADDING"
+                + "|OAEPWITHSHA1ANDMGF1PADDING"
+                + "|OAEPWITHSHA-1ANDMGF1PADDING";
+        if (allowNonOAEPFIPS) {
+            supportedPaddings += "|NOPADDING|PKCS1PADDING";
+        }
+        rsaAttr.put("SupportedModes", "ECB");
+        rsaAttr.put("SupportedPaddings", supportedPaddings);
+        rsaAttr.put("SupportedKeyClasses",
+                "java.security.interfaces.RSAPublicKey" +
+                "|java.security.interfaces.RSAPrivateKey");
         putService(new OpenJCEPlusService(jce, "Cipher", "RSA", "com.ibm.crypto.plus.provider.RSA",
-                aliases));
+                aliases, rsaAttr));
 
         aliases = new String[] {"AESWrap"};
         putService(new OpenJCEPlusService(jce, "Cipher", "AES/KW/NoPadding",

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSA.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSA.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class BaseTestRSA extends BaseTestCipher {
 
@@ -197,26 +198,36 @@ public class BaseTestRSA extends BaseTestCipher {
 
     @Test
     public void testRSACipher_PKCS1Padding() throws Exception {
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+
         encryptDecrypt("RSA/ECB/PKCS1Padding");
     }
 
     @Test
     public void testRSACipher_NoPadding() throws Exception {
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+
         encryptDecrypt("RSA/ECB/NoPadding");
     }
 
     @Test
     public void testRSACipher_ECB_PKCS1Padding() throws Exception {
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+
         encryptDecrypt("RSA/ECB/PKCS1Padding");
     }
 
     @Test
     public void testRSACipher_ECB_NoPadding() throws Exception {
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+
         encryptDecrypt("RSA/ECB/NoPadding");
     }
 
     @Test
     public void testRSACipher_ECB_ZeroPadding() throws Exception {
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+
         encryptDecrypt("RSA/ECB/ZeroPadding");
     }
 
@@ -228,11 +239,6 @@ public class BaseTestRSA extends BaseTestCipher {
     @Test
     public void testRSACipherForSSL() throws Exception {
         encryptDecrypt("RSAforSSL");
-    }
-
-    @Test
-    public void testRSACipher_SSL_PKCS1Padding() throws Exception {
-        encryptDecrypt("RSA/SSL/PKCS1Padding");
     }
 
     @Test
@@ -312,25 +318,22 @@ public class BaseTestRSA extends BaseTestCipher {
 
     @Test
     public void testRSAShortBuffer2() throws Exception {
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+
         String algorithm = "RSA/ECB/NoPadding";
         int outputByteLength = 64;
         int finalOffset = 65;
 
         try {
-
             Cipher cipher = Cipher.getInstance(algorithm, getProviderName());
 
             if (cipher.equals(null))
                 System.out.println("The cipher was null.");
 
             cipher.init(Cipher.ENCRYPT_MODE, rsaPub);
-
             byte[] newplainText2 = new byte[outputByteLength];
-
             cipher.doFinal(newplainText2, finalOffset);
-
             fail("Expected ShortBufferException did not occur");
-
         } catch (ShortBufferException ex) {
             assertTrue(true);
         }
@@ -360,6 +363,7 @@ public class BaseTestRSA extends BaseTestCipher {
 
     @Test
     public void testRSAIllegalMode() throws Exception {
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
 
         // Test RSA Cipher
         Cipher cp = Cipher.getInstance("RSA/ECB/PKCS1Padding", getProviderName());
@@ -376,7 +380,6 @@ public class BaseTestRSA extends BaseTestCipher {
 
         boolean success = decryptResultsMatch(cp.getAlgorithm(), plainText, newPlainText);
         assertTrue(success, "Decrypted text does not match expected");
-
     }
 
     @Test
@@ -386,26 +389,36 @@ public class BaseTestRSA extends BaseTestCipher {
 
     @Test
     public void testRSACipher_PKCS1Padding_getParams() throws Exception {
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+
         checkGetParamsNull("RSA/ECB/PKCS1Padding");
     }
 
     @Test
     public void testRSACipher_NoPadding_getParams() throws Exception {
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+
         checkGetParamsNull("RSA/ECB/NoPadding");
     }
 
     @Test
     public void testRSACipher_ECB_PKCS1Padding_getParams() throws Exception {
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+
         checkGetParamsNull("RSA/ECB/PKCS1Padding");
     }
 
     @Test
     public void testRSACipher_ECB_NoPadding_getParams() throws Exception {
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+
         checkGetParamsNull("RSA/ECB/NoPadding");
     }
 
     @Test
     public void testRSACipher_ECB_ZeroPadding_getParams() throws Exception {
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+
         checkGetParamsNull("RSA/ECB/ZeroPadding");
     }
 
@@ -417,11 +430,6 @@ public class BaseTestRSA extends BaseTestCipher {
     @Test
     public void testRSACipherForSSL_getParams() throws Exception {
         checkGetParamsNull("RSAforSSL");
-    }
-
-    @Test
-    public void testRSACipher_SSL_PKCS1Padding_getParams() throws Exception {
-        checkGetParamsNull("RSA/SSL/PKCS1Padding");
     }
 
     @Test

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInterop.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class BaseTestRSAKeyInterop extends BaseTestJunit5Interop {
 
@@ -475,6 +476,7 @@ public class BaseTestRSAKeyInterop extends BaseTestJunit5Interop {
 
     @Test
     public void testEncryptPlusDecryptJCE() {
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
 
         try {
 
@@ -514,6 +516,8 @@ public class BaseTestRSAKeyInterop extends BaseTestJunit5Interop {
 
     @Test
     public void testEncryptJCEDecryptPlus() {
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+
         byte[] msgBytes = ("This is a short message".getBytes());
         //long message to be encrypted and decrypted using RSA public and Private key;" + 
         //        "encrypt with JCE and decrypt with JCEPlus and vice versa").getBytes();

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestRSAKeyInteropBC.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class BaseTestRSAKeyInteropBC extends BaseTestJunit5Interop {
 
@@ -500,6 +501,7 @@ public class BaseTestRSAKeyInteropBC extends BaseTestJunit5Interop {
 
     @Test
     public void testEncryptPlusDecryptBC() {
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
 
         try {
 
@@ -543,6 +545,8 @@ public class BaseTestRSAKeyInteropBC extends BaseTestJunit5Interop {
 
     @Test
     public void testEncryptBCDecryptPlus() {
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+
         byte[] msgBytes = ("This is a short message".getBytes());
         //long message to be encrypted and decrypted using RSA public and Private key;" + 
         //        "encrypt with BC and decrypt with BCPlus and vice versa").getBytes();


### PR DESCRIPTION
This change adds attributes in the RSA service registration in the `OpenJCEPlusFIPS` provider to only support OAEP paddings.

It, also, update the `engineSetPadding()` method to only allow OAEP paddings to be set when the FIPS provider is used.

Tests are updated accordingly to skip invalid padding tests when running with `OpenJCEPlusFIPS`.

A temporary flag that allows the use of other paddings with `OpenJCEPlusFIPS` is introduced to facilitate migration of users utilizing the previous behaviour. The flag to be set to revert this behaviour is `-Dcom.ibm.openjceplusfips.allowNonOAEP=true`.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1036

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>