### PR TITLE
Disable crypto OS helpers on z/OS in FIPS

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/base/GCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/GCMCipher.java
@@ -23,7 +23,10 @@ public final class GCMCipher {
     private static final String DISABLE_GCM_ACCELERATION = "com.ibm.crypto.provider.DisableGCMAcceleration";
     private static final boolean disableGCMAcceleration = Boolean.parseBoolean(System.getProperty(DISABLE_GCM_ACCELERATION));
     private static final String debPrefix = "GCMCipher";
-    private static long GCMHardwareFunctionPtr = 0;
+
+    // This tracks if the HARDWARE actually supports GCM (Checked once)
+    // 0 = Not checked, 1 = Supported, -1 = Not supported
+    private static long actualHardwareSupport = 0;
 
     static final int parameterBlockSize = 80;
     static final int TAADLOffset = 48;
@@ -189,10 +192,20 @@ public final class GCMCipher {
         int aadLen = authenticationData.length;
 
         long gcmCtx = getGCMContext(false, key.length, ockContext, provider);
+        long GCMHardwareFunctionPtr;
 
-        if (GCMHardwareFunctionPtr == 0)
-            GCMHardwareFunctionPtr = NativeInterface
-                    .do_GCM_checkHardwareGCMSupport(ockContext.getId());
+        // The OS_Helper functions are not NIST certified, thus they can't be used in FIPS mode.
+        if (ockContext.isFIPS()) {
+            // FIPS always bypasses hardware, but doesn't change the global hardware check result
+            GCMHardwareFunctionPtr = -1;
+        } else {
+            // Non-FIPS: Check the hardware capability
+            if (actualHardwareSupport == 0) {
+                // This can be synchronized to prevent multiple JNI calls.
+                actualHardwareSupport = NativeInterface.do_GCM_checkHardwareGCMSupport(ockContext.getId());
+            }
+            GCMHardwareFunctionPtr = actualHardwareSupport;
+        }
 
         if (iv.length + key.length + aadLen <= FastJNIParameterBufferSize && !disableGCMAcceleration
                 && (inputLen <= FastJNIInputBufferSize || GCMHardwareFunctionPtr != -1)) {
@@ -317,10 +330,21 @@ public final class GCMCipher {
         int aadLen = authenticationData.length;
 
         long gcmCtx = getGCMContext(true, key.length, ockContext, provider);
+        long GCMHardwareFunctionPtr;
 
-        if (GCMHardwareFunctionPtr == 0)
-            GCMHardwareFunctionPtr = NativeInterface
-                    .do_GCM_checkHardwareGCMSupport(ockContext.getId());
+        // The OS_Helper functions are not NIST certified, thus they can't be used in FIPS mode.
+        if (ockContext.isFIPS()) {
+            // FIPS always bypasses hardware, but doesn't change the global hardware check result
+            GCMHardwareFunctionPtr = -1;
+        } else {
+            // Non-FIPS: Check the hardware capability
+            if (actualHardwareSupport == 0) {
+                // This can be synchronized to prevent multiple JNI calls.
+                actualHardwareSupport = NativeInterface.do_GCM_checkHardwareGCMSupport(ockContext.getId());
+            }
+            GCMHardwareFunctionPtr = actualHardwareSupport;
+        }
+
         if (iv.length + key.length + aadLen + tagLen <= FastJNIParameterBufferSize
                 && (inputLen <= FastJNIInputBufferSize || GCMHardwareFunctionPtr != -1)) {
             FastJNIBuffer parameters = GCMCipher.parameterBuffer.get();
@@ -442,7 +466,7 @@ public final class GCMCipher {
         if (rc != 0) {
             throw new OCKException(ErrorCodes.get(rc));
         }
-        
+
         //OCKDebug.Msg (debPrefix, methodName, "Returning length= " +  len);
         return len;
     }
@@ -500,7 +524,7 @@ public final class GCMCipher {
         //OCKDebug.Msg(debPrefix,methodName, "gcmCtx = " + gcmCtx );
 
         //To-Do - replace false with actual logic
-    
+
         //OCKDebug.Msg (debPrefix, methodName, "key.length :" + key.length + " iv.length :" + iv.length + " inputOffset :" + inputOffset);
         //OCKDebug.Msg (debPrefix, methodName, " inputLen :" + inputLen + " aadLen :" + aadLen + " tagLen :" + tagLen);
         //OCKDebug.Msg (debPrefix, methodName, "outputOffset :" + String.valueOf(outputOffset));
@@ -861,7 +885,7 @@ public final class GCMCipher {
         if (rc != 0) {
             throw new OCKException(ErrorCodes.get(rc));
         }
-        
+
         //OCKDebug.Msg(debPrefix, methodName,  "outLen=" + outLen + " output=",  output);
         return outLen;
     }
@@ -906,8 +930,8 @@ public final class GCMCipher {
         }
     }
 
-    /* 
-     * This method will be called by init/doFinal with no update calls. This won't 
+    /*
+     * This method will be called by init/doFinal with no update calls. This won't
      * look at what is buffered.
      */
     public static int getOutputSizeLegacy(int inputLen, boolean encrypting, int tLen) {

--- a/src/main/java/com/ibm/crypto/plus/provider/base/SymmetricCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/SymmetricCipher.java
@@ -49,7 +49,7 @@ public final class SymmetricCipher {
     /* private final static String debPrefix = "SymCipher"; Adding Debug causes test cases to fail */
     int paramOffset;
     FastJNIBuffer parametersBuffer = null;
-    // GSKit code adds 16 to the input buffer length for every Update  and provide a 
+    // GSKit code adds 16 to the input buffer length for every Update  and provide a
     // 16  byte buffer for the Final which has no input data.
     private final int OCK_ENCRYPTION_RESIDUE = 16;
     //final String debPrefix = "SymmetricCipher";
@@ -86,14 +86,14 @@ public final class SymmetricCipher {
         String algName;
         if (keysize == 16)
             algName = modeUpperCase.equals("ECB") ? "RC2" : "RC2-" + modeUpperCase;
-        else 
+        else
             algName = modeUpperCase.equals("ECB") ? "RC2" : "RC2-40-" + modeUpperCase;
         return getInstance(ockContext, algName, padding, provider);
     }
 
     public static SymmetricCipher getInstanceRC4(OCKContext ockContext, int keysize,
             OpenJCEPlusProvider provider) throws OCKException {
-        String algName = keysize == 16 ? "RC4" : "RC4-40"; 
+        String algName = keysize == 16 ? "RC4" : "RC4-40";
         return getInstance(ockContext, algName, Padding.NoPadding, provider);
     }
 
@@ -142,13 +142,18 @@ public final class SymmetricCipher {
         // Check whether used algorithm is CBC and whether hardware supports
         this.provider = provider;
         boolean isHardwareSupport = false;
-        if (hardwareEnabled.containsKey(ockContext))
-            isHardwareSupport = hardwareEnabled.get(ockContext);
-        else {
-            hardwareFunctionPtr = checkHardwareSupport(ockContext.getId());
-            isHardwareSupport = (hardwareFunctionPtr == 1) ? true : false;
-            hardwareEnabled.put(ockContext, isHardwareSupport);
+
+        // The OS_Helper functions are not NIST certified, thus they can't be used in FIPS mode.
+        if (!ockContext.isFIPS()) {
+            if (hardwareEnabled.containsKey(ockContext))
+                isHardwareSupport = hardwareEnabled.get(ockContext);
+            else {
+                hardwareFunctionPtr = checkHardwareSupport(ockContext.getId());
+                isHardwareSupport = (hardwareFunctionPtr == 1) ? true : false;
+                hardwareEnabled.put(ockContext, isHardwareSupport);
+            }
         }
+
         use_z_fast_command = "AES".equals(cipherName.substring(0, 3))
                 && "CBC".equals(cipherName.substring(cipherName.length() - 3)) && isHardwareSupport;
 
@@ -292,7 +297,7 @@ public final class SymmetricCipher {
     /**
      * OCKC always oversizes the buffer by 16 bytes (i.e. 128 bits).
      *
-     * This buffer is larger than what end user application will provide typically as a 
+     * This buffer is larger than what end user application will provide typically as a
      * buffer. This method calculates the amount of space that is needed by OCKC in order
      * to perform its operations.
      *


### PR DESCRIPTION
OS helper functions for hardware crypto (GCM and SymmetricCipher) should be disabled in FIPS mode. This update checks if FIPS mode is enabled, and if so, the appropriate crypto OS helpers are disabled.

Signed-off-by: Thomas-Ginader <thomas.ginader@ibm.com>