### PR TITLE
Migrate CI CD infrastructure to latest GA version

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Semeru JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '21.0.9+10.0.LTS'
+          java-version: '21.0.10+7.0.LTS'
           distribution: 'temurin'
           architecture: 'x64'
       # Uncomment to capture all files in the runner for debugging purposes.          

--- a/utils.groovy
+++ b/utils.groovy
@@ -103,6 +103,26 @@ def getBinaries(hardware, software) {
 }
 
 /*
+ * Constructs the appropriate Semeru JDK download URL based on the Java version,
+ * hardware platform, and software OS. Supports both latest GA releases and
+ * specific version releases using the AdoptOpenJDK API.
+ */
+def getJavaDownloadUrl(javaVersion, hardware, software, javaRelease) {
+    def java_link = ""
+    
+    if (javaRelease == "") {
+        // Use latest GA version
+        java_link = "https://api.adoptopenjdk.net/v3/binary/latest/${javaVersion}/ga/${software}/${hardware}/jdk/openj9/normal/ibm?project=jdk"
+    } else {
+        // Use specific version
+        def java_release_link = javaRelease.replace("+", "%2B")
+        java_link = "https://api.adoptopenjdk.net/v3/binary/version/${java_release_link}/${software}/${hardware}/jdk/openj9/normal/ibm?project=jdk"
+    }
+    
+    return java_link
+}
+
+/*
  * Figure out the proper URL, get the Semeru JDK,
  * extract it and rename the containing folder to
  * be used later on.
@@ -117,13 +137,8 @@ def getJava(hardware, software) {
         hardware = "x64"
     }
 
-    def java_link = ""
-    if (JAVA_RELEASE == "") {
-        java_link = "https://api.adoptopenjdk.net/v3/binary/latest/${JAVA_VERSION}/ga/${software}/${hardware}/jdk/openj9/normal/ibm?project=jdk"
-    } else {
-        def java_release_link = JAVA_RELEASE.replace("+", "%2B")
-        java_link = "https://api.adoptopenjdk.net/v3/binary/version/${java_release_link}/${software}/${hardware}/jdk/openj9/normal/ibm?project=jdk"
-    }
+    // Get the download URL using the helper method that uses an API
+    def java_link = getJavaDownloadUrl(JAVA_VERSION, hardware, software, JAVA_RELEASE)
 
     dir("java") {
         sh "curl -LJkO ${java_link}"


### PR DESCRIPTION
Our github action and Jenkins
pipe lines should be updated accordingly.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1304