### PR TITLE
Remove aircompressor-0.27.jar dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -737,6 +737,10 @@
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-lang3</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>aircompressor</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -841,6 +845,10 @@
                 <exclusion>
                     <groupId>org.codehaus.plexus</groupId>
                     <artifactId>commons-compress</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>aircompressor</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
This update remove the aircompressor-0.27.jar dependency.