### PR TITLE
Fix encoding issue in RSAKey.c for z/OS

### DIFF
--- a/src/main/native/RSAKey.c
+++ b/src/main/native/RSAKey.c
@@ -66,6 +66,11 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_RSAKEY_1generate(
     }
 
     snprintf(bitStr, sizeof(bitStr), "%d", (int)numBits);
+
+#ifdef __MVS__
+    forceToAscii(bitStr); // Ensure the value is ASCII before passing to OCK
+#endif
+
 #ifdef __MVS__
 #pragma convert("ISO8859-1")
 #endif
@@ -87,6 +92,11 @@ Java_com_ibm_crypto_plus_provider_ock_NativeInterface_RSAKEY_1generate(
     }
 
     snprintf(expStr, sizeof(expStr), "%ld", (long)e);
+
+#ifdef __MVS__
+    forceToAscii(expStr); // Ensure the value is ASCII before passing to OCK
+#endif
+
 #ifdef __MVS__
 #pragma convert("ISO8859-1")
 #endif

--- a/src/main/native/Utils.c
+++ b/src/main/native/Utils.c
@@ -248,5 +248,17 @@ void throwOCKException(JNIEnv *env, int code, const char *msg) {
 }
 
 #ifdef __MVS__
+/* Manual EBCDIC to ASCII conversion for digits */
+void forceToAscii(char *s) {
+    while (*s) {
+        if (*s >= (char)0xF0 && *s <= (char)0xF9) {
+            *s = *s - (char)0xF0 + (char)0x30;
+        }
+        s++;
+    }
+}
+#endif
+
+#ifdef __MVS__
 #include "closed_Utils_c.h"
 #endif

--- a/src/main/native/Utils.h
+++ b/src/main/native/Utils.h
@@ -52,4 +52,8 @@ void ockCheckStatus(ICC_CTX* ctx);
 
 void throwOCKException(JNIEnv* env, int code, const char* msg);
 
+#ifdef __MVS__
+void forceToAscii(char* s);
+#endif
+
 #endif


### PR DESCRIPTION
This update fixes an encoding issue in RSAKey.c for z/OS that was caused by https://github.com/IBM/OpenJCEPlus/pull/1113.

See: https://github.com/IBM/OpenJCEPlus/issues/1142

Signed-off-by: Thomas-Ginader <thomas.ginader@ibm.com>