### PR TITLE
Revert "Fail OpenJCEPlus compilation on warnings"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -472,7 +472,6 @@
                     <source>${jdk.build.target}</source>
                     <target>${jdk.build.target}</target>
                     <compilerArgs>
-                        <arg>-Werror</arg>
                         <arg>-XDignore.symbol.file</arg>
                         <arg>-Xlint:all</arg> 
                         <arg>-Xlint:-processing</arg>


### PR DESCRIPTION
This reverts commit 556ab9a42c0142c8b58fb08bc749ae28d9e5d5b3. Part of an effort to add back SunTLS* algorithms back into OpenJCEPlus temporarily, until a solution is found for appending SunJCE to the strict FIPS profile.

Signed-off-by: Sabrina Lee <sabrinalee@ibm.com>
Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1197