### PR TITLE
Fail OpenJCEPlus compilation on warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -472,6 +472,7 @@
                     <source>${jdk.build.target}</source>
                     <target>${jdk.build.target}</target>
                     <compilerArgs>
+                        <arg>-Werror</arg>
                         <arg>-XDignore.symbol.file</arg>
                         <arg>-Xlint:all</arg> 
                         <arg>-Xlint:-processing</arg>


### PR DESCRIPTION
Compilation will now fail if any warnings appear. Warnings that were previously appearing have been resolved so this option will make it easier to catch warnings as they appear, especially when backporting changes. This will not affect building OpenJDK.

Signed-off-by: Sabrina Lee <sabrinalee@ibm.com>

Back-ported from: #1141 