### PR TITLE
Revert "Fail OpenJCEPlus compilation on warnings"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -536,7 +536,6 @@
                     <source>${jdk.build.target}</source>
                     <target>${jdk.build.target}</target>
                     <compilerArgs>
-                        <arg>-Werror</arg>
                         <arg>-XDignore.symbol.file</arg>
                         <arg>-Xlint:all</arg>
                         <arg>-Xlint:-processing</arg>


### PR DESCRIPTION
This reverts commit 18634043484cc1113ad24a48a863b9af335511b2. Part of an effort to add back SunTLS* algorithms back into OpenJCEPlus temporarily, until a solution is found for appending SunJCE to the strict FIPS profile.

Signed-off-by: Sabrina Lee <sabrinalee@ibm.com>