### PR TITLE
Disallow weak RSA keys on macOS and Linux (aarch64) in FIPS developer mode

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -689,6 +689,32 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
         return new OpenJCEPlusFIPSContext();
     }
 
+    /**
+     * Check if the current platform is Mac or Linux on aarch64 architecture,
+     */
+    @Override
+    boolean isFIPS() {
+
+        if(super.isFIPS()) {
+            return true;
+        }
+
+        String osName = System.getProperty("os.name");
+        String osArch = System.getProperty("os.arch");
+
+        if (osName != null && osArch != null) {
+            boolean isMac = osName.toLowerCase().contains("mac");
+            boolean isLinuxAarch64 = osName.toLowerCase().contains("linux")
+                            && osArch.toLowerCase().contains("aarch64");
+
+            if (isMac || isLinuxAarch64) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     // Get SecureRandom to use for crypto operations. Returns a FIPS
     // approved SecureRandom to use. Ignore any user supplied
     // SecureRandom in FIPS mode.


### PR DESCRIPTION
This change prevents weak RSA key sizes (512 and 1024 bits) in OpenJCEPlusFIPS on macOS and Linux (aarch64) where FIPS behavior is simulated using developer mode.

Fixes: [#1076](https://github.ibm.com/runtimes/jit-crypto/issues/1076)

Signed-off-by: Mohit Rajbhar mohit.rajbhar@ibm.com