### PR TITLE
Add benchmark for RSA asymmetric cipher

### DIFF
--- a/JenkinsfilePerformance
+++ b/JenkinsfilePerformance
@@ -363,6 +363,7 @@ pipeline {
                                             'ibm.jceplus.jmh.PBEBenchmark', \
                                             'ibm.jceplus.jmh.PBKDF2Benchmark', \
                                             'ibm.jceplus.jmh.RandomBenchmark', \
+                                            'ibm.jceplus.jmh.RSACipherBenchmark', \
                                             'ibm.jceplus.jmh.RSAKeyGeneratorBenchmark', \
                                             'ibm.jceplus.jmh.RSASignatureBenchmark', \
                                             'ibm.jceplus.jmh.X448KeyExchangeBenchmark', \

--- a/src/test/java/ibm/jceplus/jmh/AESCipherBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/AESCipherBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -30,7 +30,7 @@ import org.openjdk.jmh.runner.options.Options;
 @State(Scope.Benchmark)
 @Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
-public class AESCipherBenchmark extends CipherBase {
+public class AESCipherBenchmark extends SymmetricCipherBase {
 
     @Param({"AES/ECB/PKCS5Padding", "AES/CBC/PKCS5Padding", "AES/CFB/PKCS5Padding",
             "AES/OFB/PKCS5Padding", "AES/CTR/NoPadding", "AES/GCM/NoPadding"})

--- a/src/test/java/ibm/jceplus/jmh/AESWrapBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/AESWrapBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -30,7 +30,7 @@ import org.openjdk.jmh.runner.options.Options;
 @State(Scope.Benchmark)
 @Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
-public class AESWrapBenchmark extends CipherBase {
+public class AESWrapBenchmark extends SymmetricCipherBase {
 
     @Param({"AESWrap", "AESWrapPad"})
     private String transformation;

--- a/src/test/java/ibm/jceplus/jmh/AsymmetricCipherBase.java
+++ b/src/test/java/ibm/jceplus/jmh/AsymmetricCipherBase.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright IBM Corp. 2026
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.InvalidParameterException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+
+abstract public class AsymmetricCipherBase extends JMHBase {
+
+    protected PublicKey publicKey = null;
+    protected PrivateKey privateKey = null;
+    protected SecureRandom random = new SecureRandom();
+
+    /**
+     * Sets a cipher test up for execution.
+     * @param keySize The size of the key.
+     * @param algorithm The algorithm to be used for key generation.
+     * @param provider The provider to use for key generation.
+     * @throws Exception
+     */
+    public void setup(int keySize, String algorithm, String provider)
+            throws Exception {
+        insertProvider(provider);
+
+        KeyPairGenerator kpg = null;
+        if (algorithm.contains("RSA")) {
+            String kpgProvider = provider;
+            if ("SunJCE".equalsIgnoreCase(provider)) {
+                kpgProvider = "SunRsaSign";
+            }
+            kpg = KeyPairGenerator.getInstance("RSA", kpgProvider);
+        } else {
+            throw new InvalidParameterException("Benchmark not supported for: " + algorithm);
+        }
+        
+        kpg.initialize(keySize);
+        KeyPair kp = kpg.generateKeyPair();
+
+        privateKey = kp.getPrivate();
+        publicKey = kp.getPublic();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/ChaCha20CipherBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/ChaCha20CipherBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -30,7 +30,7 @@ import org.openjdk.jmh.runner.options.Options;
 @State(Scope.Benchmark)
 @Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
-public class ChaCha20CipherBenchmark extends CipherBase {
+public class ChaCha20CipherBenchmark extends SymmetricCipherBase {
 
     @Param({"ChaCha20/None/NoPadding"})
     private String transformation;

--- a/src/test/java/ibm/jceplus/jmh/ChaCha20Poly1305CipherBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/ChaCha20Poly1305CipherBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -30,7 +30,7 @@ import org.openjdk.jmh.runner.options.Options;
 @State(Scope.Benchmark)
 @Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
-public class ChaCha20Poly1305CipherBenchmark extends CipherBase {
+public class ChaCha20Poly1305CipherBenchmark extends SymmetricCipherBase {
 
     @Param({"ChaCha20-Poly1305/None/NoPadding"})
     private String transformation;

--- a/src/test/java/ibm/jceplus/jmh/DESedeCipherBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/DESedeCipherBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -30,7 +30,7 @@ import org.openjdk.jmh.runner.options.Options;
 @State(Scope.Benchmark)
 @Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
-public class DESedeCipherBenchmark extends CipherBase {
+public class DESedeCipherBenchmark extends SymmetricCipherBase {
 
     @Param({"DESede/ECB/PKCS5Padding", "DESede/CBC/PKCS5Padding"})
     private String transformation;

--- a/src/test/java/ibm/jceplus/jmh/RSACipherBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/RSACipherBenchmark.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright IBM Corp. 2026
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+import javax.crypto.Cipher;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class RSACipherBenchmark extends AsymmetricCipherBase {
+
+    private Map<String, Cipher> encryptCiphers = new HashMap<>();
+    private Map<String, Cipher> decryptCiphers = new HashMap<>();
+
+    private Map<String, byte[]> plaintexts = new HashMap<>();
+    private Map<String, byte[]> ciphertexts = new HashMap<>();
+
+    @Param({"2048"})
+    private int keySize;
+
+    @Param({"OpenJCEPlus", "SunJCE"})
+    private String provider;
+
+    @Setup
+    public void setup() throws Exception {
+        super.setup(keySize, "RSA", provider);
+
+        Map<String, Integer> paddings = new HashMap<>();
+        paddings.put("NoPadding", 0);
+        paddings.put("PKCS1Padding", 11);
+        paddings.put("OAEPPadding", (2 * 20 + 2)); // SHA-1 size is 20 bytes
+
+        for (String padding : paddings.keySet()) {
+            encryptCiphers.put(padding, Cipher.getInstance("RSA/ECB/" + padding, provider));
+            decryptCiphers.put(padding, Cipher.getInstance("RSA/ECB/" + padding, provider));
+        }
+
+        for (Entry<String, Integer> entry : paddings.entrySet()) {
+            int payloadSize = (keySize / 8) - entry.getValue();
+            byte[] plaintext = new byte[payloadSize];
+            random.nextBytes(plaintext);
+            plaintexts.put(entry.getKey(), plaintext);
+
+            Cipher ec = encryptCiphers.get(entry.getKey());
+            ec.init(Cipher.ENCRYPT_MODE, publicKey);
+
+            if (plaintext.length > 0) {
+                ciphertexts.put(entry.getKey(), ec.doFinal(plaintext));
+            }
+
+            Cipher dc = decryptCiphers.get(entry.getKey());
+            dc.init(Cipher.DECRYPT_MODE, privateKey);
+        }
+    }
+
+    @Benchmark
+    public byte[] benchmarkEncryption_NoPadding() throws Exception {
+        return encryptCiphers.get("NoPadding").doFinal(plaintexts.get("NoPadding"));
+    }
+
+    @Benchmark
+    public byte[] benchmarkDecryption_NoPadding() throws Exception {
+        return decryptCiphers.get("NoPadding").doFinal(ciphertexts.get("NoPadding"));
+    }
+
+    @Benchmark
+    public byte[] benchmarkEncryption_PKCS1Padding() throws Exception {
+        return encryptCiphers.get("PKCS1Padding").doFinal(plaintexts.get("PKCS1Padding"));
+    }
+
+    @Benchmark
+    public byte[] benchmarkDecryption_PKCS1Padding() throws Exception {
+        return decryptCiphers.get("PKCS1Padding").doFinal(ciphertexts.get("PKCS1Padding"));
+    }
+
+    @Benchmark
+    public byte[] benchmarkEncryption_OAEPPadding() throws Exception {
+        return encryptCiphers.get("OAEPPadding").doFinal(plaintexts.get("OAEPPadding"));
+    }
+
+    @Benchmark
+    public byte[] benchmarkDecryption_OAEPPadding() throws Exception {
+        return decryptCiphers.get("OAEPPadding").doFinal(ciphertexts.get("OAEPPadding"));
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = RSACipherBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/ibm/jceplus/jmh/SymmetricCipherBase.java
+++ b/src/test/java/ibm/jceplus/jmh/SymmetricCipherBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -16,7 +16,7 @@ import javax.crypto.spec.ChaCha20ParameterSpec;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 
-abstract public class CipherBase extends JMHBase {
+abstract public class SymmetricCipherBase extends JMHBase {
 
     protected byte[] plaintext = null;
     protected SecretKey secretKey = null;


### PR DESCRIPTION
A new benchmark to measure `RSA` ciphers with different paddings is added.

The `CipherBase` is split into two separate classes, namely `AsymmetricCipherBase` and `SymmetricCipherBase` to account for the differences.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1170

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>