### PR TITLE
Use forkNode TCP configuration instead of 0 fork count for z/OS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,6 +294,8 @@
                       <printStderrOnFailure>true</printStderrOnFailure>
                       <printStderrOnSuccess>false</printStderrOnSuccess>
                     </statelessTestsetInfoReporter>
+                    <!-- Activate the use of TCP to transmit events to the plugin -->
+                    <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                   </configuration>
                 </plugin>
                 <plugin>
@@ -427,6 +429,8 @@
                       <printStderrOnFailure>true</printStderrOnFailure>
                       <printStderrOnSuccess>false</printStderrOnSuccess>
                     </statelessTestsetInfoReporter>
+                    <!-- Activate the use of TCP to transmit events to the plugin -->
+                    <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                   </configuration>
                 </plugin>
               </plugins>
@@ -677,7 +681,7 @@
                     <nuspecAnalyzerEnabled>false</nuspecAnalyzerEnabled>
                     <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                     <cocoapodsAnalyzerEnabled>false</cocoapodsAnalyzerEnabled>
-                </configuration>     
+                </configuration>
             </plugin>
         </plugins>
         <resources>

--- a/utils.groovy
+++ b/utils.groovy
@@ -148,7 +148,7 @@ def getJava(hardware, software) {
     }
 
     def java_link = ""
-    
+
     // Check if JAVA_RELEASE is a URL that contains artifactory.
     if (JAVA_RELEASE.contains("https://na.artifactory.swg-devops.com")) {
         // JAVA_RELEASE is an Artifactory URL
@@ -208,7 +208,7 @@ def getJava(hardware, software) {
             script: "ls -d jdk 2>/dev/null || echo ''",
             returnStdout: true
         ).trim()
-        
+
         if (folderCheck == "") {
             // Folder is not named 'jdk', so find and rename it
             def java_prefix = "jdk-"
@@ -257,37 +257,9 @@ def runOpenJCEPlus(command, software) {
             additional_exports = "export LIBPATH=$WORKSPACE/openjceplus/OCK/:$WORKSPACE/openjceplus/OCK/jgsk_sdk;"
         }
         if (software == "zos") {
-            // Setting exports here since forkCount is set to 0 on z/OS
-            additional_exports += "export JAVA_TOOL_OPTIONS=\"-Djgskit.library.path=$WORKSPACE/openjceplus/OpenJCEPlus/target/jgskit-mz-64/ " +
-                                            "-Dstdout.encoding=IBM-1047 " +
+            additional_exports += "export JAVA_TOOL_OPTIONS=\"-Dstdout.encoding=IBM-1047 " +
                                             "-Dstderr.encoding=IBM-1047 " +
-                                            "--add-exports=java.base/sun.security.internal.interfaces=ALL-UNNAMED " +
-                                            "--add-exports=java.base/sun.security.internal.interfaces=openjceplus " +
-                                            "--add-exports=java.base/sun.security.internal.spec=ALL-UNNAMED " +
-                                            "--add-exports=java.base/sun.security.internal.spec=openjceplus " +
-                                            "--add-exports=java.base/sun.security.pkcs=ALL-UNNAMED " +
-                                            "--add-exports=java.base/sun.security.pkcs=openjceplus " +
-                                            "--add-exports=java.base/sun.security.util=ALL-UNNAMED " +
-                                            "--add-exports=java.base/sun.security.util=openjceplus " +
-                                            "--add-exports=java.base/sun.security.x509=ALL-UNNAMED " +
-                                            "--add-exports=java.base/sun.security.x509=openjceplus " +
-                                            "--add-exports=openjceplus/ibm.jceplus.junit=ALL-UNNAMED " +
-                                            "--add-exports=openjceplus/ibm.jceplus.junit.base=ALL-UNNAMED " +
-                                            "--add-exports=openjceplus/ibm.jceplus.junit.base.memstress=ALL-UNNAMED " +
-                                            "--add-exports=openjceplus/ibm.jceplus.junit.suites=ALL-UNNAMED " +
-                                            "--add-exports=openjceplus/ibm.jceplus.junit.tests=ALL-UNNAMED " +
-                                            "--add-exports=openjceplus/ibm.jceplus.junit.openjceplus=ALL-UNNAMED " +
-                                            "--add-exports=openjceplus/ibm.jceplus.junit.openjceplus.integration=ALL-UNNAMED " +
-                                            "--add-exports=openjceplus/ibm.jceplus.junit.openjceplus.memstress=ALL-UNNAMED " +
-                                            "--add-exports=openjceplus/ibm.jceplus.junit.openjceplus.multithread=ALL-UNNAMED " +
-                                            "--add-exports=openjceplus/ibm.jceplus.junit.openjceplusfips=ALL-UNNAMED " +
-                                            "--add-exports=openjceplus/ibm.jceplus.junit.openjceplusfips.integration=ALL-UNNAMED " +
-                                            "--add-exports=openjceplus/ibm.jceplus.junit.openjceplusfips.multithread=ALL-UNNAMED " +
-                                            "--add-opens=openjceplus/ibm.jceplus.junit.base=ALL-UNNAMED " +
-                                            "--add-opens=openjceplus/ibm.jceplus.junit.tests=ALL-UNNAMED " +
-                                            "--add-exports=openjceplus/com.ibm.crypto.plus.provider.base=ALL-UNNAMED " +
                                             "--patch-module=java.base=\"$WORKSPACE/java/java.base.jar\" " +
-                                            "--patch-module=openjceplus=\"target/classes:target/test-classes\"" +
                                             "\";"
         }
 
@@ -324,12 +296,6 @@ def runOpenJCEPlus(command, software) {
             java_home = "export JAVA_HOME=$WORKSPACE/java/jdk/Contents/Home;"
         } else if (software == "aix") {
             environment = "export PATH=/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin:${mavenPath}:\$PATH;"
-        } else if (software == "zos") {
-            // Setting forkCount to 0 or else the JVM crashes on z/OS
-            additional_cmd_args += " -DforkCount=0"
-
-            // Compile first so that the tests pick up the newly built jgskit library.
-            sh "${java_home} ${gskit_home} ${additional_exports} ${environment} mvn '-Dock.library.path=${ock_path}' ${additional_cmd_args} --batch-mode compile"
         }
 
         if (software != "windows") {


### PR DESCRIPTION
This update removes the z/OS Maven configuration of setting the fork count to 0. Instead, it changes the Maven Surefire plugin to use a different forkNode implementation. In this case, it changes it to use TCP/IP to transmit events. This allows other charsets such as EBCDIC to be displayed correctly in the console output.

Backport of https://github.com/IBM/OpenJCEPlus/pull/1408

Signed-off-by: Thomas-Ginader [thomas.ginader@ibm.com](mailto:thomas.ginader@ibm.com)