### PR TITLE
Revert "Add org.owasp:dependency-check plugin (#1357)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -668,22 +668,6 @@
                 </execution>
               </executions>
             </plugin>
-            <plugin>
-                <groupId>org.owasp</groupId>
-                <artifactId>dependency-check-maven</artifactId>
-                <version>12.2.0</version>
-                <configuration>
-                    <!-- disable those analyzer OpenJCEPlus don't use -->
-                    <nodeAnalyzerEnabled>false</nodeAnalyzerEnabled>
-                    <nodeAuditAnalyzerEnabled>false</nodeAuditAnalyzerEnabled>
-                    <retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>
-                    <yarnAuditAnalyzerEnabled>false</yarnAuditAnalyzerEnabled>
-                    <pnpmAuditAnalyzerEnabled>false</pnpmAuditAnalyzerEnabled>
-                    <nuspecAnalyzerEnabled>false</nuspecAnalyzerEnabled>
-                    <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
-                    <cocoapodsAnalyzerEnabled>false</cocoapodsAnalyzerEnabled>
-                </configuration>
-            </plugin>
         </plugins>
         <resources>
             <resource>


### PR DESCRIPTION
This reverts commit 2f80aabb367c89b85851c59880eae19cc3ba431a.

Since we no longer need the org.owasp:dependency-check plugin, revert that commit to remove the plugin.