### PR TITLE
Add Jenkinsfile option to build on z/OS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# encode selected files as ASCII or EBCDIC
+buildNative.sh  		 git-encoding=utf-8 zos-working-tree-encoding=ibm-1047
+checkstyle.xml           git-encoding=utf-8 zos-working-tree-encoding=utf-8

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,7 @@ import groovy.transform.Field;
 @Field boolean X86_64_LINUX
 @Field boolean PPC64LE_LINUX
 @Field boolean S390X_LINUX
+@Field boolean S390X_ZOS
 @Field boolean X86_64_WINDOWS
 @Field boolean AARCH64_MAC
 @Field boolean X86_64_MAC
@@ -33,18 +34,41 @@ import groovy.transform.Field;
 @Field TIMEOUT_TIME
 @Field externalLibrary
 
+GIT_BRANCH_NAME = ""
+if (env.CHANGE_BRANCH) {
+    GIT_BRANCH_NAME = "${CHANGE_BRANCH}"
+} else {
+    GIT_BRANCH_NAME = "${BRANCH_NAME}"
+}
+
+GIT_REPO_NAME = ""
+if (env.CHANGE_FORK) {
+    GIT_REPO_NAME = "${CHANGE_FORK}"
+} else {
+    GIT_REPO_NAME = "IBM"
+}
+
 /*
  * Clone the branch from the repo specified to
  * get the appropriate OpenJCEPlus code to build.
  */
-def cloneOpenJCEPlus() {
+def cloneOpenJCEPlus(software) {
+    gitPrefix = "https://"
+    gitSeparator = "/"
+    if (software == "zos") {
+        gitPrefix = "git@"
+        gitSeparator = ":"
+    }
     dir("openjceplus/OpenJCEPlus") {
+        // Note that z/OS will need to use the SSH URL for cloning. e.g. git@github.com:IBM/OpenJCEPlus.git
         if ((OPENJCEPLUS_REPO == "") && (OPENJCEPLUS_BRANCH == "")) {
             echo "Clone using default branch and repository."
-            checkout scm
+            deleteDir()
+            sh "git clone -b ${GIT_BRANCH_NAME} ${gitPrefix}github.com${gitSeparator}${GIT_REPO_NAME}/OpenJCEPlus.git ."
         } else {
             echo "Clone using ${OPENJCEPLUS_BRANCH} from ${OPENJCEPLUS_REPO}"
-            git branch: "${OPENJCEPLUS_BRANCH}", url: "${OPENJCEPLUS_REPO}"
+            deleteDir()
+            sh "git clone -b ${OPENJCEPLUS_BRANCH} ${OPENJCEPLUS_REPO} ."
         }
     }
 }
@@ -72,6 +96,13 @@ def getPlatforms() {
 
     if (S390X_LINUX == "true") {
         platforms.add("s390x_linux")
+    }
+
+    if (S390X_ZOS == "true") {
+        if (!params.JAVA_VERSION.equals("25")) {
+            error "The s390x_zos platform is only supported for Java 25."
+        }
+        platforms.add("s390x_zos")
     }
 
     if (X86_64_WINDOWS == "true") {
@@ -129,7 +160,7 @@ def getTestFlag(hardware, software) {
  * @return              The URL to the uploaded file
  */
 def archive(platform, iteration) {
-    
+
     // Create compressed file containing build.
     def ending = ".tar.gz"
     def filename = "openjceplus-$iteration-$platform$ending"
@@ -210,6 +241,8 @@ def run(platform) {
             if (software == "aix") {
                 // Java 25+ requires C++17.1 runtime. Otherwise crashes occur.
                 nodeTags = "hw.arch.${node_hardware}&&sw.os.aix.7_2&&sw.tool.c++runtime.17_1&&ci.role.build"
+            } else if (software == "zos") {
+                nodeTags = "ci.project.openj9&&ci.role.build&&hw.arch.${node_hardware}&&sw.os.zos.3_2"
             } else {
 
                 // Machines tagged as ci.role.test are expected to have
@@ -229,7 +262,7 @@ def run(platform) {
             echo "${nodeTags}"
 
             node("$nodeTags") {
-                cloneOpenJCEPlus()
+                cloneOpenJCEPlus(software)
                 echo "OpenJCEPlus cloned"
                 dir("openjceplus/OpenJCEPlus") {
                     externalLibrary = load("./utils.groovy")
@@ -238,11 +271,10 @@ def run(platform) {
                     withCredentials([usernamePassword(credentialsId: '7c1c2c28-650f-49e0-afd1-ca6b60479546', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
                         externalLibrary.getJava(hardware, software)
                     }
-                    
                     echo "Java fetched"
                     externalLibrary.getBinaries(hardware, software)
                     echo "Binaries fetched"
-                    externalLibrary.getMaven()
+                    externalLibrary.getMaven(software)
                     echo "Maven fetched"
                     def command = "install"
                     command += getTestFlag(hardware, software)
@@ -297,6 +329,8 @@ pipeline {
             Build for ppc64le_linux platform')
         booleanParam(name: 's390x_linux', defaultValue: false, description: '\
             Build for s390x_linux platform')
+        booleanParam(name: 's390x_zos', defaultValue: false, description: '\
+            Build for s390x_zos platform')
         booleanParam(name: 'x86_64_windows', defaultValue: false, description: '\
             Build for x86-64_windows platform')
         booleanParam(name: 'aarch64_mac', defaultValue: false, description: '\
@@ -322,7 +356,7 @@ pipeline {
         )
         string(name: 'OPENJCEPLUS_REPO', defaultValue: '', description: '\
             The OpenJCEPlus repo to be used. When not specified this will default to the repository scanned by this multibranch pipeline.\
-            Typically this will use https://github.com/IBM/OpenJCEPlus')
+            Typically this will use https://github.com/IBM/OpenJCEPlus. For z/OS, this requires the SSH URL e.g. git@github.com:IBM/OpenJCEPlus.git.')
         string(name: 'OPENJCEPLUS_BRANCH', defaultValue: '', description: '\
             The OpenJCEPlus branch to be used. When not specified this will default to the branch scanned by this multibranch pipeline.')
         string(name: 'JAVA_VERSION', defaultValue: '26', description: '\
@@ -410,6 +444,7 @@ pipeline {
                         X86_64_LINUX = "${params.x86_64_linux}"
                         PPC64LE_LINUX="${params.ppc64le_linux}"
                         S390X_LINUX="${params.s390x_linux}"
+                        S390X_ZOS="${params.s390x_zos}"
                         X86_64_WINDOWS="${params.x86_64_windows}"
                         AARCH64_MAC="${params.aarch64_mac}"
                         X86_64_MAC="${params.x86_64_mac}"
@@ -434,7 +469,7 @@ pipeline {
                             // Figure out the platforms to build on.
                             def platforms = getPlatforms()
                             assert !((platforms.size() > 1) && (OCK_FULL_URL != "")) : "Cannot specify full OCK URL and multiple platforms."
-                             
+
                              // Check whether the build has to be run multiple times in parallel.
                             def iter = (PARALLEL_ITERATIONS ?: "1").toInteger()
                             echo "Parallel iterations to be run: ${iter}"

--- a/JenkinsfilePerformance
+++ b/JenkinsfilePerformance
@@ -103,7 +103,7 @@ def getPlatforms() {
  * @return              The URL to the uploaded file
  */
 def archive(platform, iteration) {
-    
+
     // Create compressed file containing build.
     def ending = ".tar.gz"
     def filename = "openjceplus-performance-$iteration-$platform$ending"
@@ -224,7 +224,7 @@ def run(platform) {
                     echo "Java fetched"
                     externalLibrary.getBinaries(hardware, software)
                     echo "Binaries fetched"
-                    externalLibrary.getMaven()
+                    externalLibrary.getMaven(software)
                     echo "Maven fetched"
                     def allowedProviders = []
                     if (PROVIDER_OPENJCEPLUS == "true") {
@@ -469,7 +469,7 @@ pipeline {
                             // Figure out the platforms to build on.
                             def platforms = getPlatforms()
                             assert !((platforms.size() > 1) && (OCK_FULL_URL != "")) : "Cannot specify full OCK URL and multiple platforms."
-                             
+
                              // Check whether the build has to be run multiple times in parallel.
                             def iter = (PARALLEL_ITERATIONS ?: "1").toInteger()
                             echo "Parallel iterations to be run: ${iter}"

--- a/buildNative.sh
+++ b/buildNative.sh
@@ -8,23 +8,24 @@
 # under the terms provided by IBM in the LICENSE file that accompanied
 # this code, including the "Classpath" Exception described therein.
 ###############################################################################
+set -o xtrace
 
 PLATFORMS=(arm-linux64 ppc-aix64 ppcle-linux64 s390-linux64 s390-zos64 x86-linux64)
 
-if [ -z "$JAVA_HOME" ]; 
-  then 
+if [ -z "$JAVA_HOME" ];
+  then
   echo "Error: JAVA_HOME is not defined or is empty";
   exit;
-fi 
+fi
 
-if [ -z "$GSKIT_HOME" ]; 
-  then 
+if [ -z "$GSKIT_HOME" ];
+  then
   echo "Error: GSKIT_HOME is not defined or is empty";
   exit;
 fi
 
-if [ -z "$PLATFORM" ]; 
-  then 
+if [ -z "$PLATFORM" ];
+  then
   echo "Error: PLATFORM is not defined or is empty";
   echo "PLATFORM should be one the following:"
   echo ${PLATFORMS[*]}

--- a/buildNativeMac.sh
+++ b/buildNativeMac.sh
@@ -8,15 +8,16 @@
 # under the terms provided by IBM in the LICENSE file that accompanied
 # this code, including the "Classpath" Exception described therein.
 ###############################################################################
+set -o xtrace
 
-if [ -z "$JAVA_HOME" ]; 
-  then 
+if [ -z "$JAVA_HOME" ];
+  then
   echo "Error: JAVA_HOME is not defined or is empty";
   exit;
-fi 
+fi
 
-if [ -z "$GSKIT_HOME" ]; 
-  then 
+if [ -z "$GSKIT_HOME" ];
+  then
   echo "Error: GSKIT_HOME is not defined or is empty";
   exit;
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,11 @@
               </os>
             </activation>
             <properties>
-              <style.encoding>IBM1047</style.encoding>
+              <style.encoding>UTF-8</style.encoding>
               <build.native.file>${basedir}/buildNative.sh</build.native.file>
               <build.platform.value>s390-zos64</build.platform.value>
               <build.target.jgskitlib.dir>${project.basedir}/target/jgskit-mz-64/</build.target.jgskitlib.dir>
+              <skip.native.compile>true</skip.native.compile>
             </properties>
             <build>
               <plugins>
@@ -80,32 +81,27 @@
                       <configuration>
                         <target>
                           <mkdir dir="${project.basedir}/src/main/native/ock"/>
-                          <echo file="${project.basedir}/src/main/native/ock/closed_Utils_c.h" append="false">
+                          <echo file="${project.basedir}/src/main/native/ock/closed_Utils_c.h" append="false" encoding="IBM-1047">
                             // This file is required for compiling with OpenXL. The actual file will get copied during a z/OS JDK build.
                           </echo>
                         </target>
                       </configuration>
                     </execution>
-                  </executions>
-                </plugin>
-                <plugin>
-                  <groupId>org.codehaus.mojo</groupId>
-                  <artifactId>exec-maven-plugin</artifactId>
-                  <version>3.5.0</version>
-                  <executions>
                     <execution>
-                      <id>Execute Native Library Build Script</id>
+                      <id>Execute Native Library Build Script on z/OS</id>
                       <phase>compile</phase>
                       <goals>
-                        <goal>exec</goal>
+                        <goal>run</goal>
                       </goals>
                       <configuration>
-                        <skip>${skip.native.compile}</skip>
-                        <environmentVariables>
-                          <PLATFORM>${build.platform.value}</PLATFORM>
-                        </environmentVariables>
-                        <executable>bash</executable>
-                        <commandlineArgs>${build.native.file}</commandlineArgs>
+                        <skip>${skip.zos.native.compile}</skip>
+                        <target>
+                          <exec executable="bash" failonerror="true">
+                            <arg value="-c"/>
+                            <arg value="${build.native.file}"/>
+                            <env key="PLATFORM" value="${build.platform.value}"/>
+                          </exec>
+                        </target>
                       </configuration>
                     </execution>
                   </executions>

--- a/src/main/native/ock/jgskit.mak
+++ b/src/main/native/ock/jgskit.mak
@@ -159,7 +159,10 @@ headers :
 		-d ${JAVACLASSDIR} \
 		-h ${TOPDIR}/src/main/native/ock/ \
 		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/base/FastJNIBuffer.java \
-		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/base/NativeInterface.java
+		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/base/NativeInterface.java; \
+		if  [ "${PLATFORM}" = "s390-zos64" ]; \
+			then chtag -t -c ISO8859-1 com_ibm_crypto_plus_provider_base_NativeInterface.h; \
+		fi
 
 endif # ! EXTERNAL_HEADERS
 

--- a/utils.groovy
+++ b/utils.groovy
@@ -50,6 +50,8 @@ def getOCKTarget(hardware, software) {
         if (hardware == "x86-64") {
             target = "win64_x86"
         }
+    } else if (software == "zos") {
+        target = "zos64a"
     }
 
     return target
@@ -63,7 +65,7 @@ def getOCKTarget(hardware, software) {
 def getBinaries(hardware, software) {
     def ockRelease = OCK_RELEASE
     if (ockRelease == "") {
-        if ((software == "linux") && (hardware == "s390x")) {
+        if (hardware == "s390x") { // covers LoZ and z/OS
             ockRelease = "20260219_8.9.21"
         } else {
             ockRelease = "20251128_8.9.18"
@@ -72,7 +74,7 @@ def getBinaries(hardware, software) {
     def target = getOCKTarget(hardware, software)
     def gskit_bin = "https://na.artifactory.swg-devops.com/artifactory/sec-gskit-javasec-generic-local/gskit8/$ockRelease/$target/jgsk_crypto.tar"
     def gskit_sdk_bin = "https://na.artifactory.swg-devops.com/artifactory/sec-gskit-javasec-generic-local/gskit8/$ockRelease/$target/jgsk_crypto_sdk.tar"
-    
+
     // If user has specified OCK_FULL_URL, override default location.
     def ockUrl = OCK_FULL_URL
     if (ockUrl != "") {
@@ -81,11 +83,18 @@ def getBinaries(hardware, software) {
     }
     dir("openjceplus/OCK") {
         withCredentials([usernamePassword(credentialsId: '7c1c2c28-650f-49e0-afd1-ca6b60479546', passwordVariable: 'GSKIT_PASSWORD', usernameVariable: 'GSKIT_USERNAME')]) {
-            sh "curl -u $GSKIT_USERNAME:$GSKIT_PASSWORD $gskit_bin > jgsk_crypto.tar"
-            sh "curl -u $GSKIT_USERNAME:$GSKIT_PASSWORD $gskit_sdk_bin > jgsk_crypto_sdk.tar"
+            sh "curl -k -u $GSKIT_USERNAME:$GSKIT_PASSWORD $gskit_bin -o jgsk_crypto.tar"
+            sh "curl -k -u $GSKIT_USERNAME:$GSKIT_PASSWORD $gskit_sdk_bin -o jgsk_crypto_sdk.tar"
         }
-        untar file: 'jgsk_crypto.tar'
-        untar file: 'jgsk_crypto_sdk.tar'
+        if (software == "zos") {
+            sh 'chtag -b jgsk_crypto.tar'
+            sh 'tar -oxf jgsk_crypto.tar'
+            sh 'chtag -b jgsk_crypto_sdk.tar'
+            sh 'tar -oxf jgsk_crypto_sdk.tar'
+        } else {
+            untar file: 'jgsk_crypto.tar'
+            untar file: 'jgsk_crypto_sdk.tar'
+        }
 
         def jgsk8Lib = 'libjgsk8iccs_64.so'
         if (target.contains('osx')) {
@@ -109,16 +118,19 @@ def getBinaries(hardware, software) {
  */
 def getJavaDownloadUrl(javaVersion, hardware, software, javaRelease) {
     def java_link = ""
-    
+
     if (javaRelease == "") {
         // Use latest GA version
         java_link = "https://api.adoptopenjdk.net/v3/binary/latest/${javaVersion}/ga/${software}/${hardware}/jdk/openj9/normal/ibm?project=jdk"
+        if (software == "zos") {
+            java_link = "https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/hyc-runtimes-jenkins.swg-devops.com/Build_JDK25_s390x_zos_Nightly/278/ibm-semeru-certified-jdk_s390x_zos_25.0.2.0-20260225-080405.pax.Z"
+        }
     } else {
         // Use specific version
         def java_release_link = javaRelease.replace("+", "%2B")
         java_link = "https://api.adoptopenjdk.net/v3/binary/version/${java_release_link}/${software}/${hardware}/jdk/openj9/normal/ibm?project=jdk"
     }
-    
+
     return java_link
 }
 
@@ -141,28 +153,46 @@ def getJava(hardware, software) {
     def java_link = getJavaDownloadUrl(JAVA_VERSION, hardware, software, JAVA_RELEASE)
 
     dir("java") {
-        sh "curl -LJkO ${java_link}"
-        def java_file = sh (
-            script: 'ls | grep \'tar\\|zip\'',
-            returnStdout: true
-        ).trim()
+        def java_file = ""
+        if (software == "zos") {
+            sh "curl -LJkO -u $ARTIFACTORY_USERNAME:$ARTIFACTORY_PASSWORD ${java_link}"
+            java_file = sh (
+                script: 'ls | grep \'pax\'',
+                returnStdout: true
+            ).trim()
+
+            // We also need to download a java.base patch to disabled checking for signed JARs or else we can't do a patch-module.
+            sh "curl -LJkO -u $ARTIFACTORY_USERNAME:$ARTIFACTORY_PASSWORD https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/openjceplusworkaroundzos032526/java.base.jar"
+        } else {
+            sh "curl -LJkO ${java_link}"
+            java_file = sh (
+                script: 'ls | grep \'tar\\|zip\'',
+                returnStdout: true
+            ).trim()
+        }
 
        if (software == "windows") {
             unzip zipFile: "$java_file"
+        } else if (software =="zos") {
+           sh "pax -p x -rf $java_file"
         } else {
             untar file: "$java_file"
         }
         sh "rm $java_file"
 
+        def java_prefix = "jdk-"
+        if (software == "zos") {
+            java_prefix = "J"
+        }
         def java_folder = sh (
-            script: "ls | grep \'jdk-${JAVA_VERSION}\'",
+            script: "ls | grep \'${java_prefix}${JAVA_VERSION}\'",
             returnStdout: true
         ).trim()
         fileOperations([folderRenameOperation(destination: 'jdk', source: "$java_folder")])
 
-        // AIX always loads the bundled version of native libraries. We delete them to
+        // AIX and z/OS always loads the bundled version of native libraries. We delete them to
         // ensure that the one provided by the user is utilized.
-        if (software == "aix") {
+        if (software == "aix" || software == "zos") {
             fileOperations([fileDeleteOperation(excludes: '', includes: 'jdk/lib/libjgsk8iccs_64.so'),
                             fileDeleteOperation(excludes: '', includes: 'jdk/lib/libjgskit.so'),
                             folderDeleteOperation('jdk/lib/C'),
@@ -174,9 +204,12 @@ def getJava(hardware, software) {
 /*
  * Get the Maven tool and extract it.
  */
-def getMaven() {
+def getMaven(software) {
     sh "curl -kLO https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.tar.gz"
     untar file: "apache-maven-3.9.10-bin.tar.gz"
+    if (software == "zos") {
+        sh "chtag -tR -c ISO8859-1 apache-maven-3.9.10"
+    }
 }
 
 /*
@@ -186,8 +219,42 @@ def getMaven() {
 def runOpenJCEPlus(command, software) {
     dir("openjceplus/OpenJCEPlus") {
         def additional_exports = ""
-        if (software == "aix") {
+        if (software == "aix" || software == "zos") {
             additional_exports = "export LIBPATH=$WORKSPACE/openjceplus/OCK/:$WORKSPACE/openjceplus/OCK/jgsk_sdk;"
+        }
+        if (software == "zos") {
+            // Setting exports here since forkCount is set to 0 on z/OS
+            additional_exports += "export JAVA_TOOL_OPTIONS=\"-Djgskit.library.path=$WORKSPACE/openjceplus/OpenJCEPlus/target/jgskit-mz-64/ " +
+                                            "-Dstdout.encoding=IBM-1047 " +
+                                            "-Dstderr.encoding=IBM-1047 " +
+                                            "--add-exports=java.base/sun.security.internal.interfaces=ALL-UNNAMED " +
+                                            "--add-exports=java.base/sun.security.internal.interfaces=openjceplus " +
+                                            "--add-exports=java.base/sun.security.internal.spec=ALL-UNNAMED " +
+                                            "--add-exports=java.base/sun.security.internal.spec=openjceplus " +
+                                            "--add-exports=java.base/sun.security.pkcs=ALL-UNNAMED " +
+                                            "--add-exports=java.base/sun.security.pkcs=openjceplus " +
+                                            "--add-exports=java.base/sun.security.util=ALL-UNNAMED " +
+                                            "--add-exports=java.base/sun.security.util=openjceplus " +
+                                            "--add-exports=java.base/sun.security.x509=ALL-UNNAMED " +
+                                            "--add-exports=java.base/sun.security.x509=openjceplus " +
+                                            "--add-exports=openjceplus/ibm.jceplus.junit=ALL-UNNAMED " +
+                                            "--add-exports=openjceplus/ibm.jceplus.junit.base=ALL-UNNAMED " +
+                                            "--add-exports=openjceplus/ibm.jceplus.junit.base.memstress=ALL-UNNAMED " +
+                                            "--add-exports=openjceplus/ibm.jceplus.junit.suites=ALL-UNNAMED " +
+                                            "--add-exports=openjceplus/ibm.jceplus.junit.tests=ALL-UNNAMED " +
+                                            "--add-exports=openjceplus/ibm.jceplus.junit.openjceplus=ALL-UNNAMED " +
+                                            "--add-exports=openjceplus/ibm.jceplus.junit.openjceplus.integration=ALL-UNNAMED " +
+                                            "--add-exports=openjceplus/ibm.jceplus.junit.openjceplus.memstress=ALL-UNNAMED " +
+                                            "--add-exports=openjceplus/ibm.jceplus.junit.openjceplus.multithread=ALL-UNNAMED " +
+                                            "--add-exports=openjceplus/ibm.jceplus.junit.openjceplusfips=ALL-UNNAMED " +
+                                            "--add-exports=openjceplus/ibm.jceplus.junit.openjceplusfips.integration=ALL-UNNAMED " +
+                                            "--add-exports=openjceplus/ibm.jceplus.junit.openjceplusfips.multithread=ALL-UNNAMED " +
+                                            "--add-opens=openjceplus/ibm.jceplus.junit.base=ALL-UNNAMED " +
+                                            "--add-opens=openjceplus/ibm.jceplus.junit.tests=ALL-UNNAMED " +
+                                            "--add-exports=openjceplus/com.ibm.crypto.plus.provider.base=ALL-UNNAMED " +
+                                            "--patch-module=java.base=\"$WORKSPACE/java/java.base.jar\" " +
+                                            "--patch-module=openjceplus=\"target/classes:target/test-classes\"" +
+                                            "\";"
         }
 
         def additional_envars = ADDITIONAL_ENVARS
@@ -195,7 +262,6 @@ def runOpenJCEPlus(command, software) {
             for (envar in additional_envars.split(",")) {
                 additional_exports += " export ${envar.trim()};"
             }
-            
         }
 
         def java_home = "export JAVA_HOME=$WORKSPACE/java/jdk;"
@@ -224,6 +290,12 @@ def runOpenJCEPlus(command, software) {
             java_home = "export JAVA_HOME=$WORKSPACE/java/jdk/Contents/Home;"
         } else if (software == "aix") {
             environment = "export PATH=/opt/IBM/openxlC/17.1.3/bin:/opt/IBM/openxlC/17.1.3/tools:/opt/IBM/openxlC/17.1.3/compat/llvm:${mavenPath}:\$PATH;"
+        } else if (software == "zos") {
+            // Setting forkCount to 0 or else the JVM crashes on z/OS
+            additional_cmd_args += " -DforkCount=0"
+
+            // Compile first so that the tests pick up the newly built jgskit library.
+            sh "${java_home} ${gskit_home} ${additional_exports} ${environment} mvn '-Dock.library.path=${ock_path}' ${additional_cmd_args} --batch-mode compile"
         }
 
         if (software != "windows") {
@@ -266,7 +338,7 @@ def upload_artifactory(uploadSpec) {
     return server.getUrl()
 }
 
-/* 
+/*
  * Returns a formatted directory name based upon a branch name.
  */
 def getSanitizedBranchName() {


### PR DESCRIPTION
This update allows Jenkins to build on z/OS platforms. This should also automatically trigger z/OS builds when PRs are opened. Currently, this support is only available for Java 25.

Backports https://github.com/IBM/OpenJCEPlus/pull/1377

Signed-off-by: Thomas-Ginader <thomas.ginader@ibm.com>