### PR TITLE
Allow test reporter console to be enabled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <maven.build.timestamp.format>yyyyMMdd</maven.build.timestamp.format>
         <jmh.benchmark>ibm.jceplus.jmh.RunAll</jmh.benchmark>
         <jmh.benchmark.skip>true</jmh.benchmark.skip>
+        <consoleOutputReporter.disable>true</consoleOutputReporter.disable>
     </properties>
         <profiles>
           <profile>
@@ -284,7 +285,7 @@
                     </includes>
                     <reportFormat>plain</reportFormat>
                     <consoleOutputReporter>
-                      <disable>true</disable>
+                      <disable>${consoleOutputReporter.disable}</disable>
                     </consoleOutputReporter>
                     <statelessTestsetInfoReporter
                       implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">
@@ -417,7 +418,7 @@
                     </includes>
                     <reportFormat>plain</reportFormat>
                     <consoleOutputReporter>
-                      <disable>true</disable>
+                      <disable>${consoleOutputReporter.disable}</disable>
                     </consoleOutputReporter>
                     <statelessTestsetInfoReporter
                       implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">


### PR DESCRIPTION
Allow users to override the default behavior for console log supression behavior. Users will be able to pass the property
-DconsoleOutputReporter.disable=false to enable console output.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>