### PR TITLE
Remove aircompressor-0.27.jar dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -673,6 +673,10 @@
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-lang3</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>aircompressor</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -783,6 +787,10 @@
                 <exclusion>
                     <groupId>org.codehaus.plexus</groupId>
                     <artifactId>commons-compress</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>aircompressor</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
This is a back port PR from PR: https://github.com/IBM/OpenJCEPlus/pull/1143

This update remove the aircompressor-0.27.jar dependency.