### PR TITLE
Update Bouncy Castle dependencies to 1.84

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -884,17 +884,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.80</version>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>1.80</version>
-        </dependency>
-        <dependency>
-          <groupId>org.bouncycastle</groupId>
-          <artifactId>bcprov-ext-jdk18on</artifactId>
-          <version>1.78.1</version>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>org.jacoco</groupId>


### PR DESCRIPTION
Update the Bouncy Castle provider and PKIX dependencies to version 1.84.

Remove the bcprov-ext-jdk18on dependency because it is no longer needed and is not available at version 1.84.