### PR TITLE
Support for Artifactory URL downloads in pipelines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -364,8 +364,14 @@ pipeline {
         string(name: 'JAVA_RELEASE', defaultValue: '', description: '\
             Indicate a specific Java release that you want to use to build your branch.<br> \
             If left empty, the default release for the chosen version will be used.<br> \
+            <br><b>Option 1: Specify a release version</b><br> \
             Specify the full name of the release.<br> \
-            (i.e., jdk-&ltjdk version&gt_openj9-&ltopenj9 version&gt => eg., jdk-21.0.2+13_openj9-0.43.0)')
+            (i.e., jdk-&ltjdk version&gt_openj9-&ltopenj9 version&gt => eg., jdk-21.0.2+13_openj9-0.43.0)<br> \
+            <br><b>Option 2: Specify an Artifactory URL</b><br> \
+            Provide a full URL to a Java build hosted on na.artifactory.swg-devops.com.<br> \
+            The URL must contain "na.artifactory.swg-devops.com" or the build will fail.<br> \
+            Example: https://na.artifactory.swg-devops.com/artifactory/path/to/java.tar.gz<br> \
+            Note: Artifactory credentials will be used automatically for download.')
         string(name: 'OCK_RELEASE', defaultValue: '', description: '\
             Indicate the specific release of the OCK binaries that you want to use to build your branch.<br> \
             If left empty, the latest release will be used.<br> \

--- a/JenkinsfilePerformance
+++ b/JenkinsfilePerformance
@@ -326,8 +326,14 @@ pipeline {
         string(name: 'JAVA_RELEASE', defaultValue: '', description: '\
             Indicate a specific Java release that you want to use to build your branch.<br> \
             If left empty, the default release for the chosen version will be used.<br> \
+            <br><b>Option 1: Specify a release version</b><br> \
             Specify the full name of the release.<br> \
-            (i.e., jdk-&ltjdk version&gt_openj9-&ltopenj9 version&gt => eg., jdk-21.0.2+13_openj9-0.43.0)')
+            (i.e., jdk-&ltjdk version&gt_openj9-&ltopenj9 version&gt => eg., jdk-21.0.2+13_openj9-0.43.0)<br> \
+            <br><b>Option 2: Specify an Artifactory URL</b><br> \
+            Provide a full URL to a Java build hosted on na.artifactory.swg-devops.com.<br> \
+            The URL must contain "na.artifactory.swg-devops.com" or the build will fail.<br> \
+            Example: https://na.artifactory.swg-devops.com/artifactory/path/to/java.tar.gz<br> \
+            Note: Artifactory credentials will be used automatically for download.')
         string(name: 'OCK_RELEASE', defaultValue: '', description: '\
             Indicate the specific release of the OCK binaries that you want to use to build your branch.<br> \
             If left empty, the latest release will be used.<br> \

--- a/utils.groovy
+++ b/utils.groovy
@@ -149,12 +149,37 @@ def getJava(hardware, software) {
         hardware = "x64"
     }
 
-    // Get the download URL using the helper method that uses an API
-    def java_link = getJavaDownloadUrl(JAVA_VERSION, hardware, software, JAVA_RELEASE)
+    def java_link = ""
+    
+    // Check if JAVA_RELEASE is a URL that contains artifactory.
+    if (JAVA_RELEASE.contains("https://na.artifactory.swg-devops.com")) {
+        // JAVA_RELEASE is an Artifactory URL
+        java_link = JAVA_RELEASE
+        echo "Using Artifactory URL from JAVA_RELEASE: ${java_link}"
+    } else if (JAVA_RELEASE.startsWith("http://") || JAVA_RELEASE.startsWith("https://")) {
+        // JAVA_RELEASE is a URL but not from Artifactory - fail the build
+        error("JAVA_RELEASE contains a URL that is not from na.artifactory.swg-devops.com. Only Artifactory URLs are supported.")
+    } else {
+        // JAVA_RELEASE is a version string or empty - use the API
+        java_link = getJavaDownloadUrl(JAVA_VERSION, hardware, software, JAVA_RELEASE)
+        echo "Using AdoptOpenJDK API URL: ${java_link}"
+    }
+
+    // Determine file extension based on platform
+    def file_extension = "tar.gz"
+    if (software == "windows") {
+        file_extension = "zip"
+    }
 
     dir("java") {
         def java_file = ""
-        if (software == "zos") {
+        // Download Java - use credentials if it's an Artifactory URL
+        if (JAVA_RELEASE.contains("na.artifactory.swg-devops.com")) {
+            java_file = "java.${file_extension}"
+            withCredentials([usernamePassword(credentialsId: '7c1c2c28-650f-49e0-afd1-ca6b60479546', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
+                sh "curl -u \$ARTIFACTORY_USERNAME:\$ARTIFACTORY_PASSWORD ${java_link} > ${java_file}"
+            }
+        } else if (software == "zos") {
             sh "curl -LJkO -u $ARTIFACTORY_USERNAME:$ARTIFACTORY_PASSWORD ${java_link}"
             java_file = sh (
                 script: 'ls | grep \'pax\'',
@@ -180,15 +205,26 @@ def getJava(hardware, software) {
         }
         sh "rm $java_file"
 
-        def java_prefix = "jdk-"
-        if (software == "zos") {
-            java_prefix = "J"
-        }
-        def java_folder = sh (
-            script: "ls | grep \'${java_prefix}${JAVA_VERSION}\'",
+        // Check if folder is already named 'jdk' (Artifactory downloads) or needs renaming
+        def folderCheck = sh (
+            script: "ls -d jdk 2>/dev/null || echo ''",
             returnStdout: true
         ).trim()
-        fileOperations([folderRenameOperation(destination: 'jdk', source: "$java_folder")])
+        
+        if (folderCheck == "") {
+            // Folder is not named 'jdk', so find and rename it
+            def java_prefix = "jdk-"
+            if (software == "zos") {
+                java_prefix = "J"
+            }
+            def java_folder = sh (
+                script: "ls | grep \'${java_prefix}${JAVA_VERSION}\'",
+                returnStdout: true
+            ).trim()
+            fileOperations([folderRenameOperation(destination: 'jdk', source: "$java_folder")])
+        } else {
+            echo "Java folder already named 'jdk', no rename needed"
+        }
 
         // AIX and z/OS always loads the bundled version of native libraries. We delete them to
         // ensure that the one provided by the user is utilized.


### PR DESCRIPTION
Enhanced the JAVA_RELEASE parameter to accept either a release version or a direct Artifactory URL for Java builds. This provides more flexibility in specifying custom Java builds during CI/CD execution.

Changes:
- Updated Jenkinsfile and JenkinsfilePerformance parameter descriptions to document two options: release version or Artifactory URL
- Modified utils.groovy getJava() function to detect and handle Artifactory URLs (na.artifactory.swg-devops.com)
- Added validation to reject non-Artifactory URLs for security
- Implemented authenticated downloads using ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD credentials for Artifactory URLs
- Maintained backward compatibility with existing release version format
- Detect if JDK extracted already results in a jdk directory

The implementation ensures that only trusted Artifactory URLs are accepted and automatically applies authentication when downloading from Artifactory, while preserving the existing behavior for standard release versions.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1374

Signed-off-by: Jason Katonica <katonica@us.ibm.com>