### PR TITLE
Print current benchmark info in log and fix RandomBenchmark

### DIFF
--- a/src/test/java/ibm/jceplus/jmh/JMHBase.java
+++ b/src/test/java/ibm/jceplus/jmh/JMHBase.java
@@ -9,6 +9,7 @@
 package ibm.jceplus.jmh;
 
 import java.io.File;
+import java.lang.reflect.Field;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.security.Provider;
@@ -121,7 +122,33 @@ abstract public class JMHBase {
         }
     }
 
+    private void logBenchmark() throws IllegalAccessException {
+        // JMH auto-generates multiple subclasses of the original benchmark.
+        Class<?> subClass = this.getClass();
+        Class<?> originalClass = subClass.getSuperclass();
+        while (originalClass != null && originalClass.getSimpleName().contains("_jmhType")) {
+            originalClass = originalClass.getSuperclass();
+        }
+        if (originalClass != null) {
+            System.out.println("Running " + originalClass.getSimpleName() + " with:");
+            Field[] allFields = originalClass.getDeclaredFields();
+            for (Field field : allFields) {
+                field.setAccessible(true);
+                if ((field.getType() == String.class)
+                    || (field.getType() == int.class)
+                ) {
+                    System.out.println("\t" + field.getName() + " = " + field.get(this));
+                }
+            }
+        } else {
+            System.out.println("Running " + subClass.getSimpleName() + ":");
+            System.out.println("\tNote: Failed to get original benchmark name");
+        }
+    }
+
     protected void setup(String provider) throws Exception {
+        logBenchmark();
+        
         if (allowedProviders == null) {
             allowedProviders = getAllowedProviders();
         }

--- a/src/test/java/ibm/jceplus/jmh/RandomBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/RandomBenchmark.java
@@ -43,7 +43,7 @@ public class RandomBenchmark extends JMHBase {
 
     @Setup
     public void setup() throws Exception {
-        String[] algAndProvider = randomToTest.split("|");
+        String[] algAndProvider = randomToTest.split("\\|");
         String algorithm = algAndProvider[0];
         String provider = algAndProvider[1];
         super.setup(provider);


### PR DESCRIPTION
For the benchmark currently running, its name and associated parameters are printed in the log.

Also, a fix is made to properly split the parameter string in the `RandomBenchmark`.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1303

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>