### PR TITLE
Fix potential memory leak in RSAPSS

### DIFF
--- a/src/main/native/ock/RsaPss.c
+++ b/src/main/native/ock/RsaPss.c
@@ -548,6 +548,7 @@ OCKDigest *allocateDigest(JNIEnv *env, ICC_CTX *ockCtx, jstring digestAlgo) {
         if (NULL == ockDigest->mdCtx) {
             ockCheckStatus(ockCtx);
             throwOCKException(env, 0, "ICC_EVP_MD_CTX_new failed");
+            FREE_N_NULL(ockDigest);
         } else {
             ICC_EVP_MD_CTX_init(ockCtx, ockDigest->mdCtx);
         }


### PR DESCRIPTION
When creating a new context with ICC_EVP_MD_CTX_new potential failures can occur. In the case that this API fails we should release the entire ockDigest structure upon failure.

Fixes: https://github.com/IBM/OpenJCEPlus/issues/1138

Signed-off-by: Jason Katonica <katonica@us.ibm.com>