### PR TITLE
Always report FIPS mode true on developer platforms

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -689,6 +689,15 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
         return new OpenJCEPlusFIPSContext();
     }
 
+    /**
+     * Indicate whether the platform is certified FIPS or when FIPS is simulated on non-certified platforms.
+     * @return true if FIPS is active (certified or simulated)
+     */
+    @Override
+    boolean isFIPS() {
+        return super.isFIPS() || !isFIPSCertifiedPlatform;
+    }
+
     // Get SecureRandom to use for crypto operations. Returns a FIPS
     // approved SecureRandom to use. Ignore any user supplied
     // SecureRandom in FIPS mode.


### PR DESCRIPTION
The OpenJCEPlusFIPS provider may run on platforms that support developer mode. On these systems, the provider should always report that it is operating in FIPS mode to ensure behavior is consistent with fully FIPS-certified platforms. This change simulates FIPS operation as closely as possible in development environments.

Fixes: [#1076](https://github.ibm.com/runtimes/jit-crypto/issues/1076)

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1166

Signed-off-by: Mohit Rajbhar <mohit.rajbhar@ibm.com>