### PR TITLE
Create native exception hierarchy and simplify handling

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/AESCCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESCCMCipher.java
@@ -142,11 +142,11 @@ public final class AESCCMCipher extends CipherSpi implements AESConstants, CCMCo
              * but engineDoFinal(..) is declared to be able to throw it since it also
              * handles user provided output buffers
              */
-            // OCKDebug.Msg(debPrefix, methodName, "OCKException seen");
+            // OCKDebug.Msg(debPrefix, methodName, "NativeException seen");
             if (!encrypting) {
                 AEADBadTagException abte = new AEADBadTagException(
                         "Unable to perform engine doFinal; Possibly a bad tag or bad padding or illegalBlockSize");
-                provider.setOCKExceptionCause(abte, e);
+                provider.setExceptionCause(abte, e);
                 throw abte;
             } else {
                 throw provider.providerException("unable to perform to engineDoFinal ", e);
@@ -199,11 +199,11 @@ public final class AESCCMCipher extends CipherSpi implements AESConstants, CCMCo
              * but engineDoFinal(..) is declared to be able to throw it since it also
              * handles user provided output buffers
              */
-            // OCKDebug.Msg(debPrefix, methodName, "OCKException seen");
+            // OCKDebug.Msg(debPrefix, methodName, "NativeException seen");
             if (!encrypting) {
                 AEADBadTagException abte = new AEADBadTagException(
                         "Uanble to perform engine doFinal; Possibly a bad tag or bad padding or illegalBlockSize");
-                provider.setOCKExceptionCause(abte, e);
+                provider.setExceptionCause(abte, e);
                 throw abte;
             } else {
                 throw provider.providerException("unable to perform to engineDoFinal ", e);
@@ -287,31 +287,16 @@ public final class AESCCMCipher extends CipherSpi implements AESConstants, CCMCo
                 authData = null; // Before returning from doFinal(), restore AAD to uninitialized state
                 return ret;
             }
-        } catch (AEADBadTagException e) {
-            AEADBadTagException abte = new AEADBadTagException(e.getMessage());
-            provider.setOCKExceptionCause(abte, e);
-            requireReinit = true;
-            throw abte;
-        } catch (BadPaddingException ock_bpe) {
-            BadPaddingException bpe = new BadPaddingException(ock_bpe.getMessage());
-            provider.setOCKExceptionCause(bpe, ock_bpe);
+        } catch (BadPaddingException | IllegalBlockSizeException bpe) {
             requireReinit = true;
             throw bpe;
-        } catch (IllegalBlockSizeException ock_ibse) {
-            IllegalBlockSizeException ibse = new IllegalBlockSizeException(ock_ibse.getMessage());
-            provider.setOCKExceptionCause(ibse, ock_ibse);
-            requireReinit = true;
-            throw ibse;
-        } catch (ShortBufferException ock_sbe) {
-            ShortBufferException sbe = new ShortBufferException(ock_sbe.getMessage());
-            provider.setOCKExceptionCause(sbe, ock_sbe);
+        } catch (ShortBufferException sbe) {
             throw sbe;
-        } catch (com.ibm.crypto.plus.provider.base.OCKException ock_excp) {
+        } catch (com.ibm.crypto.plus.provider.base.NativeException ock_excp) {
             requireReinit = true;
             AEADBadTagException tagexcp = new AEADBadTagException(ock_excp.getMessage());
-            provider.setOCKExceptionCause(tagexcp, ock_excp);
+            provider.setExceptionCause(tagexcp, ock_excp);
             throw tagexcp;
-
         } catch (Exception e) {
             requireReinit = true;
             throw provider.providerException("Failure in engineDoFinal", e);

--- a/src/main/java/com/ibm/crypto/plus/provider/AESCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESCipher.java
@@ -66,14 +66,8 @@ public final class AESCipher extends CipherSpi implements AESConstants {
             } else {
                 return output;
             }
-        } catch (BadPaddingException ock_bpe) {
-            BadPaddingException bpe = new BadPaddingException(ock_bpe.getMessage());
-            provider.setOCKExceptionCause(bpe, ock_bpe);
+        } catch (BadPaddingException | IllegalBlockSizeException bpe) {
             throw bpe;
-        } catch (IllegalBlockSizeException ock_ibse) {
-            IllegalBlockSizeException ibse = new IllegalBlockSizeException(ock_ibse.getMessage());
-            provider.setOCKExceptionCause(ibse, ock_ibse);
-            throw ibse;
         } catch (Exception e) {
             throw provider.providerException("Failure in engineDoFinal", e);
         }
@@ -147,18 +141,8 @@ public final class AESCipher extends CipherSpi implements AESConstants {
             } else {
                 return symmetricCipher.doFinal(input, inputOffset, inputLen, output, outputOffset);
             }
-        } catch (BadPaddingException ock_bpe) {
-            BadPaddingException bpe = new BadPaddingException(ock_bpe.getMessage());
-            provider.setOCKExceptionCause(bpe, ock_bpe);
-            throw bpe;
-        } catch (IllegalBlockSizeException ock_ibse) {
-            IllegalBlockSizeException ibse = new IllegalBlockSizeException(ock_ibse.getMessage());
-            provider.setOCKExceptionCause(ibse, ock_ibse);
-            throw ibse;
-        } catch (ShortBufferException ock_sbe) {
-            ShortBufferException sbe = new ShortBufferException(ock_sbe.getMessage());
-            provider.setOCKExceptionCause(sbe, ock_sbe);
-            throw sbe;
+        } catch (BadPaddingException | IllegalBlockSizeException | ShortBufferException exc) {
+            throw exc;
         } catch (Exception e) {
             throw provider.providerException("Failure in engineDoFinal", e);
         }
@@ -467,7 +451,7 @@ public final class AESCipher extends CipherSpi implements AESConstants {
             }
         } catch (ShortBufferException ock_sbe) {
             ShortBufferException sbe = new ShortBufferException(ock_sbe.getMessage());
-            provider.setOCKExceptionCause(sbe, ock_sbe);
+            provider.setExceptionCause(sbe, ock_sbe);
             throw sbe;
         } catch (Exception e) {
             throw provider.providerException("Failure in engineDoFinal", e);

--- a/src/main/java/com/ibm/crypto/plus/provider/AESGCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESGCMCipher.java
@@ -9,7 +9,7 @@
 package com.ibm.crypto.plus.provider;
 
 import com.ibm.crypto.plus.provider.base.GCMCipher;
-import com.ibm.crypto.plus.provider.base.OCKException;
+import com.ibm.crypto.plus.provider.base.NativeException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.security.AlgorithmParameters;
@@ -179,15 +179,15 @@ public final class AESGCMCipher extends CipherSpi implements AESConstants, GCMCo
                 resetVars(true);
 
                 throw e;
-            } catch (OCKException e) {
-                // OCKDebug.Msg(debPrefix, methodName, "OCKException encountered = " +
+            } catch (NativeException e) {
+                // OCKDebug.Msg(debPrefix, methodName, "NativeException encountered = " +
                 // e.getMessage());
 
                 if (!encrypting) {
                     AEADBadTagException abte = new AEADBadTagException(
                             "Unable to perform engine doFinal; "
                                     + "Possibly a bad tag or bad padding or illegalBlockSize");
-                    provider.setOCKExceptionCause(abte, e);
+                    provider.setExceptionCause(abte, e);
                     resetVars(true);
                     throw abte;
                 } else {
@@ -231,14 +231,14 @@ public final class AESGCMCipher extends CipherSpi implements AESConstants, GCMCo
              * handles user provided output buffers
              */
             resetVars(true);
-            // OCKDebug.Msg(debPrefix, methodName, "OCKException seen");
+            // OCKDebug.Msg(debPrefix, methodName, "NativeException seen");
             if (!encrypting) {
 
                 AEADBadTagException abte = new AEADBadTagException(
                         "Unable to perform engine doFinal; "
                                 + "Possibly a bad tag or bad padding or illegalBlockSize");
 
-                provider.setOCKExceptionCause(abte, e);
+                provider.setExceptionCause(abte, e);
                 throw abte;
             } else {
                 throw provider.providerException("unable to perform to engineDoFinal ", e);
@@ -284,7 +284,7 @@ public final class AESGCMCipher extends CipherSpi implements AESConstants, GCMCo
                 //                    requireReinit = true;
 
                 throw e;
-            } catch (OCKException e) {
+            } catch (NativeException e) {
 
                 //updateCalled = false;
                 //
@@ -292,7 +292,7 @@ public final class AESGCMCipher extends CipherSpi implements AESConstants, GCMCo
 
                 if (!encrypting) {
                     AEADBadTagException abte = new AEADBadTagException(e.getMessage());
-                    provider.setOCKExceptionCause(abte, e);
+                    provider.setExceptionCause(abte, e);
                     // OCKDebug.Msg (debPrefix, methodName, "Ret from engineDoFinal: ");
                     resetVars(true);
                     throw abte;
@@ -357,30 +357,16 @@ public final class AESGCMCipher extends CipherSpi implements AESConstants, GCMCo
                 authData = null; // Before returning from doFinal(), restore AAD to uninitialized state
                 return ret;
             }
-        } catch (AEADBadTagException e) {
+        } catch (BadPaddingException | IllegalBlockSizeException bpe) {
             resetVars(true);
-            AEADBadTagException abte = new AEADBadTagException(e.getMessage());
-            provider.setOCKExceptionCause(abte, e);
-            throw abte;
-        } catch (BadPaddingException ock_bpe) {
-            resetVars(true);
-            BadPaddingException bpe = new BadPaddingException(ock_bpe.getMessage());
-            provider.setOCKExceptionCause(bpe, ock_bpe);
             throw bpe;
-        } catch (IllegalBlockSizeException ock_ibse) {
-            resetVars(true);
-            IllegalBlockSizeException ibse = new IllegalBlockSizeException(ock_ibse.getMessage());
-            provider.setOCKExceptionCause(ibse, ock_ibse);
-            throw ibse;
-        } catch (ShortBufferException ock_sbe) {
+        } catch (ShortBufferException sbe) {
             sbeInLastFinalEncrypt = encrypting;
-            ShortBufferException sbe = new ShortBufferException(ock_sbe.getMessage());
-            provider.setOCKExceptionCause(sbe, ock_sbe);
             throw sbe;
-        } catch (com.ibm.crypto.plus.provider.base.OCKException ock_excp) {
+        } catch (com.ibm.crypto.plus.provider.base.NativeException ock_excp) {
             resetVars(true);
             AEADBadTagException tagexcp = new AEADBadTagException(ock_excp.getMessage());
-            provider.setOCKExceptionCause(tagexcp, ock_excp);
+            provider.setExceptionCause(tagexcp, ock_excp);
             throw tagexcp;
         } catch (Exception e) {
             resetVars(true);
@@ -390,7 +376,7 @@ public final class AESGCMCipher extends CipherSpi implements AESConstants, GCMCo
 
     private byte[] doFinalForUpdates(byte[] input, int inputOffset, int inputLen)
             throws IllegalBlockSizeException, BadPaddingException, AEADBadTagException,
-            IllegalStateException, OCKException {
+            IllegalStateException, NativeException {
         //final String methodName = "byte[] doFinalForUpdates";
         // OCKDebug.Msg(debPrefix, methodName, "inputOffset=" + inputOffset + "
         // inputLen=" + inputLen + " input[]", input);
@@ -433,7 +419,7 @@ public final class AESGCMCipher extends CipherSpi implements AESConstants, GCMCo
 
     private int doFinalForUpdates(byte[] input, int inputOffset, int inputLen, byte[] output,
             int outputOffset) throws ShortBufferException, IllegalBlockSizeException,
-            BadPaddingException, AEADBadTagException, IllegalStateException, OCKException {
+            BadPaddingException, AEADBadTagException, IllegalStateException, NativeException {
         //final String methodName = "doFinalForUpdates";
         checkReinit();
 
@@ -1110,35 +1096,16 @@ public final class AESGCMCipher extends CipherSpi implements AESConstants, GCMCo
                 }
             }
 
-        } catch (IllegalStateException ock_illse) {
+        } catch (IllegalStateException | BadPaddingException | IllegalBlockSizeException exc) {
             sbeInLastUpdateEncrypt = false;
-            IllegalStateException illse = new IllegalStateException(ock_illse.getMessage());
-            provider.setOCKExceptionCause(illse, ock_illse);
-            throw illse;
-        } catch (AEADBadTagException e) {
-            sbeInLastUpdateEncrypt = false;
-            AEADBadTagException abte = new AEADBadTagException(e.getMessage());
-            provider.setOCKExceptionCause(abte, e);
-            throw abte;
-        } catch (BadPaddingException ock_bpe) {
-            sbeInLastUpdateEncrypt = false;
-            BadPaddingException bpe = new BadPaddingException(ock_bpe.getMessage());
-            provider.setOCKExceptionCause(bpe, ock_bpe);
-            throw bpe;
-        } catch (IllegalBlockSizeException ock_ibse) {
-            sbeInLastUpdateEncrypt = false;
-            IllegalBlockSizeException ibse = new IllegalBlockSizeException(ock_ibse.getMessage());
-            provider.setOCKExceptionCause(ibse, ock_ibse);
-            throw ibse;
-        } catch (ShortBufferException ock_sbe) {
+            throw exc;
+        } catch (ShortBufferException sbe) {
             sbeInLastUpdateEncrypt = encrypting;
-            ShortBufferException sbe = new ShortBufferException(ock_sbe.getMessage());
-            provider.setOCKExceptionCause(sbe, ock_sbe);
             throw sbe;
-        } catch (com.ibm.crypto.plus.provider.base.OCKException ock_excp) {
+        } catch (com.ibm.crypto.plus.provider.base.NativeException ock_excp) {
             sbeInLastUpdateEncrypt = false;
             AEADBadTagException tagexcp = new AEADBadTagException(ock_excp.getMessage());
-            provider.setOCKExceptionCause(tagexcp, ock_excp);
+            provider.setExceptionCause(tagexcp, ock_excp);
             throw tagexcp;
         } catch (Exception e) {
             sbeInLastUpdateEncrypt = false;
@@ -1223,7 +1190,7 @@ public final class AESGCMCipher extends CipherSpi implements AESConstants, GCMCo
 
     private int fillOutputBuffer(byte[] finalBuf, int finalOffset, byte[] output, int outOfs,
             int finalBufLen, byte[] input) throws ShortBufferException, BadPaddingException,
-            IllegalBlockSizeException, OCKException {
+            IllegalBlockSizeException, NativeException {
         //final String methodName = "fillOutputBuffer";
         // OCKDebug.Msg(debPrefix, methodName, "Entering finalOffset = ", finalBuf);
         int len;
@@ -1245,7 +1212,7 @@ public final class AESGCMCipher extends CipherSpi implements AESConstants, GCMCo
 
     private int finalNoPadding(byte[] in, int inOfs, byte[] out, int outOfs, int len)
             throws IllegalBlockSizeException, AEADBadTagException, BadPaddingException,
-            ShortBufferException, OCKException {
+            ShortBufferException, NativeException {
 
         //final String methodName = "finalNoPadding";
         // OCKDebug.Msg(debPrefix, methodName, "Entering in" + in + " len=" + 0);

--- a/src/main/java/com/ibm/crypto/plus/provider/AESKeyWrapCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESKeyWrapCipher.java
@@ -9,7 +9,7 @@
 package com.ibm.crypto.plus.provider;
 
 import com.ibm.crypto.plus.provider.base.AESKeyWrap;
-import com.ibm.crypto.plus.provider.base.OCKException;
+import com.ibm.crypto.plus.provider.base.NativeException;
 import java.security.AlgorithmParameters;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -110,7 +110,7 @@ abstract class AESKeyWrapCipher extends CipherSpi {
             } else {
                 out = cipher.unwrap(buffer, 0, bufSize);
             }
-        } catch (OCKException ocke) {
+        } catch (NativeException ocke) {
             throw new ProviderException("Operation doFinal failed", ocke);
         }
         this.bufSize = 0;

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Cipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Cipher.java
@@ -63,14 +63,8 @@ public final class ChaCha20Cipher extends CipherSpi implements ChaCha20Constants
             } else {
                 return output;
             }
-        } catch (BadPaddingException ock_bpe) {
-            BadPaddingException bpe = new BadPaddingException(ock_bpe.getMessage());
-            provider.setOCKExceptionCause(bpe, ock_bpe);
-            throw bpe;
-        } catch (IllegalBlockSizeException ock_ibse) {
-            IllegalBlockSizeException ibse = new IllegalBlockSizeException(ock_ibse.getMessage());
-            provider.setOCKExceptionCause(ibse, ock_ibse);
-            throw ibse;
+        } catch (BadPaddingException | IllegalBlockSizeException exc) {
+            throw exc;
         } catch (Exception e) {
             throw provider.providerException("Failure in engineDoFinal", e);
         } finally {
@@ -88,19 +82,8 @@ public final class ChaCha20Cipher extends CipherSpi implements ChaCha20Constants
         try {
             int ret = symmetricCipher.doFinal(input, inputOffset, inputLen, output, outputOffset);
             return ret;
-        } catch (BadPaddingException ock_bpe) {
-            BadPaddingException bpe = new BadPaddingException(ock_bpe.getMessage());
-            provider.setOCKExceptionCause(bpe, ock_bpe);
-            throw bpe;
-        } catch (IllegalBlockSizeException ock_ibse) {
-
-            IllegalBlockSizeException ibse = new IllegalBlockSizeException(ock_ibse.getMessage());
-            provider.setOCKExceptionCause(ibse, ock_ibse);
-            throw ibse;
-        } catch (ShortBufferException ock_sbe) {
-            ShortBufferException sbe = new ShortBufferException(ock_sbe.getMessage());
-            provider.setOCKExceptionCause(sbe, ock_sbe);
-            throw sbe;
+        } catch (BadPaddingException | IllegalBlockSizeException | ShortBufferException exc) {
+            throw exc;
         } catch (Exception e) {
             throw provider.providerException("Failure in engineDoFinal", e);
         } finally {
@@ -326,9 +309,7 @@ public final class ChaCha20Cipher extends CipherSpi implements ChaCha20Constants
 
         try {
             return symmetricCipher.update(input, inputOffset, inputLen, output, outputOffset);
-        } catch (ShortBufferException ock_sbe) {
-            ShortBufferException sbe = new ShortBufferException(ock_sbe.getMessage());
-            provider.setOCKExceptionCause(sbe, ock_sbe);
+        } catch (ShortBufferException sbe) {
             throw sbe;
         } catch (Exception e) {
             throw provider.providerException("Failure in engineUpdate", e);

--- a/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Poly1305Cipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ChaCha20Poly1305Cipher.java
@@ -8,7 +8,7 @@
 
 package com.ibm.crypto.plus.provider;
 
-import com.ibm.crypto.plus.provider.base.OCKException;
+import com.ibm.crypto.plus.provider.base.NativeException;
 import com.ibm.crypto.plus.provider.base.Padding;
 import com.ibm.crypto.plus.provider.base.Poly1305Cipher;
 import java.io.IOException;
@@ -77,23 +77,13 @@ public final class ChaCha20Poly1305Cipher extends CipherSpi
             } else {
                 return output;
             }
-        } catch (BadPaddingException ock_bpe) {
-            BadPaddingException bpe = new BadPaddingException(ock_bpe.getMessage());
-            provider.setOCKExceptionCause(bpe, ock_bpe);
-            throw bpe;
-        } catch (IllegalBlockSizeException ock_ibse) {
-            IllegalBlockSizeException ibse = new IllegalBlockSizeException(ock_ibse.getMessage());
-            provider.setOCKExceptionCause(ibse, ock_ibse);
-            throw ibse;
-        } catch (IllegalArgumentException ock_iae) {
-            IllegalArgumentException iae = new IllegalArgumentException(ock_iae.getMessage());
-            provider.setOCKExceptionCause(iae, ock_iae);
-            throw iae;
-        } catch (OCKException ockException) {
+        } catch (BadPaddingException | IllegalBlockSizeException | IllegalArgumentException exc) {
+            throw exc;
+        } catch (NativeException NativeException) {
             if (!encrypting) {
                 throw new AEADBadTagException("Tag mismatch");
             } else {
-                throw provider.providerException("Failure in engineDoFinal", ockException);
+                throw provider.providerException("Failure in engineDoFinal", NativeException);
             }
         } catch (Exception e) {
             throw provider.providerException("Failure in engineDoFinal", e);
@@ -116,27 +106,13 @@ public final class ChaCha20Poly1305Cipher extends CipherSpi
             int retvalue = poly1305Cipher.doFinal(input, inputOffset, inputLen, output,
                     outputOffset);
             return retvalue;
-        } catch (BadPaddingException ock_bpe) {
-            BadPaddingException bpe = new BadPaddingException(ock_bpe.getMessage());
-            provider.setOCKExceptionCause(bpe, ock_bpe);
-            throw bpe;
-        } catch (IllegalBlockSizeException ock_ibse) {
-            IllegalBlockSizeException ibse = new IllegalBlockSizeException(ock_ibse.getMessage());
-            provider.setOCKExceptionCause(ibse, ock_ibse);
-            throw ibse;
-        } catch (ShortBufferException ock_sbe) {
-            ShortBufferException sbe = new ShortBufferException(ock_sbe.getMessage());
-            provider.setOCKExceptionCause(sbe, ock_sbe);
-            throw sbe;
-        } catch (IllegalArgumentException ock_iae) {
-            IllegalArgumentException iae = new IllegalArgumentException(ock_iae.getMessage());
-            provider.setOCKExceptionCause(iae, ock_iae);
-            throw iae;
-        } catch (OCKException ockException) {
+        } catch (BadPaddingException | IllegalBlockSizeException | ShortBufferException | IllegalArgumentException exc) {
+            throw exc;
+        } catch (NativeException NativeException) {
             if (!encrypting) {
                 throw new AEADBadTagException("Tag mismatch");
             } else {
-                throw provider.providerException("Failure in engineDoFinal", ockException);
+                throw provider.providerException("Failure in engineDoFinal", NativeException);
             }
         } catch (Exception e) {
             throw provider.providerException("Failure in engineDoFinal", e);
@@ -432,9 +408,7 @@ public final class ChaCha20Poly1305Cipher extends CipherSpi
             int retvalue = poly1305Cipher.update(input, inputOffset, inputLen, output,
                     outputOffset);
             return retvalue;
-        } catch (ShortBufferException ock_sbe) {
-            ShortBufferException sbe = new ShortBufferException(ock_sbe.getMessage());
-            provider.setOCKExceptionCause(sbe, ock_sbe);
+        } catch (ShortBufferException sbe) {
             throw sbe;
         } catch (Exception e) {
             throw provider.providerException("Failure in engineDoUpdate", e);

--- a/src/main/java/com/ibm/crypto/plus/provider/DESedeCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DESedeCipher.java
@@ -60,14 +60,8 @@ public final class DESedeCipher extends LegacyCipher implements DESConstants {
             } else {
                 return output;
             }
-        } catch (BadPaddingException ock_bpe) {
-            BadPaddingException bpe = new BadPaddingException(ock_bpe.getMessage());
-            provider.setOCKExceptionCause(bpe, ock_bpe);
-            throw bpe;
-        } catch (IllegalBlockSizeException ock_ibse) {
-            IllegalBlockSizeException ibse = new IllegalBlockSizeException(ock_ibse.getMessage());
-            provider.setOCKExceptionCause(ibse, ock_ibse);
-            throw ibse;
+        } catch (BadPaddingException | IllegalBlockSizeException exc) {
+            throw exc;
         } catch (Exception e) {
             throw provider.providerException("Failure in engineDoFinal", e);
         }
@@ -81,18 +75,8 @@ public final class DESedeCipher extends LegacyCipher implements DESConstants {
 
         try {
             return symmetricCipher.doFinal(input, inputOffset, inputLen, output, outputOffset);
-        } catch (BadPaddingException ock_bpe) {
-            BadPaddingException bpe = new BadPaddingException(ock_bpe.getMessage());
-            provider.setOCKExceptionCause(bpe, ock_bpe);
-            throw bpe;
-        } catch (IllegalBlockSizeException ock_ibse) {
-            IllegalBlockSizeException ibse = new IllegalBlockSizeException(ock_ibse.getMessage());
-            provider.setOCKExceptionCause(ibse, ock_ibse);
-            throw ibse;
-        } catch (ShortBufferException ock_sbe) {
-            ShortBufferException sbe = new ShortBufferException(ock_sbe.getMessage());
-            provider.setOCKExceptionCause(sbe, ock_sbe);
-            throw sbe;
+        } catch (BadPaddingException | IllegalBlockSizeException | ShortBufferException exc) {
+            throw exc;
         } catch (Exception e) {
             throw provider.providerException("Failure in engineDoFinal", e);
         }
@@ -309,9 +293,7 @@ public final class DESedeCipher extends LegacyCipher implements DESConstants {
 
         try {
             return symmetricCipher.update(input, inputOffset, inputLen, output, outputOffset);
-        } catch (ShortBufferException ock_sbe) {
-            ShortBufferException sbe = new ShortBufferException(ock_sbe.getMessage());
-            provider.setOCKExceptionCause(sbe, ock_sbe);
+        } catch (ShortBufferException sbe) {
             throw sbe;
         } catch (Exception e) {
             throw provider.providerException("Failure in engineDoFinal", e);

--- a/src/main/java/com/ibm/crypto/plus/provider/DHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHKeyAgreement.java
@@ -9,8 +9,8 @@
 package com.ibm.crypto.plus.provider;
 
 import com.ibm.crypto.plus.provider.base.DHKey;
+import com.ibm.crypto.plus.provider.base.NativeException;
 import com.ibm.crypto.plus.provider.base.NativeInterface;
-import com.ibm.crypto.plus.provider.base.OCKException;
 import com.ibm.crypto.plus.provider.ock.NativeOCKAdapterFIPS;
 import com.ibm.crypto.plus.provider.ock.NativeOCKAdapterNonFIPS;
 import java.io.IOException;
@@ -152,12 +152,8 @@ public final class DHKeyAgreement extends KeyAgreementSpi {
                             ockDHKeyPub.getDHKeyId(), ockDHKeyPriv.getDHKeyId());
                 }
             }
-        } catch (IllegalStateException ise) {
-            throw new IllegalStateException(ise.getMessage());
-        } catch (OCKException e) {
-            IllegalStateException ise = new IllegalStateException(e.getMessage());
-            provider.setOCKExceptionCause(ise, e);
-            throw ise;
+        } catch (NativeException e) {
+            throw new IllegalStateException("engineGenerateSecret failed", e);
         }
 
         // Make the computed secert compatible with  IBMJCE provider
@@ -184,7 +180,7 @@ public final class DHKeyAgreement extends KeyAgreementSpi {
                     System.arraycopy(secret, 1, result, 0, expectedLen);
                 } else {
                     throw provider.providerException("Failed to generate secret",
-                            new OCKException("secret is out-of-range"));
+                            new NativeException("secret is out-of-range"));
                 }
             }
             return result;

--- a/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHPrivateKey.java
@@ -9,7 +9,7 @@
 package com.ibm.crypto.plus.provider;
 
 import com.ibm.crypto.plus.provider.base.DHKey;
-import com.ibm.crypto.plus.provider.base.OCKException;
+import com.ibm.crypto.plus.provider.base.NativeException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -95,7 +95,7 @@ final class DHPrivateKey extends PKCS8Key implements javax.crypto.interfaces.DHP
             this.dhKey = DHKey.createPrivateKey(encodedKey, provider);
         } catch (IOException e) {
             throw new InvalidKeyException("Cannot produce ASN.1 encoding");
-        } catch (OCKException e) {
+        } catch (NativeException e) {
             throw new InvalidKeyException("Failure in DHPrivateKey");
         }
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAPrivateKey.java
@@ -70,10 +70,8 @@ final class DSAPrivateKey extends PKCS8Key
             byte[] privateKeyBytes = buildOCKPrivateKeyBytes();
             this.dsaKey = DSAKey.createPrivateKey(privateKeyBytes, provider);
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create DSA private key",
+            throw new InvalidKeyException("Failed to create DSA private key",
                     exception);
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
         }
     }
 
@@ -92,10 +90,8 @@ final class DSAPrivateKey extends PKCS8Key
             byte[] privateKeyBytes = buildOCKPrivateKeyBytes();
             this.dsaKey = DSAKey.createPrivateKey(privateKeyBytes, provider);
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create DSA private key",
+            throw new InvalidKeyException("Failed to create DSA private key",
                     exception);
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
         }
     }
 
@@ -108,10 +104,8 @@ final class DSAPrivateKey extends PKCS8Key
             this.dsaKey = dsaKey;
             parseKeyBits();
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create DSA private key",
+            throw new InvalidKeyException("Failed to create DSA private key",
                     exception);
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/DSAPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSAPublicKey.java
@@ -72,9 +72,7 @@ final class DSAPublicKey extends X509Key
             byte[] publicKeyBytes = buildOCKPublicKeyBytes();
             this.dsaKey = DSAKey.createPublicKey(publicKeyBytes, provider);
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create DSA public key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create DSA public key", exception);
         }
     }
 
@@ -93,9 +91,7 @@ final class DSAPublicKey extends X509Key
             byte[] publicKeyBytes = buildOCKPublicKeyBytes();
             this.dsaKey = DSAKey.createPublicKey(publicKeyBytes, provider);
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create DSA public key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create DSA public key", exception);
         }
     }
 
@@ -110,10 +106,8 @@ final class DSAPublicKey extends X509Key
             this.dsaKey = dsaKey;
             parseKeyBits();
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create DSA public key",
+            throw new InvalidKeyException("Failed to create DSA public key",
                     exception);
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/DSASignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSASignature.java
@@ -76,9 +76,7 @@ abstract class DSASignature extends SignatureSpi {
         try {
             this.signature.update(b, off, len);
         } catch (Exception e) {
-            SignatureException se = new SignatureException("Failure in engineUpdate");
-            provider.setOCKExceptionCause(se, e);
-            throw se;
+            throw new SignatureException("Failure in engineUpdate", e);
         }
     }
 
@@ -87,9 +85,7 @@ abstract class DSASignature extends SignatureSpi {
         try {
             return this.signature.sign();
         } catch (Exception e) {
-            SignatureException signatureException = new SignatureException("Could not sign data");
-            provider.setOCKExceptionCause(signatureException, e);
-            throw signatureException;
+            throw new SignatureException("Could not sign data", e);
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/DSASignatureNONE.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DSASignatureNONE.java
@@ -89,9 +89,7 @@ public final class DSASignatureNONE extends SignatureSpi {
             byte[] signature = this.signature.sign(digestBuffer);
             return signature;
         } catch (Exception e) {
-            SignatureException signatureException = new SignatureException("Could not sign data");
-            provider.setOCKExceptionCause(signatureException, e);
-            throw signatureException;
+            throw new SignatureException("Could not sign data", e);
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/DatawithECDSA.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DatawithECDSA.java
@@ -126,10 +126,7 @@ public final class DatawithECDSA extends SignatureSpi {
                 throw new SignatureException("invalid encoding for signature: " + ioe, ioe);
             }
         } catch (Exception e) {
-            SignatureException signatureException = new SignatureException("Could not sign data",
-                    e);
-            provider.setOCKExceptionCause(signatureException, e);
-            throw signatureException;
+            throw new SignatureException("Could not sign data", e);
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/ECDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECDHKeyAgreement.java
@@ -9,7 +9,7 @@
 package com.ibm.crypto.plus.provider;
 
 import com.ibm.crypto.plus.provider.base.ECKey;
-import com.ibm.crypto.plus.provider.base.OCKException;
+import com.ibm.crypto.plus.provider.base.NativeException;
 import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -210,7 +210,7 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi { // implements
                             ockEcKeyPub.getEcKeyId(), ockEcKeyPriv.getEcKeyId(), provider);
                 }
             }
-        } catch (OCKException e) {
+        } catch (NativeException e) {
             throw new IllegalStateException(e.getMessage());
         } catch (Exception e) {
             throw provider.providerException("Failed to generate secret", e);

--- a/src/main/java/com/ibm/crypto/plus/provider/ECDSASignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECDSASignature.java
@@ -87,9 +87,7 @@ abstract class ECDSASignature extends SignatureSpi {
         try {
             this.signature.update(b, off, len);
         } catch (Exception e) {
-            SignatureException signatureException = new SignatureException(e.getMessage());
-            provider.setOCKExceptionCause(signatureException, e);
-            throw signatureException;
+            throw new SignatureException("Could not update", e);
         }
     }
 
@@ -98,9 +96,7 @@ abstract class ECDSASignature extends SignatureSpi {
         try {
             return this.signature.sign();
         } catch (Exception e) {
-            SignatureException signatureException = new SignatureException("Could not sign data");
-            provider.setOCKExceptionCause(signatureException, e);
-            throw signatureException;
+            throw new SignatureException("Could not sign data", e);
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/ECPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECPublicKey.java
@@ -68,9 +68,7 @@ final class ECPublicKey extends X509Key
             this.ecKey = ECKey.createPublicKey(publicKeyBytes,
                     parameterBytes, provider);
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create EC public key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create EC public key", exception);
         }
     }
 
@@ -92,9 +90,7 @@ final class ECPublicKey extends X509Key
             this.ecKey = ECKey.createPublicKey(publicKeyBytes,
                     parameterBytes, provider);
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create EC public key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create EC public key", exception);
         }
     }
 
@@ -116,9 +112,7 @@ final class ECPublicKey extends X509Key
             parseKeyBits();
 
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create EC public key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create EC public key", exception);
         } finally {
             if (algidOut != null) {
                 try {

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAPrivateKeyImpl.java
@@ -106,7 +106,7 @@ final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKey {
         } catch (Exception exception) {
             InvalidParameterException ike = new InvalidParameterException(
                     "Failed to create XEC private key");
-            provider.setOCKExceptionCause(ike, exception);
+            provider.setExceptionCause(ike, exception);
             throw ike;
         }
         checkLength(this.curve);
@@ -126,9 +126,7 @@ final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKey {
                     encodingSize, provider);
 
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create XEC private key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create XEC private key", exception);
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAPublicKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAPublicKeyImpl.java
@@ -74,9 +74,7 @@ final class EdDSAPublicKeyImpl extends X509Key implements EdECPublicKey {
             this.algid = CurveUtil.getAlgId(curve);
             setFieldsFromXeckey();
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create XEC public key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create XEC public key", exception);
         }
 
         //System.out.println("Pub Point = " + this.point);
@@ -116,9 +114,7 @@ final class EdDSAPublicKeyImpl extends X509Key implements EdECPublicKey {
             this.xecKey = XECKey.createPublicKey(alteredEncoded, provider);
 
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create EdDSA public key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create EdDSA public key", exception);
         }
 
         checkLength(this.curve);
@@ -148,9 +144,7 @@ final class EdDSAPublicKeyImpl extends X509Key implements EdECPublicKey {
             this.xecKey = XECKey.createPublicKey(der, provider);
 
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create EdDSA public key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create EdDSA public key", exception);
         }
         checkLength(this.curve);
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSASignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSASignature.java
@@ -163,9 +163,7 @@ abstract class EdDSASignature extends SignatureSpi {
             message = null;
             return this.signature.sign(dataBytes);
         } catch (Exception e) {
-            SignatureException signatureException = new SignatureException("Could not sign data");
-            provider.setOCKExceptionCause(signatureException, e);
-            throw signatureException;
+            throw new SignatureException("Could not sign data", e);
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/HKDFGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/HKDFGenerator.java
@@ -9,7 +9,7 @@
 package com.ibm.crypto.plus.provider;
 
 import com.ibm.crypto.plus.provider.base.HKDF;
-import com.ibm.crypto.plus.provider.base.OCKException;
+import com.ibm.crypto.plus.provider.base.NativeException;
 import ibm.security.internal.spec.HKDFExpandParameterSpec;
 import ibm.security.internal.spec.HKDFExtractParameterSpec;
 import ibm.security.internal.spec.HKDFParameterSpec;
@@ -116,7 +116,7 @@ public class HKDFGenerator extends KeyGeneratorSpi {
                 extractedBytes = hkdfObj.extract(saltBytes, saltBytes.length, ikmBytes,
                         ikmBytes.length);
                 secretKey = new SecretKeySpec(extractedBytes, keyAlgorithm);
-            } catch (OCKException e) {
+            } catch (NativeException e) {
                 throw new IllegalStateException(MSG_EXTRACT + e.getMessage());
             }
 
@@ -131,7 +131,7 @@ public class HKDFGenerator extends KeyGeneratorSpi {
                 expandedBytes = hkdfObj.expand(prkBytes, (long) prkBytes.length, infoBytes,
                         (long) infoBytes.length, okmLength);
                 secretKey = new SecretKeySpec(expandedBytes, keyAlgorithm);
-            } catch (OCKException e) {
+            } catch (NativeException e) {
                 throw new IllegalStateException(MSG_EXPAND + e.getMessage());
             }
 
@@ -151,7 +151,7 @@ public class HKDFGenerator extends KeyGeneratorSpi {
                 resultBytes = hkdfObj.derive(saltBytes, (long) saltBytes.length, ikmBytes,
                         (long) ikmBytes.length, infoBytes, (long) infoBytes.length, okmLength);
                 secretKey = new SecretKeySpec(resultBytes, keyAlgorithm);
-            } catch (OCKException e) {
+            } catch (NativeException e) {
                 throw new IllegalStateException(MSG_DERIVE + e.getMessage());
             }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/MLKEMImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/MLKEMImpl.java
@@ -8,7 +8,7 @@
 
 package com.ibm.crypto.plus.provider;
 
-import com.ibm.crypto.plus.provider.base.OCKException;
+import com.ibm.crypto.plus.provider.base.NativeException;
 import com.ibm.crypto.plus.provider.base.OJPKEM;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -119,7 +119,7 @@ public class MLKEMImpl implements KEMSpi {
             try {
                 OJPKEM.KEM_encapsulate(((PQCPublicKey) publicKey).getPQCKey().getPKeyId(),
                         encapsulation, secret, provider);
-            } catch (OCKException e) {
+            } catch (NativeException e) {
                 throw new ProviderException("OCK Exception: ", e);
             }
 
@@ -201,7 +201,7 @@ public class MLKEMImpl implements KEMSpi {
                 secret = OJPKEM.KEM_decapsulate(((PQCPrivateKey) this.privateKey).getPQCKey().getPKeyId(),
                         cipherText, provider);
 
-            } catch (OCKException e) {
+            } catch (NativeException e) {
                 throw new DecapsulateException("Decapsulation Error: ", e);
             }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
@@ -1200,12 +1200,6 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
         }
     }
 
-    ProviderException providerException(String message, Throwable ockException) {
-        ProviderException providerException = new ProviderException(message, ockException);
-        setOCKExceptionCause(providerException, ockException);
-        return providerException;
-    }
-
     // Get the date from the ImplementationVersion in the manifest file
     private static String getDebugDate(String className) {
         String versionDate = "Unknown";

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -742,12 +742,6 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
         }
     }
 
-    ProviderException providerException(String message, Throwable ockException) {
-        ProviderException providerException = new ProviderException(message, ockException);
-        setOCKExceptionCause(providerException, ockException);
-        return providerException;
-    }
-
     // Get the date from the ImplementationVersion in the manifest file
     private static String getDebugDate(String className) {
         String versionDate = "Unknown";

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
@@ -105,11 +105,13 @@ public abstract class OpenJCEPlusProvider extends java.security.Provider {
         return JAVA_VER;
     }
 
-    abstract ProviderException providerException(String message, Throwable ockException);
+    ProviderException providerException(String message, Throwable throwable) {
+        return new ProviderException(message, throwable);
+    }
 
-    void setOCKExceptionCause(Exception exception, Throwable ockException) {
-        if ((debug != null) && (exception != null) && (exception.getCause() == null)) {
-            exception.initCause(ockException);
+    void setExceptionCause(Exception exception, Throwable throwable) {
+        if ((exception != null) && (exception.getCause() == null)) {
+            exception.initCause(throwable);
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/PBKDF2KeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PBKDF2KeyImpl.java
@@ -8,7 +8,7 @@
 
 package com.ibm.crypto.plus.provider;
 
-import com.ibm.crypto.plus.provider.base.OCKException;
+import com.ibm.crypto.plus.provider.base.NativeException;
 import com.ibm.crypto.plus.provider.base.PBKDF;
 import java.io.IOException;
 import java.io.InvalidObjectException;
@@ -120,7 +120,7 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
             try {
                 this.key = PBKDF.PBKDF2derive(this.prfAlgorithm,
                         passwdBytes, salt, iterCount, keyLength / 8, provider);
-            } catch (OCKException e) {
+            } catch (NativeException e) {
                 throw new InvalidKeySpecException(
                         "Error while deriving PBKDF2 key from a given PBEKeySpec.", e);
             }

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCPublicKey.java
@@ -51,9 +51,7 @@ final class PQCPublicKey extends X509Key
 
             this.pqcKey = PQCKey.createPublicKey(algName, b, provider);
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create public key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create public key", exception);
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCSignatureImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCSignatureImpl.java
@@ -138,9 +138,7 @@ abstract class PQCSignatureImpl extends SignatureSpi {
             byte[] sign = this.signature.sign(dataBytes);
             return sign;
         } catch (Exception e) {
-            SignatureException signatureException = new SignatureException("Could not sign data");
-            provider.setOCKExceptionCause(signatureException, e);
-            throw signatureException;
+            throw new SignatureException("Could not sign data", e);
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/RC2Cipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RC2Cipher.java
@@ -8,7 +8,7 @@
 
 package com.ibm.crypto.plus.provider;
 
-import com.ibm.crypto.plus.provider.base.OCKException;
+import com.ibm.crypto.plus.provider.base.NativeException;
 import com.ibm.crypto.plus.provider.base.Padding;
 import com.ibm.crypto.plus.provider.base.SymmetricCipher;
 import java.security.AlgorithmParameters;
@@ -68,7 +68,7 @@ public final class RC2Cipher extends LegacyCipher {
         } catch (ShortBufferException ock_sbe) {
             // should not occur
             throw provider.providerException("Failure in engineDoFinal", ock_sbe);
-        } catch (OCKException e) {
+        } catch (NativeException e) {
             throw provider.providerException("Failure in engineDoFinal", e);
         }
     }
@@ -81,7 +81,7 @@ public final class RC2Cipher extends LegacyCipher {
 
         try {
             return symmetricCipher.doFinal(input, inputOffset, inputLen, output, outputOffset);
-        } catch (OCKException e) {
+        } catch (NativeException e) {
             throw provider.providerException("Failure in engineDoFinal", e);
         }
     }
@@ -245,7 +245,7 @@ public final class RC2Cipher extends LegacyCipher {
         } catch (ShortBufferException ock_sbe) {
             // should not occur
             throw provider.providerException("Failure in engineUpdate", ock_sbe);
-        } catch (OCKException e) {
+        } catch (NativeException e) {
             throw provider.providerException("Failure in engineUpdate", e);
         }
     }
@@ -260,7 +260,7 @@ public final class RC2Cipher extends LegacyCipher {
         } catch (BadPaddingException ock_bpe) {
             // should not occur
             throw provider.providerException("Failure in engineDoFinal", ock_bpe);
-        } catch (OCKException e) {
+        } catch (NativeException e) {
             throw provider.providerException("Failure in engineDoFinal", e);
         }
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/RC4Cipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RC4Cipher.java
@@ -8,7 +8,7 @@
 
 package com.ibm.crypto.plus.provider;
 
-import com.ibm.crypto.plus.provider.base.OCKException;
+import com.ibm.crypto.plus.provider.base.NativeException;
 import com.ibm.crypto.plus.provider.base.SymmetricCipher;
 import java.security.AlgorithmParameters;
 import java.security.InvalidAlgorithmParameterException;
@@ -62,7 +62,7 @@ public final class RC4Cipher extends LegacyCipher {
         } catch (ShortBufferException ock_sbe) {
             // should not occur
             throw provider.providerException("Failure in engineDoFinal", ock_sbe);
-        } catch (OCKException e) {
+        } catch (NativeException e) {
             throw provider.providerException("Failure in engineDoFinal", e);
         }
     }
@@ -75,7 +75,7 @@ public final class RC4Cipher extends LegacyCipher {
 
         try {
             return symmetricCipher.doFinal(input, inputOffset, inputLen, output, outputOffset);
-        } catch (OCKException e) {
+        } catch (NativeException e) {
             throw provider.providerException("Failure in engineDoFinal", e);
         }
     }
@@ -213,7 +213,7 @@ public final class RC4Cipher extends LegacyCipher {
         } catch (ShortBufferException ock_sbe) {
             // should not occur
             throw provider.providerException("Failure in engineUpdate", ock_sbe);
-        } catch (OCKException e) {
+        } catch (NativeException e) {
             throw provider.providerException("Failure in engineUpdate", e);
         }
     }
@@ -228,7 +228,7 @@ public final class RC4Cipher extends LegacyCipher {
         } catch (BadPaddingException ock_bpe) {
             // should not occur
             throw provider.providerException("Failure in engineDoFinal", ock_bpe);
-        } catch (OCKException e) {
+        } catch (NativeException e) {
             throw provider.providerException("Failure in engineDoFinal", e);
         }
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/RSA.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSA.java
@@ -8,7 +8,7 @@
 
 package com.ibm.crypto.plus.provider;
 
-import com.ibm.crypto.plus.provider.base.OCKException;
+import com.ibm.crypto.plus.provider.base.NativeException;
 import com.ibm.crypto.plus.provider.base.RSACipher;
 import com.ibm.crypto.plus.provider.base.RSAPadding;
 import java.nio.ByteBuffer;
@@ -142,7 +142,7 @@ public final class RSA extends CipherSpi {
             this.msgLength = 0; // reset cipher for another
                                 // encryption/decryption
             return outLen;
-        } catch (OCKException e) {
+        } catch (NativeException e) {
             // Unsure of msg length behavior on failure. e.g. do we set it to 0?
             // do we clear the buffer?
             throw provider.providerException("Failure in engineDoFinal", e);
@@ -547,7 +547,7 @@ public final class RSA extends CipherSpi {
         }
     }
 
-    private int oaepInputLimit() throws InvalidAlgorithmParameterException, OCKException {
+    private int oaepInputLimit() throws InvalidAlgorithmParameterException, NativeException {
         int digestLength = getDigestLength();
         // The limit for useful data is the maximum amount based on the keysize
         // minus the OAEP padding, which is twice the output size of the digest
@@ -555,7 +555,7 @@ public final class RSA extends CipherSpi {
         return rsaCipher.getOutputSize() - (2 * digestLength) - 2;
     }
 
-    private int pkcs1InputLimit() throws OCKException {
+    private int pkcs1InputLimit() throws NativeException {
         // The limit for useful data is the maximum amount based on the keysize
         // minus the PKCS1 padding, which is exactly 11 bytes.
         return rsaCipher.getOutputSize() - 11;

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPSSSignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPSSSignature.java
@@ -295,9 +295,7 @@ public final class RSAPSSSignature extends SignatureSpi {
         try {
             this.signature.update(b, off, len);
         } catch (Exception e) {
-            SignatureException se = new SignatureException("Failure in engineUpdate");
-            provider.setOCKExceptionCause(se, e);
-            throw se;
+            throw new SignatureException("Failure in engineUpdate", e);
         }
     }
 
@@ -306,9 +304,7 @@ public final class RSAPSSSignature extends SignatureSpi {
         try {
             return this.signature.signFinal();
         } catch (Exception e) {
-            SignatureException signatureException = new SignatureException("Could not sign data");
-            provider.setOCKExceptionCause(signatureException, e);
-            throw signatureException;
+            throw new SignatureException("Could not sign data", e);
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateCrtKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateCrtKey.java
@@ -113,9 +113,7 @@ final class RSAPrivateCrtKey extends PKCS8Key
         try {
             this.rsaKey = RSAKey.createPrivateKey(this.key, provider);
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create RSA private key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create RSA private key", exception);
         }
     }
 
@@ -127,10 +125,8 @@ final class RSAPrivateCrtKey extends PKCS8Key
         try {
             parseKeyBits();
         } catch (IOException e) {
-            InvalidKeyException ike = new InvalidKeyException(
-                    "Failed to parse key bits of encoded key");
-            provider.setOCKExceptionCause(ike, e);
-            throw ike;
+            throw new InvalidKeyException(
+                    "Failed to parse key bits of encoded key", e);
         }
 
         RSAKeyFactory.checkRSAProviderKeyLengths(provider, modulus.bitLength(), publicExponent);
@@ -138,9 +134,7 @@ final class RSAPrivateCrtKey extends PKCS8Key
         try {
             this.rsaKey = RSAKey.createPrivateKey(this.key, provider);
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create RSA private key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create RSA private key", exception);
         }
     }
 
@@ -165,9 +159,7 @@ final class RSAPrivateCrtKey extends PKCS8Key
             this.keyParams = RSAUtil.getParamSpec(algid);
             parseKeyBits();
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create RSA private key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create RSA private key", exception);
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPrivateKey.java
@@ -71,9 +71,7 @@ final class RSAPrivateKey extends PKCS8Key
         try {
             this.rsaKey = RSAKey.createPrivateKey(this.key, provider);
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create RSA private key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create RSA private key", exception);
         }
     }
 
@@ -83,10 +81,8 @@ final class RSAPrivateKey extends PKCS8Key
         try {
             parseKeyBits();
         } catch (IOException e) {
-            InvalidKeyException ike = new InvalidKeyException(
-                    "Failed to parse key bits of encoded key");
-            provider.setOCKExceptionCause(ike, e);
-            throw ike;
+            throw new InvalidKeyException(
+                    "Failed to parse key bits of encoded key", e);
         }
 
         RSAKeyFactory.checkRSAProviderKeyLengths(provider, modulus.bitLength(), null);
@@ -94,9 +90,7 @@ final class RSAPrivateKey extends PKCS8Key
         try {
             this.rsaKey = RSAKey.createPrivateKey(this.key, provider);
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create RSA private key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create RSA private key", exception);
         }
     }
 
@@ -123,9 +117,7 @@ final class RSAPrivateKey extends PKCS8Key
             this.keyParams = RSAUtil.getParamSpec(algId);
             parseKeyBits();
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create RSA private key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create RSA private key", exception);
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAPublicKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAPublicKey.java
@@ -75,9 +75,7 @@ final class RSAPublicKey extends X509Key
         try {
             this.rsaKey = RSAKey.createPublicKey(getKey().toByteArray(), provider);
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create RSA public key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create RSA public key", exception);
         }
     }
 
@@ -93,9 +91,7 @@ final class RSAPublicKey extends X509Key
         try {
             this.rsaKey = RSAKey.createPublicKey(getKey().toByteArray(), provider);
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create RSA public key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create RSA public key", exception);
         }
         try {
             // this will check the validity of params
@@ -150,9 +146,7 @@ final class RSAPublicKey extends X509Key
             this.rsaKey = rsaKey;
             parseKeyBits();
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create RSA public key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create RSA public key", exception);
         }
 
         try {

--- a/src/main/java/com/ibm/crypto/plus/provider/RSASignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSASignature.java
@@ -168,9 +168,7 @@ abstract class RSASignature extends SignatureSpi {
         try {
             this.signature.update(b, off, len);
         } catch (Exception e) {
-            SignatureException se = new SignatureException("Failure in engineUpdate");
-            provider.setOCKExceptionCause(se, e);
-            throw se;
+            throw new SignatureException("Failure in engineUpdate", e);
         }
     }
 
@@ -199,9 +197,7 @@ abstract class RSASignature extends SignatureSpi {
             }
             return this.signature.sign();
         } catch (Exception e) {
-            SignatureException signatureException = new SignatureException("Could not sign data");
-            provider.setOCKExceptionCause(signatureException, e);
-            throw signatureException;
+            throw new SignatureException("Could not sign data", e);
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/RSASignatureNONE.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSASignatureNONE.java
@@ -174,9 +174,7 @@ public final class RSASignatureNONE extends SignatureSpi {
                 return output;
             }
         } catch (Exception e) {
-            SignatureException signatureException = new SignatureException("Could not sign data");
-            provider.setOCKExceptionCause(signatureException, e);
-            throw signatureException;
+            throw new SignatureException("Could not sign data", e);
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/RSASignatureSSL.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSASignatureSSL.java
@@ -176,9 +176,7 @@ public final class RSASignatureSSL extends SignatureSpi {
                 return output;
             }
         } catch (Exception e) {
-            SignatureException signatureException = new SignatureException("Could not sign data");
-            provider.setOCKExceptionCause(signatureException, e);
-            throw signatureException;
+            throw new SignatureException("Could not sign data", e);
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/RSASignatureSSL_I2.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSASignatureSSL_I2.java
@@ -169,9 +169,7 @@ public final class RSASignatureSSL_I2 extends SignatureSpi {
             byte[] signature = this.signature.sign(dataBytes);
             return signature;
         } catch (Exception e) {
-            SignatureException signatureException = new SignatureException("Could not sign data");
-            provider.setOCKExceptionCause(signatureException, e);
-            throw signatureException;
+            throw new SignatureException("Could not sign data", e);
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
@@ -10,7 +10,7 @@ package com.ibm.crypto.plus.provider;
 
 
 import com.ibm.crypto.plus.provider.CurveUtil.CURVE;
-import com.ibm.crypto.plus.provider.base.OCKException;
+import com.ibm.crypto.plus.provider.base.NativeException;
 import com.ibm.crypto.plus.provider.base.XECKey;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -113,7 +113,7 @@ abstract class XDHKeyAgreement extends KeyAgreementSpi {
             }
             this.secret = XECKey.computeECDHSecret(genCtx,
                     ockXecKeyPub.getPKeyId(), ockXecKeyPriv.getPKeyId(), secrectBufferSize, provider);
-        } catch (OCKException e) {
+        } catch (NativeException e) {
             //Validate the secret value for a small order point condition.
             byte orValue = (byte) 0;
             for (int i = 0; i < secret.length; i++) {

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
@@ -95,9 +95,7 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
             int encodingSize = CurveUtil.getDEREncodingSize(curve);
             this.xecKey = XECKey.createPrivateKey(alteredEncoded, encodingSize, provider);
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create XEC private key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create XEC private key", exception);
         }
     }
 
@@ -148,7 +146,7 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
         } catch (Exception exception) {
             InvalidParameterException ike = new InvalidParameterException(
                     "Failed to create XEC private key");
-            provider.setOCKExceptionCause(ike, exception);
+            provider.setExceptionCause(ike, exception);
             throw ike;
         }
 
@@ -446,9 +444,7 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
         try {
             setFieldsFromXeckey();
         } catch (Exception exception) {
-            IOException ike = new IOException("Failed in setFieldsFromXeckey");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new IOException("Failed in setFieldsFromXeckey", exception);
         }
 
         DerOutputStream bytes = new DerOutputStream();

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPublicKeyImpl.java
@@ -89,9 +89,7 @@ final class XDHPublicKeyImpl extends X509Key implements XECPublicKey, Destroyabl
             this.algid = CurveUtil.getAlgId(curve);
             setFieldsFromXeckey();
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create XEC public key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create XEC public key", exception);
         }
     }
 
@@ -130,9 +128,7 @@ final class XDHPublicKeyImpl extends X509Key implements XECPublicKey, Destroyabl
             byte[] alteredEncoded = alterEncodedPublicKey(encoded); // Alters encoded to fit GSKit, and sets params
             this.xecKey = XECKey.createPublicKey(alteredEncoded, provider);
         } catch (Exception exception) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to create XEC public key");
-            provider.setOCKExceptionCause(ike, exception);
-            throw ike;
+            throw new InvalidKeyException("Failed to create XEC public key", exception);
         }
     }
 
@@ -212,7 +208,7 @@ final class XDHPublicKeyImpl extends X509Key implements XECPublicKey, Destroyabl
         } catch (Exception exception) {
             InvalidParameterException ike = new InvalidParameterException(
                     "Failed to create XEC public key");
-            provider.setOCKExceptionCause(ike, exception);
+            provider.setExceptionCause(ike, exception);
             throw ike;
         }
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/base/AESKeyWrap.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/AESKeyWrap.java
@@ -20,18 +20,18 @@ public final class AESKeyWrap {
     private boolean padding = false;
 
     public AESKeyWrap(OpenJCEPlusProvider provider, byte[] key, boolean padding)
-            throws OCKException {
+            throws NativeException {
         if (key == null) {
-            throw new OCKException("Invalid input data");
+            throw new NativeException("Invalid input data");
         }
         this.nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
         this.key = key;
         this.padding = padding;
     }
 
-    public byte[] wrap(byte[] data, int start, int length) throws OCKException {
+    public byte[] wrap(byte[] data, int start, int length) throws NativeException {
         if (data == null || start < 0 || data.length < start || data.length < (length + start)) {
-            throw new OCKException("Invalid input data");
+            throw new NativeException("Invalid input data");
         }
         byte[] output = null;
         byte[] inData = Arrays.copyOfRange(data, start, length);
@@ -44,7 +44,7 @@ public final class AESKeyWrap {
         try {
             output = this.nativeInterface.CIPHER_KeyWraporUnwrap(inData, this.key, type);
         } catch (Exception e) {
-            throw new OCKException("Failed to wrap data" + e.getMessage());
+            throw new NativeException("Failed to wrap data" + e.getMessage());
         }  finally {
             //Clear inData
             Arrays.fill(inData, (byte) 0);
@@ -52,9 +52,9 @@ public final class AESKeyWrap {
         return output;
     }
 
-    public byte[] unwrap(byte[] data, int start, int length) throws OCKException {
+    public byte[] unwrap(byte[] data, int start, int length) throws NativeException {
         if (data == null || start < 0 || length < start || data.length < (length - start)) {
-            throw new OCKException("Invalid input data");
+            throw new NativeException("Invalid input data");
         }
         byte[] output = null;
         byte[] inData = Arrays.copyOfRange(data, start, length);
@@ -67,7 +67,7 @@ public final class AESKeyWrap {
         try {
             output = this.nativeInterface.CIPHER_KeyWraporUnwrap(inData, this.key, type);
         } catch (Exception e) {
-            throw new OCKException("Failed to unwrap data" + e.getMessage());
+            throw new NativeException("Failed to unwrap data" + e.getMessage());
         }  finally {
             //Clear inData
             Arrays.fill(inData, (byte) 0);

--- a/src/main/java/com/ibm/crypto/plus/provider/base/AsymmetricKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/AsymmetricKey.java
@@ -12,9 +12,9 @@ public interface AsymmetricKey {
 
     public String getAlgorithm();
 
-    public long getPKeyId() throws OCKException;
+    public long getPKeyId() throws NativeException;
 
-    public byte[] getPrivateKeyBytes() throws OCKException;
+    public byte[] getPrivateKeyBytes() throws NativeException;
 
-    public byte[] getPublicKeyBytes() throws OCKException;
+    public byte[] getPublicKeyBytes() throws NativeException;
 }

--- a/src/main/java/com/ibm/crypto/plus/provider/base/BasicRandom.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/BasicRandom.java
@@ -26,7 +26,7 @@ public final class BasicRandom {
         this.nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
     }
 
-    public void nextBytes(byte[] bytes) throws OCKException {
+    public void nextBytes(byte[] bytes) throws NativeException {
         if (bytes == null) {
             throw new IllegalArgumentException("bytes is null");
         }
@@ -36,7 +36,7 @@ public final class BasicRandom {
         }
     }
 
-    public void setSeed(byte[] seed) throws OCKException {
+    public void setSeed(byte[] seed) throws NativeException {
         if (seed == null) {
             throw new IllegalArgumentException("seed is null");
         }
@@ -46,7 +46,7 @@ public final class BasicRandom {
         }
     }
 
-    public byte[] generateSeed(int numBytes) throws OCKException {
+    public byte[] generateSeed(int numBytes) throws NativeException {
         if (numBytes < 0) {
             throw new IllegalArgumentException("numBytes is negative");
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/base/CCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/CCMCipher.java
@@ -84,7 +84,7 @@ public final class CCMCipher {
         //        int tls_support_result=1;
         //        try {
         //            tls_support_result = NativeInterface.get_CCM_TLSEnabled();
-        //        } catch (OCKException e) {
+        //        } catch (NativeException e) {
         //            tls_support_result = 1;
         //        }
         //Java Thread Local Storage is always enabled.
@@ -106,7 +106,7 @@ public final class CCMCipher {
 
     public static int doCCMFinal_Decrypt(byte[] key, byte[] iv, int tagLen,
             byte[] input, int inputOffset, int inputLen, byte[] output, int outputOffset,
-            byte[] aad, OpenJCEPlusProvider provider) throws OCKException, IllegalStateException, ShortBufferException,
+            byte[] aad, OpenJCEPlusProvider provider) throws NativeException, IllegalStateException, ShortBufferException,
             IllegalBlockSizeException, BadPaddingException, AEADBadTagException {
 
         //final String methodName="doCCMFinal_Decrypt ";
@@ -224,7 +224,7 @@ public final class CCMCipher {
             }
 
             if (rc != 0) {
-                throw new OCKException(ErrorCodes.get(rc));
+                throw new NativeException(ErrorCodes.get(rc));
             }
         } else {
             //OCKDebug.Msg (debPrefix, methodName, "key.length :" + key.length + " iv.length :" + iv.length + " inputOffset :" + inputOffset);
@@ -243,7 +243,7 @@ public final class CCMCipher {
                     tagLen);
 
             if (rc != 0) {
-                throw new OCKException(ErrorCodes.get(rc));
+                throw new NativeException(ErrorCodes.get(rc));
             } else {
                 // Copy contents of tempOutput to output at outputOffset for len bytes
                 // len is at least output.length + outputOffset
@@ -258,7 +258,7 @@ public final class CCMCipher {
 
     public static int doCCMFinal_Encrypt(byte[] key, byte[] iv, int tagLen,
             byte[] input, int inputOffset, int inputLen, byte[] output, int outputOffset,
-            byte[] aad, OpenJCEPlusProvider provider) throws OCKException, IllegalStateException, ShortBufferException,
+            byte[] aad, OpenJCEPlusProvider provider) throws NativeException, IllegalStateException, ShortBufferException,
             IllegalBlockSizeException, BadPaddingException {
 
         //final String methodName = "doCCMFinal_Encrypt ";
@@ -363,7 +363,7 @@ public final class CCMCipher {
                 outputBuffer.get(0, output, outputOffset, len);
             }
             if (rc != 0) {
-                throw new OCKException(ErrorCodes.get(rc));
+                throw new NativeException(ErrorCodes.get(rc));
             }
 
         } else {
@@ -381,7 +381,7 @@ public final class CCMCipher {
                     tempOutput.length, tagLen);
 
             if (rc != 0) {
-                throw new OCKException(ErrorCodes.get(rc));
+                throw new NativeException(ErrorCodes.get(rc));
             } else {
                 // Copy contents of tempOutput to output at outputOffset for len bytes
                 // len is at least output.length + outputOffset
@@ -440,7 +440,7 @@ public final class CCMCipher {
     }
 
 
-    public static void doCCM_cleanup(OpenJCEPlusProvider provider) throws OCKException {
+    public static void doCCM_cleanup(OpenJCEPlusProvider provider) throws NativeException {
         NativeInterface nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
         nativeInterface.do_CCM_delete();
     }
@@ -470,7 +470,7 @@ public final class CCMCipher {
     static int useHardwareCCM(boolean isEncrypt, int inputLen, int ivLen, int keyLen, int aadLen,
             int tagLen, byte[] key, byte[] input, int inputOffset, byte[] output, int outputOffset,
             FastJNIBuffer parameters)
-            throws OCKException, IllegalStateException, ShortBufferException,
+            throws NativeException, IllegalStateException, ShortBufferException,
             IllegalBlockSizeException, BadPaddingException, AEADBadTagException {
 
         int rc = 0;

--- a/src/main/java/com/ibm/crypto/plus/provider/base/DHKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/DHKey.java
@@ -34,7 +34,7 @@ public final class DHKey implements AsymmetricKey {
     private static final String debPrefix = "DHKey";
 
     public static DHKey generateKeyPair(byte[] parameters, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         //final String methodName = "generateKeyPair(byte[]) ";
 
         if (parameters == null || parameters.length == 0) {
@@ -50,7 +50,7 @@ public final class DHKey implements AsymmetricKey {
                 unobtainedKeyBytes, provider);
     }
 
-    public static DHKey generateKeyPair(int numBits, OpenJCEPlusProvider provider) throws OCKException {
+    public static DHKey generateKeyPair(int numBits, OpenJCEPlusProvider provider) throws NativeException {
         if (numBits < 0) {
             throw new IllegalArgumentException("key length is invalid");
         }
@@ -72,7 +72,7 @@ public final class DHKey implements AsymmetricKey {
     }
 
     public static DHKey createPrivateKey(byte[] privateKeyBytes, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         //final String methodName = "DHKey createPrivateKey (byte[]) ";
         if (privateKeyBytes == null) {
             throw new IllegalArgumentException("key bytes is null");
@@ -87,7 +87,7 @@ public final class DHKey implements AsymmetricKey {
     }
 
     public static DHKey createPublicKey(byte[] publicKeyBytes, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         if (publicKeyBytes == null) {
             throw new IllegalArgumentException("key bytes is null");
         }
@@ -125,7 +125,7 @@ public final class DHKey implements AsymmetricKey {
     }
 
     @Override
-    public long getPKeyId() throws OCKException {
+    public long getPKeyId() throws NativeException {
         //final String methodName = "getPKeyId() :";
         if (pkeyId.getValue() == 0) {
             obtainPKeyId();
@@ -134,7 +134,7 @@ public final class DHKey implements AsymmetricKey {
     }
 
     @Override
-    public byte[] getPrivateKeyBytes() throws OCKException {
+    public byte[] getPrivateKeyBytes() throws NativeException {
         //final String methodName = "getPrivateKeyBytes () :";
         if (privateKeyBytes == unobtainedKeyBytes) {
             obtainPrivateKeyBytes();
@@ -143,7 +143,7 @@ public final class DHKey implements AsymmetricKey {
         return (privateKeyBytes == null) ? null : privateKeyBytes.clone();
     }
 
-    public byte[] getParameters() throws OCKException {
+    public byte[] getParameters() throws NativeException {
         //final String methodName = "getParameters () :";
         if (parameters == null) {
             obtainParameters();
@@ -152,7 +152,7 @@ public final class DHKey implements AsymmetricKey {
     }
 
     @Override
-    public byte[] getPublicKeyBytes() throws OCKException {
+    public byte[] getPublicKeyBytes() throws NativeException {
         //final String methodName = "getPublicKeyBytes () :";
         if (publicKeyBytes == unobtainedKeyBytes) {
             obtainPublicKeyBytes();
@@ -165,7 +165,7 @@ public final class DHKey implements AsymmetricKey {
     // DHKey.computeDHSecret is not synchronized and not thread safe.
     // The method DHKey.computeDHSecret should NOT be synchronized for performance as that would create a global lock.
     public static byte[] computeDHSecret(NativeInterface nativeInterface, long pubKeyId, long privKeyId)
-            throws OCKException {
+            throws NativeException {
         //final String methodName = "computeDHSecret";
         if (nativeInterface == null) {
             throw new IllegalArgumentException("nativeInterface is null");
@@ -180,37 +180,37 @@ public final class DHKey implements AsymmetricKey {
         }
 
         if (!validId(pubKeyId) || !validId(privKeyId)) {
-            throw new OCKException(badIdMsg1);
+            throw new NativeException(badIdMsg1);
         }
         byte[] sharedSecretBytes = nativeInterface.DHKEY_computeDHSecret(pubKeyId, privKeyId);
         return sharedSecretBytes;
     }
 
-    private synchronized void obtainPKeyId() throws OCKException {
+    private synchronized void obtainPKeyId() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getPKeyId at the same time, we only want to call the native
         // code one time.
         if (pkeyId.getValue() == 0) {
             if (!validId(dhKeyId)) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             this.pkeyId.setValue(this.nativeInterface.DHKEY_createPKey(dhKeyId));
         }
     }
 
-    private synchronized void obtainPrivateKeyBytes() throws OCKException {
+    private synchronized void obtainPrivateKeyBytes() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getPrivateKeyBytes at the same time, we only want to call the
         // native code one time.
         if (privateKeyBytes == unobtainedKeyBytes) {
             if (!validId(dhKeyId)) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             this.privateKeyBytes = this.nativeInterface.DHKEY_getPrivateKeyBytes(dhKeyId);
         }
     }
 
-    private synchronized void obtainPublicKeyBytes() throws OCKException {
+    private synchronized void obtainPublicKeyBytes() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getPublicKeyBytes at the same time, we only want to call the
         // native code one time.
@@ -219,13 +219,13 @@ public final class DHKey implements AsymmetricKey {
         }
     }
 
-    private synchronized void obtainParameters() throws OCKException {
+    private synchronized void obtainParameters() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getParameters at the same time, we only want to call the
         // native code one time.
         if (parameters == null) {
             if (!validId(dhKeyId)) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             this.parameters = this.nativeInterface.DHKEY_getParameters(dhKeyId);
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/base/DSAKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/DSAKey.java
@@ -31,7 +31,7 @@ public final class DSAKey implements AsymmetricKey {
     private static final String badIdMsg = "DSA Key Identifier is not valid";
     private final static String debPrefix = "DSAKey";
 
-    public static DSAKey generateKeyPair(int numBits, OpenJCEPlusProvider provider) throws OCKException {
+    public static DSAKey generateKeyPair(int numBits, OpenJCEPlusProvider provider) throws NativeException {
         //final String methodName = "generateKeyPair(numBits) ";
         if (numBits < 0) {
             throw new IllegalArgumentException("key length is invalid");
@@ -40,7 +40,7 @@ public final class DSAKey implements AsymmetricKey {
         NativeInterface nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
         long dsaKeyId = nativeInterface.DSAKEY_generate(numBits);
         if (!validId(dsaKeyId)) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
 
         if (provider == null) {
@@ -51,7 +51,7 @@ public final class DSAKey implements AsymmetricKey {
     }
 
     public static byte[] generateParameters(int numBits, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         //final String methodName = "generateParameters(numBits) ";
         byte[] paramBytes = null;
         if (numBits < 0) {
@@ -61,13 +61,13 @@ public final class DSAKey implements AsymmetricKey {
         NativeInterface nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
         paramBytes = nativeInterface.DSAKEY_generateParameters(numBits);
         if (paramBytes == null) {
-            throw new OCKException("The generated DSA parameter bytes are incorrect.");
+            throw new NativeException("The generated DSA parameter bytes are incorrect.");
         }
         return paramBytes;
     }
 
     public static DSAKey generateKeyPair(byte[] parameters, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         //final String methodName = "generateKeyPair";
         if (parameters == null || parameters.length == 0) {
             throw new IllegalArgumentException("DSA parameters are null/empty");
@@ -77,7 +77,7 @@ public final class DSAKey implements AsymmetricKey {
         long dsaKeyId = nativeInterface.DSAKEY_generate(parameters);
         //OCKDebug.Msg (debPrefix, methodName, "dsaKeyId=" + dsaKeyId);
         if (!validId(dsaKeyId)) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
 
         if (provider == null) {
@@ -88,7 +88,7 @@ public final class DSAKey implements AsymmetricKey {
     }
 
     public static DSAKey createPrivateKey(byte[] privateKeyBytes, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         //final String methodName = "createPrivateKey ";
         if (privateKeyBytes == null) {
             throw new IllegalArgumentException("key bytes is null");
@@ -98,7 +98,7 @@ public final class DSAKey implements AsymmetricKey {
         long dsaKeyId = nativeInterface.DSAKEY_createPrivateKey(privateKeyBytes);
         //OCKDebug.Msg (debPrefix, methodName,  "dsakKeyId=" + dsaKeyId);
         if (!validId(dsaKeyId)) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
 
         if (provider == null) {
@@ -108,7 +108,7 @@ public final class DSAKey implements AsymmetricKey {
     }
 
     public static DSAKey createPublicKey(byte[] publicKeyBytes, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         //final String methodName = "createPublicKey";
         if (publicKeyBytes == null) {
             throw new IllegalArgumentException("key bytes is null");
@@ -117,7 +117,7 @@ public final class DSAKey implements AsymmetricKey {
         NativeInterface nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
         long dsaKeyId = nativeInterface.DSAKEY_createPublicKey(publicKeyBytes);
         if (!validId(dsaKeyId)) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
 
         if (provider == null) {
@@ -152,7 +152,7 @@ public final class DSAKey implements AsymmetricKey {
     }
 
     @Override
-    public long getPKeyId() throws OCKException {
+    public long getPKeyId() throws NativeException {
         //final String methodName = "getPKeyId";
         if (pkeyId.getValue() == 0) {
             obtainPKeyId();
@@ -161,7 +161,7 @@ public final class DSAKey implements AsymmetricKey {
         return pkeyId.getValue();
     }
 
-    public byte[] getParameters() throws OCKException {
+    public byte[] getParameters() throws NativeException {
         //final String methodName = "getParameters";
         if (parameters == null) {
             obtainParameters();
@@ -172,7 +172,7 @@ public final class DSAKey implements AsymmetricKey {
     }
 
     @Override
-    public byte[] getPrivateKeyBytes() throws OCKException {
+    public byte[] getPrivateKeyBytes() throws NativeException {
         //final String methodName = "getPrivateKeyBytes";
         if (privateKeyBytes == unobtainedKeyBytes) {
             obtainPrivateKeyBytes();
@@ -182,7 +182,7 @@ public final class DSAKey implements AsymmetricKey {
     }
 
     @Override
-    public byte[] getPublicKeyBytes() throws OCKException {
+    public byte[] getPublicKeyBytes() throws NativeException {
         //final String methodName = "getPublicKeyBytes";
         if (publicKeyBytes == unobtainedKeyBytes) {
             obtainPublicKeyBytes();
@@ -191,24 +191,24 @@ public final class DSAKey implements AsymmetricKey {
         return (publicKeyBytes == null) ? null : publicKeyBytes.clone();
     }
 
-    private synchronized void obtainPKeyId() throws OCKException {
+    private synchronized void obtainPKeyId() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getPKeyId at the same time, we only want to call the native
         // code one time.
         //
         if (pkeyId.getValue() == 0) {
             if (!validId(dsaKeyId)) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             this.pkeyId.setValue(this.nativeInterface.DSAKEY_createPKey(dsaKeyId));
             if (!validId(pkeyId.getValue())) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
         }
 
     }
 
-    private synchronized void obtainParameters() throws OCKException {
+    private synchronized void obtainParameters() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getParameters at the same time, we only want to call the
         // native code one time.
@@ -216,13 +216,13 @@ public final class DSAKey implements AsymmetricKey {
         //final String methodName = "obtainParameters";
         if (parameters == null) {
             if (!validId(dsaKeyId)) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             this.parameters = this.nativeInterface.DSAKEY_getParameters(dsaKeyId);
         }
     }
 
-    private synchronized void obtainPrivateKeyBytes() throws OCKException {
+    private synchronized void obtainPrivateKeyBytes() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getPrivateKeyBytes at the same time, we only want to call the
         // native code one time.
@@ -230,13 +230,13 @@ public final class DSAKey implements AsymmetricKey {
         //final String methodName = "obtainPrivateKeyBytes";
         if (privateKeyBytes == unobtainedKeyBytes) {
             if (!validId(dsaKeyId)) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             this.privateKeyBytes = this.nativeInterface.DSAKEY_getPrivateKeyBytes(dsaKeyId);
         }
     }
 
-    private synchronized void obtainPublicKeyBytes() throws OCKException {
+    private synchronized void obtainPublicKeyBytes() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getPublicKeyBytes at the same time, we only want to call the
         // native code one time.
@@ -244,7 +244,7 @@ public final class DSAKey implements AsymmetricKey {
         //final String methodName = "obtainPublicKeyBytes";
         if (publicKeyBytes == unobtainedKeyBytes) {
             if (!validId(dsaKeyId)) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             this.publicKeyBytes = this.nativeInterface.DSAKEY_getPublicKeyBytes(dsaKeyId);
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/base/Digest.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/Digest.java
@@ -78,7 +78,7 @@ public final class Digest implements Cloneable {
         });
     }
 
-    void getContext() throws OCKException {
+    void getContext() throws NativeException {
         if (needsInit) {
             synchronized (Digest.class) {
                 if (needsInit) {
@@ -158,7 +158,7 @@ public final class Digest implements Cloneable {
     private OpenJCEPlusProvider provider;
     private NativeInterface nativeInterface;
 
-    public static Digest getInstance(String digestAlgo, OpenJCEPlusProvider provider) throws OCKException {
+    public static Digest getInstance(String digestAlgo, OpenJCEPlusProvider provider) throws NativeException {
         if (digestAlgo == null || digestAlgo.isEmpty()) {
             throw new IllegalArgumentException("digestAlgo is null/empty");
         }
@@ -166,7 +166,7 @@ public final class Digest implements Cloneable {
         return new Digest(digestAlgo, provider);
     }
 
-    private Digest(String digestAlgo, OpenJCEPlusProvider provider) throws OCKException {
+    private Digest(String digestAlgo, OpenJCEPlusProvider provider) throws NativeException {
         //final String methodName = "Digest(String)";
         if (provider == null) {
             throw new IllegalArgumentException("Provider cannot be null.");
@@ -185,22 +185,22 @@ public final class Digest implements Cloneable {
     private Digest() {
     }
 
-    static void throwOCKException(int errorCode) throws OCKException {
+    static void throwNativeException(int errorCode) throws NativeException {
         //final String methodName = "throwOCKExeption";
-        // OCKDebug.Msg(debPrefix, methodName, "throwOCKException errorCode =  " + errorCode);
+        // OCKDebug.Msg(debPrefix, methodName, "throwNativeException errorCode =  " + errorCode);
         switch (errorCode) {
             case -1:
-                throw new OCKException("ICC_EVP_DigestFinal failed!");
+                throw new NativeException("ICC_EVP_DigestFinal failed!");
             case -2:
-                throw new OCKException("ICC_EVP_DigestInit failed!");
+                throw new NativeException("ICC_EVP_DigestInit failed!");
             case -3:
-                throw new OCKException("ICC_EVP_DigestUpdate failed!");
+                throw new NativeException("ICC_EVP_DigestUpdate failed!");
             default:
-                throw new OCKException("Unknow Error Code");
+                throw new NativeException("Unknow Error Code");
         }
     }
 
-    public synchronized void update(byte[] input, int offset, int length) throws OCKException {
+    public synchronized void update(byte[] input, int offset, int length) throws NativeException {
         //final String methodName = "update ";
         int errorCode = 0;
 
@@ -214,22 +214,22 @@ public final class Digest implements Cloneable {
 
         //OCKDebug.Msg(debPrefix, methodName, "offset :"  + offset + " digestId :" + this.digestId + " length :" + length);
         if (!validId(this.digestId)) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
 
         errorCode = this.nativeInterface.DIGEST_update(this.digestId, input, offset, length);
         if (errorCode < 0) {
-            throwOCKException(errorCode);
+            throwNativeException(errorCode);
         }
         this.needsReinit.setValue(true);
     }
 
-    public synchronized byte[] digest() throws OCKException {
+    public synchronized byte[] digest() throws NativeException {
         //final String methodName = "digest()";
         int errorCode = 0;
 
         if (!validId(this.digestId)) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
         //OCKDebug.Msg (debPrefix, methodName, "digestId :" + this.digestId);
 
@@ -239,20 +239,20 @@ public final class Digest implements Cloneable {
 
         errorCode = this.nativeInterface.DIGEST_digest_and_reset(this.digestId, digestBytes);
         if (errorCode < 0) {
-            throwOCKException(errorCode);
+            throwNativeException(errorCode);
         }
         this.needsReinit.setValue(false);
 
         return digestBytes;
     }
 
-    protected long getId() throws OCKException {
+    protected long getId() throws NativeException {
         //final String methodName = "getId()";
         //OCKDebug.Msg(debPrefix, methodName, "digestId :" + this.digestId);
         return this.digestId;
     }
 
-    public int getDigestLength() throws OCKException {
+    public int getDigestLength() throws NativeException {
         //final String methodName = "getDigestLength()";
 
         if (digestLength == 0) {
@@ -262,7 +262,7 @@ public final class Digest implements Cloneable {
         return digestLength;
     }
 
-    public synchronized void reset() throws OCKException {
+    public synchronized void reset() throws NativeException {
         //final String methodName = "reset ";
         //OCKDebug.Msg(debPrefix, methodName,  "digestId =" + this.digestId);
 
@@ -271,7 +271,7 @@ public final class Digest implements Cloneable {
         }
 
         if (!validId(this.digestId)) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
         if (this.needsReinit.getValue()) {
             this.nativeInterface.DIGEST_reset(this.digestId);
@@ -279,7 +279,7 @@ public final class Digest implements Cloneable {
         this.needsReinit.setValue(false);
     }
 
-    private synchronized void obtainDigestLength() throws OCKException {
+    private synchronized void obtainDigestLength() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getDigestLength at the same time, we only want to call the
         // native code one time.
@@ -290,7 +290,7 @@ public final class Digest implements Cloneable {
         } else {
             if (this.digestLength == 0) {
                 if (!validId(this.digestId)) {
-                    throw new OCKException(badIdMsg);
+                    throw new NativeException(badIdMsg);
                 }
                 this.digestLength = this.nativeInterface.DIGEST_size(this.digestId);
             }
@@ -328,7 +328,7 @@ public final class Digest implements Cloneable {
             if (0 == copy.digestId) {
                 throw new CloneNotSupportedException("Copy of native digest context failed.");
             }
-        } catch (OCKException e) {
+        } catch (NativeException e) {
             StackTraceElement[] stackTraceArray = e.getStackTrace();
             String stackTrace = Stream.of(stackTraceArray)
                                       .map(t -> t.toString())
@@ -341,7 +341,7 @@ public final class Digest implements Cloneable {
         return copy;
     }
 
-    public byte[] PKCS12KeyDeriveHelp(byte[] input, int offset, int length, int iterationCount) throws OCKException {
+    public byte[] PKCS12KeyDeriveHelp(byte[] input, int offset, int length, int iterationCount) throws NativeException {
         int errorCode = 0;
 
         if (length == 0) {
@@ -353,12 +353,12 @@ public final class Digest implements Cloneable {
         }
 
         if (!validId(this.digestId)) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
 
         errorCode = this.nativeInterface.DIGEST_PKCS12KeyDeriveHelp(this.digestId, input, offset, length, iterationCount);
         if (errorCode < 0) {
-            throwOCKException(errorCode);
+            throwNativeException(errorCode);
         }
         this.needsReinit.setValue(false);
 
@@ -370,7 +370,7 @@ public final class Digest implements Cloneable {
         return () -> {
             try {
                 if (digestId == 0) {
-                    throw new OCKException("Digest Identifier is not valid");
+                    throw new NativeException("Digest Identifier is not valid");
                 }
                 // not SHA* algorithm
                 if (algIndx == -2) {
@@ -388,7 +388,7 @@ public final class Digest implements Cloneable {
                         nativeInterface.DIGEST_delete(digestId);
                     }
                 }
-            } catch (OCKException e) {
+            } catch (NativeException e) {
                 if (OpenJCEPlusProvider.getDebug() != null) {
                     OpenJCEPlusProvider.getDebug().println("An error occurred while cleaning : " + e.getMessage());
                     e.printStackTrace();

--- a/src/main/java/com/ibm/crypto/plus/provider/base/ECKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/ECKey.java
@@ -110,14 +110,14 @@ public final class ECKey implements AsymmetricKey {
     // Note that the caller of this method must ensure the pointer ecKeyId is not used
     // concurrently by suitable locking.
     protected static byte[] getParametersBytes(long ecKeyId, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         NativeInterface nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
         return nativeInterface.ECKEY_getParameters(ecKeyId);
     }
 
 
     public static ECKey generateKeyPair(int size, SecureRandom random, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         //final String methodName = "generateKeyPair ";
         if (size < 0) {
             throw new IllegalArgumentException("The key length parameter is invalid");
@@ -131,7 +131,7 @@ public final class ECKey implements AsymmetricKey {
         long ecKeyId;
         try {
             ecKeyId = nativeInterface.ECKEY_generate(size);
-        } catch (OCKException oe) {
+        } catch (NativeException oe) {
             if (oe.getMessage().contains("Incorrect key size") && allowIncorrectKeysizes) {
                 // If the flag is set and an incorrect key size was provided, default to 256.
                 ecKeyId = nativeInterface.ECKEY_generate(256);
@@ -141,7 +141,7 @@ public final class ECKey implements AsymmetricKey {
         }
         
         if (!validId(ecKeyId)) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
 
         byte[] parameterBytes = getParametersBytes(ecKeyId, provider);
@@ -152,7 +152,7 @@ public final class ECKey implements AsymmetricKey {
 
 
     public static ECKey generateKeyPair(String soid, SecureRandom random, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         //final String methodName = "generateKeyPair(String, SecureRandom) ";
         if ((soid == null) || (soid.equals("") == true)) {
             throw new IllegalArgumentException("The String Object Identifier parameter is invalid");
@@ -165,7 +165,7 @@ public final class ECKey implements AsymmetricKey {
         NativeInterface nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
         long ecKeyId = nativeInterface.ECKEY_generate(soid);
         if (!validId(ecKeyId)) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
         byte[] parameterBytes = getParametersBytes(ecKeyId, provider);
         //OCKDebug.Msg (debPrefix, methodName, "soid :" + soid + " ecKeyId :" + ecKeyId + "parameterBytes :",  parameterBytes);
@@ -175,7 +175,7 @@ public final class ECKey implements AsymmetricKey {
     }
 
     public static ECKey generateKeyPair(byte[] parameterBytes,
-            SecureRandom random, OpenJCEPlusProvider provider) throws OCKException {
+            SecureRandom random, OpenJCEPlusProvider provider) throws NativeException {
         //final String methodName = "generateKeyPair(byte[], SecureRandom) ";
         if (parameterBytes == null) {
             throw new IllegalArgumentException("The parameter bytes is null");
@@ -193,7 +193,7 @@ public final class ECKey implements AsymmetricKey {
                 unobtainedKeyBytes, provider);
     }
 
-    public static byte[] generateParameters(int size, OpenJCEPlusProvider provider) throws OCKException {
+    public static byte[] generateParameters(int size, OpenJCEPlusProvider provider) throws NativeException {
         //final String methodName = "generateParameters (int) ";
         if (size < 0) {
             throw new IllegalArgumentException("key length is invalid");
@@ -205,7 +205,7 @@ public final class ECKey implements AsymmetricKey {
     }
 
     public static byte[] generateParameters(String soid, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         //final String methodName = "generateParameters(soid) ";
         if (soid == null || soid.equals("")) {
             throw new IllegalArgumentException(
@@ -229,7 +229,7 @@ public final class ECKey implements AsymmetricKey {
     }
 
     @Override
-    public long getPKeyId() throws OCKException {
+    public long getPKeyId() throws NativeException {
         if (pkeyId.getValue() == 0) {
             obtainPKeyId();
         }
@@ -237,7 +237,7 @@ public final class ECKey implements AsymmetricKey {
         return pkeyId.getValue();
     }
 
-    public byte[] getParameters() throws OCKException {
+    public byte[] getParameters() throws NativeException {
         //final String methodName = "getParameters :";
         if (ecSpec == null) {
             obtainParameters();
@@ -252,7 +252,7 @@ public final class ECKey implements AsymmetricKey {
     //    }
 
     @Override
-    public byte[] getPrivateKeyBytes() throws OCKException {
+    public byte[] getPrivateKeyBytes() throws NativeException {
         //final String methodName = "getPrivateKeyBytes()";
         if (privateKeyBytes == unobtainedKeyBytes) {
             obtainPrivateKeyBytes();
@@ -262,7 +262,7 @@ public final class ECKey implements AsymmetricKey {
     }
 
     @Override
-    public byte[] getPublicKeyBytes() throws OCKException {
+    public byte[] getPublicKeyBytes() throws NativeException {
         //final String methodName = "getPublickeyBytes()";
         if (publicKeyBytes == unobtainedKeyBytes) {
             obtainPublicKeyBytes();
@@ -271,54 +271,54 @@ public final class ECKey implements AsymmetricKey {
         return (publicKeyBytes == null) ? null : publicKeyBytes.clone();
     }
 
-    private synchronized void obtainPKeyId() throws OCKException {
+    private synchronized void obtainPKeyId() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getPKeyId at the same time, we only want to call the native
         // code one time.
         //
         if (pkeyId.getValue() == 0) {
             if (!validId(ecKeyId)) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             this.pkeyId.setValue(this.nativeInterface.ECKEY_createPKey(ecKeyId));
         }
     }
 
-    private synchronized void obtainParameters() throws OCKException {
+    private synchronized void obtainParameters() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getParameters at the same time, we only want to call the
         // native code one time.
         //
         if (ecSpec == null) {
             if (!validId(ecKeyId)) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             this.parameterBytes = this.nativeInterface.ECKEY_getParameters(ecKeyId);
         }
     }
 
-    private synchronized void obtainPrivateKeyBytes() throws OCKException {
+    private synchronized void obtainPrivateKeyBytes() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getPrivateKeyBytes at the same time, we only want to call the
         // native code one time.
         //
         if (privateKeyBytes == unobtainedKeyBytes) {
             if (!validId(ecKeyId)) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             this.privateKeyBytes = this.nativeInterface.ECKEY_getPrivateKeyBytes(ecKeyId);
 
         }
     }
 
-    private synchronized void obtainPublicKeyBytes() throws OCKException {
+    private synchronized void obtainPublicKeyBytes() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getPublicKeyBytes at the same time, we only want to call the
         // native code one time.
         //
         if (publicKeyBytes == unobtainedKeyBytes) {
             if (!validId(ecKeyId)) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             this.publicKeyBytes = this.nativeInterface.ECKEY_getPublicKeyBytes(ecKeyId);
         }
@@ -327,7 +327,7 @@ public final class ECKey implements AsymmetricKey {
     // The underlying native function used in this method does not use any native pointer
     // that is shared across threads. Hence, it does not require any locks
     public static ECKey createPrivateKey(byte[] privateKeyBytes,
-            byte[] paramBytes, OpenJCEPlusProvider provider) throws OCKException {
+            byte[] paramBytes, OpenJCEPlusProvider provider) throws NativeException {
         //final String methodName = "createPrivateKey";
         if (privateKeyBytes == null) {
             throw new IllegalArgumentException("key bytes is null");
@@ -342,7 +342,7 @@ public final class ECKey implements AsymmetricKey {
         long ecKeyId = nativeInterface.ECKEY_createPrivateKey(privateKeyBytes);
         //OCKDebug.Msg (debPrefix, methodName, "ecPrivateKeyId :" + ecKeyId);
         if (!validId(ecKeyId)) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
         byte[] publicKeyBytes = nativeInterface.ECKEY_getPublicKeyBytes(ecKeyId);
 
@@ -355,7 +355,7 @@ public final class ECKey implements AsymmetricKey {
     // ECKEY.signDatawithECDSA is not synchronized and not thread safe.
     // The method ECKey.signDatawithECDSA should NOT be synchronized for performance as that would create a global lock.
     public static byte[] signDatawithECDSA(byte[] digestBytes,
-            int digestBytesLen, ECKey ecPrivateKey, OpenJCEPlusProvider provider) throws OCKException {
+            int digestBytesLen, ECKey ecPrivateKey, OpenJCEPlusProvider provider) throws NativeException {
         //final String methodName = "signDatawithECDSA";
         if (digestBytes == null || digestBytesLen < 1) {
             throw new IllegalArgumentException("digest bytes is null");
@@ -368,7 +368,7 @@ public final class ECKey implements AsymmetricKey {
         }
 
         if (!validId(ecPrivateKey.getEcKeyId())) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
 
         NativeInterface nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
@@ -388,7 +388,7 @@ public final class ECKey implements AsymmetricKey {
     // The method ECKey.verifyDatawithECDSA should NOT be synchronized for performance as that would create a global lock.
     public static boolean verifyDatawithECDSA(byte[] digestBytes,
             int digestBytesLen, byte[] sigBytes, int sigBytesLen, ECKey ecPublicKey, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         //final String methodName = "verifyDatawithECDSA";
         boolean verified = false;
         if (digestBytes == null || digestBytesLen < 1) {
@@ -415,7 +415,7 @@ public final class ECKey implements AsymmetricKey {
         }
 
         if (!validId(ecPublicKey.getEcKeyId())) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
         //OCKDebug.Msg (debPrefix, methodName, "diestBytesLen : " + digestBytesLen + " digestAcutalBytes : ", digestActualBytes);
         //OCKDebug.Msg (debPrefix, methodName, " sigActualBytes : ", sigActualBytes);
@@ -430,7 +430,7 @@ public final class ECKey implements AsymmetricKey {
     }
 
     public static ECKey createPublicKey(byte[] publicKeyBytes,
-            byte[] parameterBytes, OpenJCEPlusProvider provider) throws OCKException {
+            byte[] parameterBytes, OpenJCEPlusProvider provider) throws NativeException {
         //final String methodName = "createPublicKey";
         if (publicKeyBytes == null) {
             throw new IllegalArgumentException("key bytes is null");
@@ -454,7 +454,7 @@ public final class ECKey implements AsymmetricKey {
     // ECKey.computeDHSecret is not synchronized and not thread safe.
     // The method ECKey.computeDHSecret should NOT be synchronized for performance as that would create a global lock.
     public static byte[] computeECDHSecret(long pubEcKeyId, long privEcKeyId, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         //final String methodName = "computeECDHSecret ";
         if (pubEcKeyId == 0) {
             throw new IllegalArgumentException("The public key parameter is not valid");

--- a/src/main/java/com/ibm/crypto/plus/provider/base/ExtendedRandom.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/ExtendedRandom.java
@@ -19,7 +19,7 @@ public final class ExtendedRandom {
     final long ockPRNGContextId;
 
     public static ExtendedRandom getInstance(String algName, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         if ((algName == null) || algName.isEmpty()) {
             throw new IllegalArgumentException("algName is null/empty");
         }
@@ -31,7 +31,7 @@ public final class ExtendedRandom {
         return new ExtendedRandom(algName, provider);
     }
 
-    private ExtendedRandom(String algName, OpenJCEPlusProvider provider) throws OCKException {
+    private ExtendedRandom(String algName, OpenJCEPlusProvider provider) throws NativeException {
         this.provider = provider;
         this.nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
         this.ockPRNGContextId = this.nativeInterface.EXTRAND_create(algName);
@@ -39,7 +39,7 @@ public final class ExtendedRandom {
         this.provider.registerCleanable(this, cleanOCKResources(ockPRNGContextId, nativeInterface));
     }
 
-    public synchronized void nextBytes(byte[] bytes) throws OCKException {
+    public synchronized void nextBytes(byte[] bytes) throws NativeException {
         if (bytes == null) {
             throw new IllegalArgumentException("bytes is null");
         }
@@ -49,7 +49,7 @@ public final class ExtendedRandom {
         }
     }
 
-    public synchronized void setSeed(byte[] seed) throws OCKException {
+    public synchronized void setSeed(byte[] seed) throws NativeException {
         if (seed == null) {
             throw new IllegalArgumentException("seed is null");
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/base/GCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/GCMCipher.java
@@ -110,7 +110,7 @@ public final class GCMCipher {
         //        int tls_support_result;
         //        try {
         //            tls_support_result = NativeInterface.get_GCM_TLSEnabled();
-        //        } catch (OCKException e) {
+        //        } catch (NativeException e) {
         //            tls_support_result = 1;
         //        }
         //        useJavaTLS = (tls_support_result != 0);
@@ -137,7 +137,7 @@ public final class GCMCipher {
     // except ICC_CTX which is thread safe
     public int doGCMFinal_Decrypt(byte[] key, byte[] iv, int tagLen,
             byte[] input, int inputOffset, int inputLen, byte[] output, int outputOffset,
-            byte[] aad) throws OCKException, IllegalStateException, ShortBufferException,
+            byte[] aad) throws NativeException, IllegalStateException, ShortBufferException,
             IllegalBlockSizeException, BadPaddingException, AEADBadTagException {
         //final String methodName="doGCMFinal_Decrypt ";
         int rc = 0;
@@ -250,14 +250,14 @@ public final class GCMCipher {
 
             //OCKDebug.Msg (debPrefix, methodName, "RC = " + rc);
             if (rc != 0) {
-                throw new OCKException(ErrorCodes.get(rc));
+                throw new NativeException(ErrorCodes.get(rc));
             }
         } else {
             rc = this.nativeInterface.do_GCM_decrypt(gcmCtx, key, key.length, iv,
                     iv.length, input, inputOffset, inputLen - tagLen, output, outputOffset,
                     authenticationData, aadLen, tagLen);
             if (rc != 0) {
-                throw new OCKException(ErrorCodes.get(rc));
+                throw new NativeException(ErrorCodes.get(rc));
             }
         }
         return len;
@@ -267,7 +267,7 @@ public final class GCMCipher {
     // except ICC_CTX which is thread safe
     public int doGCMFinal_Encrypt(byte[] key, byte[] iv, int tagLen,
             byte[] input, int inputOffset, int inputLen, byte[] output, int outputOffset,
-            byte[] aad) throws OCKException, IllegalStateException, ShortBufferException,
+            byte[] aad) throws NativeException, IllegalStateException, ShortBufferException,
             IllegalBlockSizeException, BadPaddingException {
 
         //final String methodName = "doGCMFinal_Encrypt ";
@@ -380,7 +380,7 @@ public final class GCMCipher {
                 outputBuffer.get(0, output, outputOffset, len);
             }
             if (rc != 0) {
-                throw new OCKException(ErrorCodes.get(rc));
+                throw new NativeException(ErrorCodes.get(rc));
             }
             // Copy Tag out of native data buffer
             parameters.get(keyLen + ivLen + aadLen, output, outputOffset + inputLen, tagLen);
@@ -397,7 +397,7 @@ public final class GCMCipher {
             System.arraycopy(tag, 0, output, outputOffset + inputLen, tagLen);
             outLen = inputLen + tagLen;
             if (rc != 0) {
-                throw new OCKException(ErrorCodes.get(rc));
+                throw new NativeException(ErrorCodes.get(rc));
             }
         }
         //OCKDebug.Msg(debPrefix, methodName,  "outLen=" + outLen + " output=",  output);
@@ -407,7 +407,7 @@ public final class GCMCipher {
     public int do_GCM_FinalForUpdateDecrypt(byte[] key, byte[] iv,
             int tagLen, byte[] input, int inputOffset, int inputLen, byte[] output,
             int outputOffset, byte[] aad)
-            throws OCKException, IllegalStateException, ShortBufferException,
+            throws NativeException, IllegalStateException, ShortBufferException,
             IllegalBlockSizeException, BadPaddingException, AEADBadTagException {
         //final String methodName="do_GCM_FinalForUpdateDecrypt ";
         int rc = 0;
@@ -474,7 +474,7 @@ public final class GCMCipher {
         //OCKDebug.Msg (debPrefix, methodName, "After calling do_GCM_FinalForUpdateDecrypt gcmUpdateOutlen ="  + String.valueOf(gcmUpdateOutlen.getValue()));
         //OCKDebug.Msg (debPrefix, methodName, "Decrypted text from do_GCM_FinalForUpdateDecrypt = ",  output);
         if (rc != 0) {
-            throw new OCKException(ErrorCodes.get(rc));
+            throw new NativeException(ErrorCodes.get(rc));
         }
 
         //OCKDebug.Msg (debPrefix, methodName, "Returning length= " +  len);
@@ -485,7 +485,7 @@ public final class GCMCipher {
     public int do_GCM_InitForUpdateDecrypt(byte[] key, byte[] iv,
             int tagLen, byte[] input, int inputOffset, int inputLen, byte[] output,
             int outputOffset, byte[] aad)
-            throws OCKException, IllegalStateException, ShortBufferException,
+            throws NativeException, IllegalStateException, ShortBufferException,
             IllegalBlockSizeException, BadPaddingException, AEADBadTagException {
         //final String methodName="do_GCM_InitForUpdateDecrypt ";
         int rc = 0;
@@ -540,7 +540,7 @@ public final class GCMCipher {
 
         //OCKDebug.Msg (debPrefix, methodName, "After calling do_GCM_InitForUpdateDecrypt gcmUpdateOutlen ="  + String.valueOf(gcmUpdateOutlen.getValue()));
         if (rc != 0) {
-            throw new OCKException(ErrorCodes.get(rc));
+            throw new NativeException(ErrorCodes.get(rc));
         }
         //OCKDebug.Msg (debPrefix, methodName, "Native do_GCM_InitForUpdateDecrypt returns  output offset=" + outputOffset + " output=", output);
 
@@ -550,7 +550,7 @@ public final class GCMCipher {
     public /*synchronized*/ int do_GCM_UpdForUpdateDecrypt(byte[] key,
             byte[] iv, int tagLen, byte[] input, int inputOffset, int inputLen, byte[] output,
             int outputOffset, byte[] aad)
-            throws OCKException, IllegalStateException, ShortBufferException,
+            throws NativeException, IllegalStateException, ShortBufferException,
             IllegalBlockSizeException, BadPaddingException, AEADBadTagException {
         //final String methodName="do_GCM_UpdForUpdateDecrypt ";
         int rc = 0;
@@ -612,7 +612,7 @@ public final class GCMCipher {
         //                //OCKDebug.Msg (debPrefix, methodName, "rc =" + rc + " After calling do_GCM_UpdForUpdateDecrypt gcmUpdateOutlen ="  + String.valueOf(gcmUpdateOutlen.getValue()));
 
         if (rc != 0) {
-            throw new OCKException(ErrorCodes.get(rc));
+            throw new NativeException(ErrorCodes.get(rc));
         }
         //              //OCKDebug.Msg (debPrefix, methodName, "Native do_GCM_UpdForUpdateDecrypt returns  output offset=" + outputOffset + " output=", output);
 
@@ -621,7 +621,7 @@ public final class GCMCipher {
 
     public int do_GCM_FinalForUpdateEncrypt(byte[] key, byte[] iv,
             int tagLen, byte[] input, int inputOffset, int inputLen, byte[] output,
-            int outputOffset, byte[] aad) throws OCKException, IllegalStateException,
+            int outputOffset, byte[] aad) throws NativeException, IllegalStateException,
             ShortBufferException, IllegalBlockSizeException, BadPaddingException {
 
         //final String methodName = "do_GCM_FinalForUpdateEncrypt ";
@@ -715,7 +715,7 @@ public final class GCMCipher {
         outLen = inputLen + tagLen;
 
         if (rc != 0) {
-            throw new OCKException(ErrorCodes.get(rc));
+            throw new NativeException(ErrorCodes.get(rc));
         }
         //OCKDebug.Msg (debPrefix, methodName, "output from native do_GCM_FinalForUpdateEncrypt=", output);
 
@@ -728,7 +728,7 @@ public final class GCMCipher {
     // except ICC_CTX which is thread safe
     public int do_GCM_UpdForUpdateEncrypt(byte[] key, byte[] iv,
             int tagLen, byte[] input, int inputOffset, int inputLen, byte[] output,
-            int outputOffset, byte[] aad) throws OCKException, IllegalStateException,
+            int outputOffset, byte[] aad) throws NativeException, IllegalStateException,
             ShortBufferException, IllegalBlockSizeException, BadPaddingException {
 
         //final String methodName = "do_GCM_UpdForUpdateEncrypt ";
@@ -801,7 +801,7 @@ public final class GCMCipher {
         outLen = inputLen;
 
         if (rc != 0) {
-            throw new OCKException(ErrorCodes.get(rc));
+            throw new NativeException(ErrorCodes.get(rc));
         }
 
         //OCKDebug.Msg(debPrefix, methodName,  "outLen=" + outLen + " output=",  output);
@@ -812,7 +812,7 @@ public final class GCMCipher {
     // except ICC_CTX which is thread safe
     public int do_GCM_InitForUpdateEncrypt(byte[] key, byte[] iv,
             int tagLen, byte[] input, int inputOffset, int inputLen, byte[] output,
-            int outputOffset, byte[] aad) throws OCKException, IllegalStateException,
+            int outputOffset, byte[] aad) throws NativeException, IllegalStateException,
             ShortBufferException, IllegalBlockSizeException, BadPaddingException {
 
         //final String methodName = "do_GCM_InitForUpdateEncrypt ";
@@ -873,7 +873,7 @@ public final class GCMCipher {
         outLen = 0;
 
         if (rc != 0) {
-            throw new OCKException(ErrorCodes.get(rc));
+            throw new NativeException(ErrorCodes.get(rc));
         }
 
         //OCKDebug.Msg(debPrefix, methodName,  "outLen=" + outLen + " output=",  output);
@@ -882,7 +882,7 @@ public final class GCMCipher {
 
 
     private static long getGCMContext(boolean encrypting, int keyLength, OpenJCEPlusProvider provider, NativeInterface nativeInterface)
-            throws OCKException {
+            throws NativeException {
         //// if it is indicated that Java based TLS storage of GCM contexts should be used
         //// we fetch the TLS copy of the gcm context. if uninitialized, create a new one
         if (useJavaTLS) {
@@ -965,7 +965,7 @@ public final class GCMCipher {
         return totalLen;
     }
 
-    public static void doGCM_cleanup(OpenJCEPlusProvider provider) throws OCKException {
+    public static void doGCM_cleanup(OpenJCEPlusProvider provider) throws NativeException {
         NativeInterface nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
         nativeInterface.do_GCM_delete();
     }
@@ -995,7 +995,7 @@ public final class GCMCipher {
     static int useHardwareGCM(boolean isEncrypt, int inputLen, int ivLen, int keyLen, int aadLen,
             int tagLen, byte[] key, byte[] input, int inputOffset, byte[] output, int outputOffset,
             FastJNIBuffer parameters, OpenJCEPlusProvider provider)
-            throws OCKException, IllegalStateException, ShortBufferException,
+            throws NativeException, IllegalStateException, ShortBufferException,
             IllegalBlockSizeException, BadPaddingException, AEADBadTagException {
         int rc = 0;
         // Setting offsets and inputLen
@@ -1056,7 +1056,7 @@ public final class GCMCipher {
         OpenJCEPlusProvider provider;
         final long gcmCtx;
 
-        GCMContextPointer(NativeInterface nativeInterface, OpenJCEPlusProvider provider) throws OCKException {
+        GCMContextPointer(NativeInterface nativeInterface, OpenJCEPlusProvider provider) throws NativeException {
             this.gcmCtx = nativeInterface.create_GCM_context();
             this.provider = provider;
 

--- a/src/main/java/com/ibm/crypto/plus/provider/base/HKDF.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/HKDF.java
@@ -28,14 +28,14 @@ public final class HKDF {
     private final String badIdMsg = "HKDF Identifier is not valid";
 
 
-    public static HKDF getInstance(String digestAlgo, OpenJCEPlusProvider provider) throws OCKException {
+    public static HKDF getInstance(String digestAlgo, OpenJCEPlusProvider provider) throws NativeException {
         if (provider == null) {
             throw new IllegalArgumentException("provider is null");
         }
         return new HKDF(digestAlgo, provider);
     }
 
-    private HKDF(String digestAlgo, OpenJCEPlusProvider provider) throws OCKException {
+    private HKDF(String digestAlgo, OpenJCEPlusProvider provider) throws NativeException {
         //final String methodName = "HKDF (ockContext, String)";
         this.provider = provider;
         this.nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
@@ -47,7 +47,7 @@ public final class HKDF {
 
 
     public synchronized byte[] extract(byte[] salt, long saltLen, byte[] inKey, long inpKeyLen)
-            throws OCKException {
+            throws NativeException {
         //final String methodName = "HKDF extract(byte[] salt, long saltLen, byte[] inKey, long inpKeyLen)";
         //OCKDebug.Msg (debPrefix, methodName,  "this.hkdfId :" + this.hkdfId );
         //OCKDebug.Msg (debPrefix, methodName,  "saltLen:" + saltLen );
@@ -59,7 +59,7 @@ public final class HKDF {
     }
 
     public synchronized byte[] expand(byte[] prkBytes, long prkLen, byte[] info, long infoLen,
-            long okmLen) throws OCKException {
+            long okmLen) throws NativeException {
         //final String methodName = "HKDF expand (byte[] prkBytes, long prkLen, \r\n"
         //        + "            byte[] info, long infoLen, long okmLen)";
         //OCKDebug.Msg (debPrefix, methodName,  "this.hkdfId :" + this.hkdfId );
@@ -70,7 +70,7 @@ public final class HKDF {
     }
 
     public synchronized byte[] derive(byte[] salt, long saltLen, byte[] inKey, long inpKeyLen,
-            byte[] info, long infoLen, long okmLen) throws OCKException {
+            byte[] info, long infoLen, long okmLen) throws NativeException {
         //final String methodName = "HKDFGenetateBytes(byte[] salt, long saltLen, byte[] inKey, long inpKeyLen, byte[] info, long infoLen)";
         //OCKDebug.Msg (debPrefix, methodName,  "this.hkdfId :" + this.hkdfId );
         //OCKDebug.Msg (debPrefix, methodName,  "saltLen:" + saltLen );
@@ -83,7 +83,7 @@ public final class HKDF {
 
 
 
-    public int getMacLength() throws OCKException {
+    public int getMacLength() throws NativeException {
         //final String methodName = "HKDF getMacLength() ";
         if (macLength == 0) {
             obtainMacLength();
@@ -98,14 +98,14 @@ public final class HKDF {
         return hkdfId;
     }
 
-    private synchronized void obtainMacLength() throws OCKException {
+    private synchronized void obtainMacLength() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getMacLength at the same time, we only want to call the
         // native code one time.
         //
         if (macLength == 0) {
             if (!validId(hkdfId)) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             this.macLength = this.nativeInterface.HKDF_size(hkdfId);
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/base/HMAC.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/HMAC.java
@@ -24,7 +24,7 @@ public final class HMAC {
     private final String badIdMsg = "HMAC Identifier is not valid";
     private static final String debPrefix = "HAMC";
 
-    public static HMAC getInstance(String digestAlgo, OpenJCEPlusProvider provider) throws OCKException {
+    public static HMAC getInstance(String digestAlgo, OpenJCEPlusProvider provider) throws NativeException {
         if (provider == null) {
             throw new IllegalArgumentException("provider is null");
         }
@@ -32,20 +32,20 @@ public final class HMAC {
         return new HMAC(digestAlgo, provider);
     }
 
-    static void throwOCKException(int errorCode) throws OCKException {
+    static void throwNativeException(int errorCode) throws NativeException {
         switch (errorCode) {
             case -1:
-                throw new OCKException("ICC_HMAC_Init failed!");
+                throw new NativeException("ICC_HMAC_Init failed!");
             case -2:
-                throw new OCKException("ICC_HMAC_Update failed!");
+                throw new NativeException("ICC_HMAC_Update failed!");
             case -3:
-                throw new OCKException("ICC_HMAC_Final failed!");
+                throw new NativeException("ICC_HMAC_Final failed!");
             default:
-                throw new OCKException("Unknow Error Code");
+                throw new NativeException("Unknow Error Code");
         }
     }
 
-    private HMAC(String digestAlgo, OpenJCEPlusProvider provider) throws OCKException {
+    private HMAC(String digestAlgo, OpenJCEPlusProvider provider) throws NativeException {
         //final String methodName = "HMAC (String)";
         this.provider = provider;
         this.nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
@@ -55,14 +55,14 @@ public final class HMAC {
         this.provider.registerCleanable(this, cleanOCKResources(hmacId, reinitKey, nativeInterface));
     }
 
-    public synchronized void initialize(byte[] key) throws OCKException {
+    public synchronized void initialize(byte[] key) throws NativeException {
         //final String methodName = "HMAC initialize ";
         if ((key == null) || (key.length == 0)) {
             throw new IllegalArgumentException("key is null/empty");
         }
         //OCKDebug.Msg(debPrefix, methodName, "hmacId :" + hmacId + " key :", key);
         if (!validId(hmacId)) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
 
         if (key != reinitKey) {
@@ -74,7 +74,7 @@ public final class HMAC {
         needsReinit = true;
     }
 
-    public int getMacLength() throws OCKException {
+    public int getMacLength() throws NativeException {
         //final String methodName = "HMAC getMacLength() ";
         if (macLength == 0) {
             obtainMacLength();
@@ -84,7 +84,7 @@ public final class HMAC {
     }
 
     public synchronized void update(byte[] input, int inputOffset, int inputLen)
-            throws OCKException {
+            throws NativeException {
         //final String methodName = "update";
         if (this.reinitKey == null) {
             throw new IllegalStateException("HMAC not initialized");
@@ -100,17 +100,17 @@ public final class HMAC {
         }
         //OCKDebug.Msg (debPrefix, methodName,  "hmacId :" + hmacId + " inputOffset :" + inputOffset + " inputLen :" + inputLen );
         if (!validId(hmacId)) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
         int result = this.nativeInterface.HMAC_update(hmacId, reinitKey,
                 reinitKey.length, input, inputOffset, inputLen, needsReinit);
         if (result < 0) {
-            throwOCKException(result);
+            throwNativeException(result);
         }
         this.needsReinit = false;
     }
 
-    public synchronized byte[] doFinal() throws OCKException {
+    public synchronized byte[] doFinal() throws NativeException {
         //final String methodName = "doFinal";
         if (reinitKey == null) {
             throw new IllegalStateException("HMAC not initialized");
@@ -118,14 +118,14 @@ public final class HMAC {
 
         //OCKDebug.Msg (debPrefix, methodName, "hmacId :" + hmacId);
         if (!validId(hmacId)) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
         obtainMacLength();
         byte[] hmac = new byte[macLength];
         int result = this.nativeInterface.HMAC_doFinal(hmacId, reinitKey,
                 reinitKey.length, hmac, needsReinit);
         if (result < 0) {
-            throwOCKException(result);
+            throwNativeException(result);
         }
         // Need to reset the object such that it can be re-used.
         //
@@ -134,18 +134,18 @@ public final class HMAC {
         return hmac;
     }
 
-    public synchronized void reset() throws OCKException {
+    public synchronized void reset() throws NativeException {
         needsReinit = true;
     }
 
-    private synchronized void obtainMacLength() throws OCKException {
+    private synchronized void obtainMacLength() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getMacLength at the same time, we only want to call the
         // native code one time.
         //
         if (macLength == 0) {
             if (!validId(hmacId)) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             this.macLength = this.nativeInterface.HMAC_size(hmacId);
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/base/NativeException.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/NativeException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright IBM Corp. 2026
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package com.ibm.crypto.plus.provider.base;
+
+/**
+ * This is a class used for exceptions created by the native code that
+ * utilizes the equivalent native libraries.
+ *
+ * The class can be subclassed by library-specific exception classes, or
+ * be used directly by other classes who need to indicate that the problem
+ * occured in native code, but might not have knowledge of the exact library
+ * used.
+ */
+public class NativeException extends java.lang.Exception {
+
+    private static final long serialVersionUID = 9223372036854775807L;
+
+    protected int code = -1; // Non-specific value designed to be overriden.
+
+    // These codes must be overriden by library-specific native exceptions.
+    public static final int GKR_FIPS_MODE_INVALID = -1;
+    public static final int GKR_OCK_ATTACH_FAILED = -1;
+    public static final int GKR_DECRYPT_FINAL_BAD_PADDING_ERROR = -1;
+    public static final int GKR_UNSPECIFIED = -1;
+
+    public NativeException(String s) {
+        super(s);
+    }
+
+    public NativeException(String s, Throwable cause) {
+        super(s, cause);
+    }
+
+    public int getCode() {
+        return code;
+    }
+}

--- a/src/main/java/com/ibm/crypto/plus/provider/base/NativeInterface.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/NativeInterface.java
@@ -12,13 +12,13 @@ import java.nio.ByteBuffer;
 import java.security.ProviderException;
 
 public interface NativeInterface {
-    public String getLibraryVersion() throws OCKException;
+    public String getLibraryVersion() throws NativeException;
 
-    public String getLibraryInstallPath() throws OCKException;
+    public String getLibraryInstallPath() throws NativeException;
 
-    void validateLibraryLocation() throws ProviderException, OCKException;
+    void validateLibraryLocation() throws ProviderException, NativeException;
 
-    void validateLibraryVersion() throws ProviderException, OCKException;
+    void validateLibraryVersion() throws ProviderException, NativeException;
 
     // =========================================================================
     // General functions
@@ -30,9 +30,9 @@ public interface NativeInterface {
     // Static stub functions
     // =========================================================================
 
-    public long initializeOCK(boolean isFIPS) throws OCKException;
+    public long initializeOCK(boolean isFIPS) throws NativeException;
 
-    public String CTX_getValue(int valueId) throws OCKException;
+    public String CTX_getValue(int valueId) throws NativeException;
 
     public long getByteBufferPointer(ByteBuffer b);
 
@@ -40,40 +40,40 @@ public interface NativeInterface {
     // Basic random number generator functions
     // =========================================================================
 
-    public void RAND_nextBytes(byte[] buffer) throws OCKException;
+    public void RAND_nextBytes(byte[] buffer) throws NativeException;
 
-    public void RAND_setSeed(byte[] seed) throws OCKException;
+    public void RAND_setSeed(byte[] seed) throws NativeException;
 
-    public void RAND_generateSeed(byte[] seed) throws OCKException;
+    public void RAND_generateSeed(byte[] seed) throws NativeException;
 
     // =========================================================================
     // Extended random number generator functions
     // =========================================================================
 
-    public long EXTRAND_create(String algName) throws OCKException;
+    public long EXTRAND_create(String algName) throws NativeException;
 
     public void EXTRAND_nextBytes(long ockPRNGContextId,
-            byte[] buffer) throws OCKException;
+            byte[] buffer) throws NativeException;
 
     public void EXTRAND_setSeed(long ockPRNGContextId, byte[] seed)
-            throws OCKException;
+            throws NativeException;
 
     public void EXTRAND_delete(long ockPRNGContextId)
-            throws OCKException;
+            throws NativeException;
 
     // =========================================================================
     // Cipher functions
     // =========================================================================
 
-    public long CIPHER_create(String cipher) throws OCKException;
+    public long CIPHER_create(String cipher) throws NativeException;
 
     public void CIPHER_init(long ockCipherId, int isEncrypt,
-            int paddingId, byte[] key, byte[] iv) throws OCKException;
+            int paddingId, byte[] key, byte[] iv) throws NativeException;
 
-    public void CIPHER_clean(long ockCipherId) throws OCKException;
+    public void CIPHER_clean(long ockCipherId) throws NativeException;
 
     public void CIPHER_setPadding(long ockCipherId, int paddingId)
-            throws OCKException;
+            throws NativeException;
 
     public int CIPHER_getBlockSize(long ockCipherId);
 
@@ -85,27 +85,27 @@ public interface NativeInterface {
 
     public int CIPHER_encryptUpdate(long ockCipherId,
             byte[] plaintext, int plaintextOffset, int plaintextLen, byte[] ciphertext,
-            int ciphertextOffset, boolean needsReinit) throws OCKException;
+            int ciphertextOffset, boolean needsReinit) throws NativeException;
 
     public int CIPHER_decryptUpdate(long ockCipherId,
             byte[] ciphertext, int cipherOffset, int cipherLen, byte[] plaintext,
-            int plaintextOffset, boolean needsReinit) throws OCKException;
+            int plaintextOffset, boolean needsReinit) throws NativeException;
 
     public int CIPHER_encryptFinal(long ockCipherId, byte[] input,
             int inOffset, int inLen, byte[] ciphertext, int ciphertextOffset, boolean needsReinit)
-            throws OCKException;
+            throws NativeException;
 
     public int CIPHER_decryptFinal(long ockCipherId,
             byte[] ciphertext, int cipherOffset, int cipherLen, byte[] plaintext,
-            int plaintextOffset, boolean needsReinit) throws OCKException;
+            int plaintextOffset, boolean needsReinit) throws NativeException;
 
     public long checkHardwareSupport();
 
     public void CIPHER_delete(long ockCipherId)
-            throws OCKException;
+            throws NativeException;
             
     public byte[] CIPHER_KeyWraporUnwrap(byte[] key, byte[] KEK, int type)
-            throws OCKException;
+            throws NativeException;
 
     public int z_kmc_native(byte[] input, int inputOffset, byte[] output,
             int outputOffset, long paramPointer, int inputLength, int mode);
@@ -115,16 +115,16 @@ public interface NativeInterface {
     // =========================================================================
 
     public long POLY1305CIPHER_create(String cipher)
-            throws OCKException;
+            throws NativeException;
 
     public void POLY1305CIPHER_init(long ockCipherId,
-            int isEncrypt, byte[] key, byte[] iv) throws OCKException;
+            int isEncrypt, byte[] key, byte[] iv) throws NativeException;
 
     public void POLY1305CIPHER_clean(long ockCipherId)
-            throws OCKException;
+            throws NativeException;
 
     public void POLY1305CIPHER_setPadding(long ockCipherId,
-            int paddingId) throws OCKException;
+            int paddingId) throws NativeException;
 
     public int POLY1305CIPHER_getBlockSize(long ockCipherId);
 
@@ -136,22 +136,22 @@ public interface NativeInterface {
 
     public int POLY1305CIPHER_encryptUpdate(long ockCipherId,
             byte[] plaintext, int plaintextOffset, int plaintextLen, byte[] ciphertext,
-            int ciphertextOffset) throws OCKException;
+            int ciphertextOffset) throws NativeException;
 
     public int POLY1305CIPHER_decryptUpdate(long ockCipherId,
             byte[] ciphertext, int cipherOffset, int cipherLen, byte[] plaintext,
-            int plaintextOffset) throws OCKException;
+            int plaintextOffset) throws NativeException;
 
     public int POLY1305CIPHER_encryptFinal(long ockCipherId,
             byte[] input, int inOffset, int inLen, byte[] ciphertext, int ciphertextOffset,
-            byte[] tag) throws OCKException;
+            byte[] tag) throws NativeException;
 
     public int POLY1305CIPHER_decryptFinal(long ockCipherId,
             byte[] ciphertext, int cipherOffset, int cipherLen, byte[] plaintext,
-            int plaintextOffset, byte[] tag) throws OCKException;
+            int plaintextOffset, byte[] tag) throws NativeException;
 
     public void POLY1305CIPHER_delete(long ockCipherId)
-            throws OCKException;
+            throws NativeException;
 
     // =========================================================================
     // GCM Cipher functions
@@ -162,67 +162,67 @@ public interface NativeInterface {
     public int do_GCM_encryptFastJNI_WithHardwareSupport(int keyLen, int ivLen,
             int inOffset, int inLen, int ciphertextOffset, int aadLen, int tagLen,
             long parameterBuffer, byte[] input, int inputOffset, byte[] output, int outputOffset)
-            throws OCKException;
+            throws NativeException;
 
     public int do_GCM_encryptFastJNI(long gcmCtx, int keyLen,
             int ivLen, int inOffset, int inLen, int ciphertextOffset, int aadLen, int tagLen,
-            long parameterBuffer, long inputBuffer, long outputBuffer) throws OCKException;
+            long parameterBuffer, long inputBuffer, long outputBuffer) throws NativeException;
 
     public int do_GCM_decryptFastJNI_WithHardwareSupport(int keyLen, int ivLen,
             int inOffset, int inLen, int ciphertextOffset, int aadLen, int tagLen,
             long parameterBuffer, byte[] input, int inputOffset, byte[] output, int outputOffset)
-            throws OCKException;
+            throws NativeException;
 
     public int do_GCM_decryptFastJNI(long gcmCtx, int keyLen,
             int ivLen, int ciphertextOffset, int ciphertextLen, int plainOffset, int aadLen,
             int tagLen, long parameterBuffer, long inputBuffer, long outputBuffer)
-            throws OCKException;
+            throws NativeException;
 
     public int do_GCM_encrypt(long gcmCtx, byte[] key, int keyLen,
             byte[] iv, int ivLen, byte[] input, int inOffset, int inLen, byte[] ciphertext,
             int ciphertextOffset, byte[] aad, int aadLen, byte[] tag, int tagLen)
-            throws OCKException;
+            throws NativeException;
 
     public int do_GCM_decrypt(long gcmCtx, byte[] key, int keyLen,
             byte[] iv, int ivLen, byte[] ciphertext, int cipherOffset, int cipherLen,
             byte[] plaintext, int plaintextOffset, byte[] aad, int aadLen, int tagLen)
-            throws OCKException;
+            throws NativeException;
 
     public int do_GCM_FinalForUpdateEncrypt(long gcmCtx,
             byte[] key, int keyLen, byte[] iv, int ivLen, byte[] input, int inOffset, int inLen,
             byte[] ciphertext, int ciphertextOffset, byte[] aad, int aadLen, byte[] tag, int tagLen)
-            throws OCKException;
+            throws NativeException;
 
     public int do_GCM_FinalForUpdateDecrypt(long gcmCtx,
             /* byte[] key, int keyLen,
              byte[] iv, int ivLen,*/
             byte[] ciphertext, int cipherOffset, int cipherLen, byte[] plaintext,
             int plaintextOffset, int plaintextlen, byte[] aad, int aadLen, int tagLen)
-            throws OCKException;
+            throws NativeException;
 
     public int do_GCM_UpdForUpdateEncrypt(long gcmCtx,
             byte[] input, int inOffset, int inLen, byte[] ciphertext, int ciphertextOffset)
-            throws OCKException;
+            throws NativeException;
 
     public int do_GCM_UpdForUpdateDecrypt(long gcmCtx,
             byte[] ciphertext, int cipherOffset, int cipherLen, byte[] plaintext,
-            int plaintextOffset) throws OCKException;
+            int plaintextOffset) throws NativeException;
 
     public int do_GCM_InitForUpdateEncrypt(long gcmCtx, byte[] key,
-            int keyLen, byte[] iv, int ivLen, byte[] aad, int aadLen) throws OCKException;
+            int keyLen, byte[] iv, int ivLen, byte[] aad, int aadLen) throws NativeException;
 
     public int do_GCM_InitForUpdateDecrypt(long gcmCtx, byte[] key,
-            int keyLen, byte[] iv, int ivLen, byte[] aad, int aadLen) throws OCKException;
+            int keyLen, byte[] iv, int ivLen, byte[] aad, int aadLen) throws NativeException;
 
 
-    public void do_GCM_delete() throws OCKException;
+    public void do_GCM_delete() throws NativeException;
 
     public void free_GCM_ctx(long gcmContextId)
-            throws OCKException;
+            throws NativeException;
 
-    //public int get_GCM_TLSEnabled() throws OCKException;
+    //public int get_GCM_TLSEnabled() throws NativeException;
 
-    public long create_GCM_context() throws OCKException;
+    public long create_GCM_context() throws NativeException;
 
     // =========================================================================
     // CCM Cipher functions
@@ -233,30 +233,30 @@ public interface NativeInterface {
     public int do_CCM_encryptFastJNI_WithHardwareSupport(int keyLen, int ivLen,
             int inOffset, int inLen, int ciphertextOffset, int aadLen, int tagLen,
             long parameterBuffer, byte[] input, int inputOffset, byte[] output, int outputOffset)
-            throws OCKException;
+            throws NativeException;
 
     public int do_CCM_encryptFastJNI(int keyLen, int ivLen,
             int inLen, int ciphertextLen, int aadLen, int tagLen, long parameterBuffer,
-            long inputBuffer, long outputBuffer) throws OCKException;
+            long inputBuffer, long outputBuffer) throws NativeException;
 
     public int do_CCM_decryptFastJNI_WithHardwareSupport(int keyLen, int ivLen,
             int inOffset, int inLen, int ciphertextOffset, int aadLen, int tagLen,
             long parameterBuffer, byte[] input, int inputOffset, byte[] output, int outputOffset)
-            throws OCKException;
+            throws NativeException;
 
     public int do_CCM_decryptFastJNI(int keyLen, int ivLen,
             int ciphertextLen, int plaintextLen, int aadLen, int tagLen, long parameterBuffer,
-            long inputBuffer, long outputBuffer) throws OCKException;
+            long inputBuffer, long outputBuffer) throws NativeException;
 
     public int do_CCM_encrypt(byte[] iv, int ivLen, byte[] key,
             int keyLen, byte[] aad, int aadLen, byte[] input, int inLen, byte[] ciphertext,
-            int ciphertextLen, int tagLen) throws OCKException;
+            int ciphertextLen, int tagLen) throws NativeException;
 
     public int do_CCM_decrypt(byte[] iv, int ivLen, byte[] key,
             int keyLen, byte[] aad, int aadLen, byte[] ciphertext, int ciphertextLength,
-            byte[] plaintext, int plaintextLength, int tagLen) throws OCKException;
+            byte[] plaintext, int plaintextLength, int tagLen) throws NativeException;
 
-    public void do_CCM_delete() throws OCKException;
+    public void do_CCM_delete() throws NativeException;
 
     // =========================================================================
     // RSA cipher functions
@@ -264,71 +264,71 @@ public interface NativeInterface {
 
     public int RSACIPHER_public_encrypt(long rsaKeyId,
             int rsaPaddingId, int mdId, int mgf1Id, byte[] plaintext, int plaintextOffset,
-            int plaintextLen, byte[] ciphertext, int ciphertextOffset) throws OCKException;
+            int plaintextLen, byte[] ciphertext, int ciphertextOffset) throws NativeException;
 
     public int RSACIPHER_private_encrypt(long rsaKeyId,
             int rsaPaddingId, byte[] plaintext, int plaintextOffset, int plaintextLen,
-            byte[] ciphertext, int ciphertextOffset, boolean convertKey) throws OCKException;
+            byte[] ciphertext, int ciphertextOffset, boolean convertKey) throws NativeException;
 
     public int RSACIPHER_public_decrypt(long rsaKeyId,
             int rsaPaddingId, byte[] ciphertext, int ciphertextOffset, int ciphertextLen,
-            byte[] plaintext, int plaintextOffset) throws OCKException;
+            byte[] plaintext, int plaintextOffset) throws NativeException;
 
     public int RSACIPHER_private_decrypt(long rsaKeyId,
             int rsaPaddingId, int mdId, int mgf1Id, byte[] ciphertext, int ciphertextOffset,
             int ciphertextLen, byte[] plaintext, int plaintextOffset, boolean convertKey)
-            throws OCKException;
+            throws NativeException;
 
     // =========================================================================
     // DH key functions
     // =========================================================================
 
-    public long DHKEY_generate(int numBits) throws OCKException;
+    public long DHKEY_generate(int numBits) throws NativeException;
 
     public byte[] DHKEY_generateParameters(int numBits);
 
     public long DHKEY_generate(byte[] dhParameters)
-            throws OCKException;
+            throws NativeException;
 
     public long DHKEY_createPrivateKey(byte[] privateKeyBytes)
-            throws OCKException;
+            throws NativeException;
 
     public long DHKEY_createPublicKey(byte[] publicKeyBytes)
-            throws OCKException;
+            throws NativeException;
 
     public byte[] DHKEY_getParameters(long dhKeyId);
 
     public byte[] DHKEY_getPrivateKeyBytes(long dhKeyId)
-            throws OCKException;
+            throws NativeException;
 
     public byte[] DHKEY_getPublicKeyBytes(long dhKeyId)
-            throws OCKException;
+            throws NativeException;
 
-    public long DHKEY_createPKey(long dhKeyId) throws OCKException;
+    public long DHKEY_createPKey(long dhKeyId) throws NativeException;
 
     public byte[] DHKEY_computeDHSecret(long pubKeyId,
-            long privKeyId) throws OCKException;
+            long privKeyId) throws NativeException;
 
-    public void DHKEY_delete(long dhKeyId) throws OCKException;
+    public void DHKEY_delete(long dhKeyId) throws NativeException;
 
     // =========================================================================
     // RSA key functions
     // =========================================================================
 
     public long RSAKEY_generate(int numBits, long e)
-            throws OCKException;
+            throws NativeException;
 
     public long RSAKEY_createPrivateKey(byte[] privateKeyBytes)
-            throws OCKException;
+            throws NativeException;
 
     public long RSAKEY_createPublicKey(byte[] publicKeyBytes)
-            throws OCKException;
+            throws NativeException;
 
     public byte[] RSAKEY_getPrivateKeyBytes(long rsaKeyId)
-            throws OCKException;
+            throws NativeException;
 
     public byte[] RSAKEY_getPublicKeyBytes(long rsaKeyId)
-            throws OCKException;
+            throws NativeException;
 
     public int RSAKEY_size(long rsaKeyId);
 
@@ -338,272 +338,272 @@ public interface NativeInterface {
     // DSA key functions
     // =========================================================================
 
-    public long DSAKEY_generate(int numBits) throws OCKException;
+    public long DSAKEY_generate(int numBits) throws NativeException;
 
     public byte[] DSAKEY_generateParameters(int numBits);
 
     public long DSAKEY_generate(byte[] dsaParameters)
-            throws OCKException;
+            throws NativeException;
 
     public long DSAKEY_createPrivateKey(byte[] privateKeyBytes)
-            throws OCKException;
+            throws NativeException;
 
     public long DSAKEY_createPublicKey(byte[] publicKeyBytes)
-            throws OCKException;
+            throws NativeException;
 
     public byte[] DSAKEY_getParameters(long dsaKeyId);
 
     public byte[] DSAKEY_getPrivateKeyBytes(long dsaKeyId)
-            throws OCKException;
+            throws NativeException;
 
     public byte[] DSAKEY_getPublicKeyBytes(long dsaKeyId)
-            throws OCKException;
+            throws NativeException;
 
     public long DSAKEY_createPKey(long dsaKeyId)
-            throws OCKException;
+            throws NativeException;
 
-    public void DSAKEY_delete(long dsaKeyId) throws OCKException;
+    public void DSAKEY_delete(long dsaKeyId) throws NativeException;
 
     // =========================================================================
     // PKey functions
     // =========================================================================
 
-    public void PKEY_delete(long pkeyId) throws OCKException;
+    public void PKEY_delete(long pkeyId) throws NativeException;
 
     // =========================================================================
     // Digest functions
     // =========================================================================
 
     public long DIGEST_create(String digestAlgo)
-            throws OCKException;
+            throws NativeException;
 
     public long DIGEST_copy(long digestId)
-            throws OCKException;
+            throws NativeException;
 
     public int DIGEST_update(long digestId, byte[] input,
-            int offset, int length) throws OCKException;
+            int offset, int length) throws NativeException;
 
     public void DIGEST_updateFastJNI(long digestId,
-            long inputBuffer, int length) throws OCKException;
+            long inputBuffer, int length) throws NativeException;
 
-    public byte[] DIGEST_digest(long digestId) throws OCKException;
+    public byte[] DIGEST_digest(long digestId) throws NativeException;
 
     public void DIGEST_digest_and_reset(long digestId,
-            long outputBuffer, int length) throws OCKException;
+            long outputBuffer, int length) throws NativeException;
 
     public int DIGEST_digest_and_reset(long digestId,
-            byte[] output) throws OCKException;
+            byte[] output) throws NativeException;
 
-    public int DIGEST_size(long digestId) throws OCKException;
+    public int DIGEST_size(long digestId) throws NativeException;
 
-    public void DIGEST_reset(long digestId) throws OCKException;
+    public void DIGEST_reset(long digestId) throws NativeException;
 
-    public void DIGEST_delete(long digestId) throws OCKException;
+    public void DIGEST_delete(long digestId) throws NativeException;
 
     public int DIGEST_PKCS12KeyDeriveHelp(long digestId, byte[] input,
-            int offset, int length, int iterationCount) throws OCKException;
+            int offset, int length, int iterationCount) throws NativeException;
 
     // =========================================================================
     // Signature functions (with digest)
     // =========================================================================
 
     public byte[] SIGNATURE_sign(long digestId, long pkeyId,
-            boolean convert) throws OCKException;
+            boolean convert) throws NativeException;
 
     public boolean SIGNATURE_verify(long digestId, long pkeyId,
-            byte[] sigBytes) throws OCKException;
+            byte[] sigBytes) throws NativeException;
 
     public byte[] SIGNATUREEdDSA_signOneShot(long pkeyId,
-            byte[] bytes) throws OCKException;
+            byte[] bytes) throws NativeException;
 
     public boolean SIGNATUREEdDSA_verifyOneShot(long pkeyId,
-            byte[] sigBytes, byte[] oneShot) throws OCKException;
+            byte[] sigBytes, byte[] oneShot) throws NativeException;
 
     // =========================================================================
     // RSAPSSSignature functions
     // =========================================================================
 
     public int RSAPSS_signInit(long rsaPssId, long pkeyId,
-            int saltlen, boolean convert) throws OCKException;
+            int saltlen, boolean convert) throws NativeException;
 
     public int RSAPSS_verifyInit(long rsaPssId, long pkeyId,
-            int saltlen) throws OCKException;
+            int saltlen) throws NativeException;
 
     public int RSAPSS_getSigLen(long rsaPssId);
 
     public void RSAPSS_signFinal(long rsaPssId, byte[] signature,
-            int length) throws OCKException;
+            int length) throws NativeException;
 
     public boolean RSAPSS_verifyFinal(long rsaPssId,
-            byte[] sigBytes, int length) throws OCKException;
+            byte[] sigBytes, int length) throws NativeException;
 
     public long RSAPSS_createContext(String digestAlgo,
-            String mgf1SpecAlgo) throws OCKException;
+            String mgf1SpecAlgo) throws NativeException;
 
     public void RSAPSS_releaseContext(long rsaPssId)
-            throws OCKException;
+            throws NativeException;
 
     public void RSAPSS_digestUpdate(long rsaPssId, byte[] input,
-            int offset, int length) throws OCKException;
+            int offset, int length) throws NativeException;
 
-    public void RSAPSS_reset(long digestId) throws OCKException;
+    public void RSAPSS_reset(long digestId) throws NativeException;
 
     public void RSAPSS_resetDigest(long rsaPssId)
-            throws OCKException;
+            throws NativeException;
 
     // =========================================================================
     // DSA Signature functions (pre-hashed data)
     // =========================================================================
 
     public byte[] DSANONE_SIGNATURE_sign(byte[] digest,
-            long dsaKeyId) throws OCKException;
+            long dsaKeyId) throws NativeException;
 
     public boolean DSANONE_SIGNATURE_verify(byte[] digest,
-            long dsaKeyId, byte[] sigBytes) throws OCKException;
+            long dsaKeyId, byte[] sigBytes) throws NativeException;
 
     // =========================================================================
     // RSASSL Signature functions (pre-hashed data)
     // =========================================================================
 
     public byte[] RSASSL_SIGNATURE_sign(byte[] digest,
-            long rsaKeyId) throws OCKException;
+            long rsaKeyId) throws NativeException;
 
     public boolean RSASSL_SIGNATURE_verify(byte[] digest,
-            long rsaKeyId, byte[] sigBytes, boolean convert) throws OCKException;
+            long rsaKeyId, byte[] sigBytes, boolean convert) throws NativeException;
 
     // =========================================================================
     // HMAC functions
     // =========================================================================
 
-    public long HMAC_create(String digestAlgo) throws OCKException;
+    public long HMAC_create(String digestAlgo) throws NativeException;
 
     public int HMAC_update(long hmacId, byte[] key, int keyLength,
-            byte[] input, int inputOffset, int inputLength, boolean needInit) throws OCKException;
+            byte[] input, int inputOffset, int inputLength, boolean needInit) throws NativeException;
 
     public int HMAC_doFinal(long hmacId, byte[] key, int keyLength,
-            byte[] hmac, boolean needInit) throws OCKException;
+            byte[] hmac, boolean needInit) throws NativeException;
 
-    public int HMAC_size(long hmacId) throws OCKException;
+    public int HMAC_size(long hmacId) throws NativeException;
 
-    public void HMAC_delete(long hmacId) throws OCKException;
+    public void HMAC_delete(long hmacId) throws NativeException;
 
     // =========================================================================
     // EC key functions
     // =========================================================================
 
-    public long ECKEY_generate(int numBits) throws OCKException;
+    public long ECKEY_generate(int numBits) throws NativeException;
 
     public long ECKEY_generate(String curveOid)
-            throws OCKException;
+            throws NativeException;
 
     public long XECKEY_generate(int option, long bufferPtr)
-            throws OCKException;
+            throws NativeException;
 
     public byte[] ECKEY_generateParameters(int numBits)
-            throws OCKException;
+            throws NativeException;
 
     public byte[] ECKEY_generateParameters(String curveOid)
-            throws OCKException;
+            throws NativeException;
 
     public long ECKEY_generate(byte[] ecParameters)
-            throws OCKException;
+            throws NativeException;
 
     public long ECKEY_createPrivateKey(byte[] privateKeyBytes)
-            throws OCKException;
+            throws NativeException;
 
     public long XECKEY_createPrivateKey(byte[] privateKeyBytes,
-            long bufferPtr) throws OCKException;
+            long bufferPtr) throws NativeException;
 
     public long ECKEY_createPublicKey(byte[] publicKeyBytes,
-            byte[] parameterBytes) throws OCKException;
+            byte[] parameterBytes) throws NativeException;
 
     public long XECKEY_createPublicKey(byte[] publicKeyBytes)
-            throws OCKException;
+            throws NativeException;
 
     public byte[] ECKEY_getParameters(long ecKeyId);
 
     public byte[] ECKEY_getPrivateKeyBytes(long ecKeyId)
-            throws OCKException;
+            throws NativeException;
 
     public byte[] XECKEY_getPrivateKeyBytes(long xecKeyId)
-            throws OCKException;
+            throws NativeException;
 
     public byte[] ECKEY_getPublicKeyBytes(long ecKeyId)
-            throws OCKException;
+            throws NativeException;
 
     public byte[] XECKEY_getPublicKeyBytes(long xecKeyId)
-            throws OCKException;
+            throws NativeException;
 
-    public long ECKEY_createPKey(long ecKeyId) throws OCKException;
+    public long ECKEY_createPKey(long ecKeyId) throws NativeException;
 
-    public void ECKEY_delete(long ecKeyId) throws OCKException;
+    public void ECKEY_delete(long ecKeyId) throws NativeException;
 
-    public void XECKEY_delete(long xecKeyId) throws OCKException;
+    public void XECKEY_delete(long xecKeyId) throws NativeException;
 
     public long XDHKeyAgreement_init(long privId);
 
     public void XDHKeyAgreement_setPeer(long genCtx, long pubId);
 
     public byte[] ECKEY_computeECDHSecret(long pubEcKeyId,
-            long privEcKeyId) throws OCKException;
+            long privEcKeyId) throws NativeException;
 
     public byte[] XECKEY_computeECDHSecret(long genCtx,
-            long pubEcKeyId, long privEcKeyId, int secrectBufferSize) throws OCKException;
+            long pubEcKeyId, long privEcKeyId, int secrectBufferSize) throws NativeException;
 
 
     public byte[] ECKEY_signDatawithECDSA(byte[] digestBytes,
-            int digestBytesLen, long ecPrivateKeyId) throws OCKException;
+            int digestBytesLen, long ecPrivateKeyId) throws NativeException;
 
     public boolean ECKEY_verifyDatawithECDSA(byte[] digestBytes,
             int digestBytesLen, byte[] sigBytes, int sigBytesLen, long ecPublicKeyId)
-            throws OCKException;
+            throws NativeException;
 
 
     // =========================================================================
     // HKDF functions
     // =========================================================================
 
-    public long HKDF_create(String digestAlgo) throws OCKException;
+    public long HKDF_create(String digestAlgo) throws NativeException;
 
     public byte[] HKDF_extract(long hkdfId, byte[] saltBytes,
-            long saltLen, byte[] inKey, long inKeyLen) throws OCKException;
+            long saltLen, byte[] inKey, long inKeyLen) throws NativeException;
 
     public byte[] HKDF_expand(long hkdfId, byte[] prkBytes,
-            long prkBytesLen, byte[] info, long infoLen, long okmLen) throws OCKException;
+            long prkBytesLen, byte[] info, long infoLen, long okmLen) throws NativeException;
 
     public byte[] HKDF_derive(long hkdfId, byte[] saltBytes,
             long saltLen, byte[] inKey, long inKeyLen, byte[] info, long infoLen, long okmLen)
-            throws OCKException;
+            throws NativeException;
 
-    public void HKDF_delete(long hkdfId) throws OCKException;
+    public void HKDF_delete(long hkdfId) throws NativeException;
 
-    public int HKDF_size(long hkdfId) throws OCKException;
+    public int HKDF_size(long hkdfId) throws NativeException;
 
     // =========================================================================
     // Password based key derivation functions ( PBKDF )
     // =========================================================================
 
     public byte[] PBKDF2_derive(String hashAlgorithm, byte[] password, byte[] salt,
-            int iterations, int keyLength) throws OCKException;
+            int iterations, int keyLength) throws NativeException;
 
     // =========================================================================
     // ML-KEY key functions
     // =========================================================================
 
     public long MLKEY_generate(String cipherName)
-            throws OCKException;
+            throws NativeException;
 
     public long MLKEY_createPrivateKey(String cipherName, byte[] privateKeyBytes)
-            throws OCKException;
+            throws NativeException;
 
     public long MLKEY_createPublicKey(String cipherName, byte[] publicKeyBytes)
-            throws OCKException;
+            throws NativeException;
 
     public byte[] MLKEY_getPrivateKeyBytes(long mlkeyId)
-            throws OCKException;
+            throws NativeException;
 
     public byte[] MLKEY_getPublicKeyBytes(long mlkeyId)
-            throws OCKException;
+            throws NativeException;
 
     public void MLKEY_delete(long mlkeyId);
 
@@ -611,17 +611,17 @@ public interface NativeInterface {
     // Key Encapsulation functions
     // =========================================================================
     public void KEM_encapsulate(long ockPKeyId, byte[] wrappedKey, byte[] randomKey)
-            throws OCKException;
+            throws NativeException;
 
     public byte[] KEM_decapsulate(long ockPKeyId, byte[] wrappedKey)
-            throws OCKException;
+            throws NativeException;
 
     // =========================================================================
     // PQC Signture functions - for use with ML-DSA and ML-SLH
     // =========================================================================
     public byte[] PQC_SIGNATURE_sign(long ockPKeyId, byte[] data)
-            throws OCKException;
+            throws NativeException;
 
     public boolean PQC_SIGNATURE_verify(long ockPKeyId, byte[] sigBytes, byte[] data)
-            throws OCKException;
+            throws NativeException;
 }

--- a/src/main/java/com/ibm/crypto/plus/provider/base/OJPKEM.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/OJPKEM.java
@@ -19,13 +19,13 @@ public final class OJPKEM {
      */
 
     public static void KEM_encapsulate(long ockPKeyId, byte[] encapsulatedKey,
-            byte[] keyMaterial, OpenJCEPlusProvider provider) throws OCKException {
+            byte[] keyMaterial, OpenJCEPlusProvider provider) throws NativeException {
         NativeInterface nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
         nativeInterface.KEM_encapsulate(ockPKeyId, encapsulatedKey, keyMaterial);
     }
 
     public static byte[] KEM_decapsulate(long ockPKeyId, byte[] encapsulatedKey, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         NativeInterface nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
         byte[] keyMaterial = nativeInterface.KEM_decapsulate(ockPKeyId, encapsulatedKey);
 

--- a/src/main/java/com/ibm/crypto/plus/provider/base/PBKDF.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/PBKDF.java
@@ -28,10 +28,10 @@ public final class PBKDF {
      * @param iterations The number of iterations to use when deriving the key.
      * @param keyLength The desired length of the key to be derived.
      * @return An array of bytes representing the key that was derived.
-     * @throws OCKException If input parameters are incorrect or an error occurs in OCKC deriving the key.
+     * @throws NativeException If input parameters are incorrect or an error occurs in OCKC deriving the key.
      */
     public static byte[] PBKDF2derive(String algorithmName, final byte[] password,
-            byte[] salt, int iterations, int keyLength, OpenJCEPlusProvider provider) throws OCKException {
+            byte[] salt, int iterations, int keyLength, OpenJCEPlusProvider provider) throws NativeException {
 
         if ((!algorithmName.equalsIgnoreCase("HmacSHA512/224"))
                 && (!algorithmName.equalsIgnoreCase("HmacSHA512/256"))
@@ -40,29 +40,29 @@ public final class PBKDF {
                 && (!algorithmName.equalsIgnoreCase("HmacSHA256"))
                 && (!algorithmName.equalsIgnoreCase("HmacSHA224"))
                 && (!algorithmName.equalsIgnoreCase("HmacSHA1"))) {
-            throw new OCKException("Algorithm name not recognized: " + algorithmName);
+            throw new NativeException("Algorithm name not recognized: " + algorithmName);
         }
         algorithmName = algorithmName.replace("/", "-");
         String algorithmHashName = algorithmName.substring(4).toUpperCase();
 
         if (keyLength <= 0) {
-            throw new OCKException("Key length is less then or equal to 0");
+            throw new NativeException("Key length is less then or equal to 0");
         }
 
         if (algorithmName == null || algorithmName.isEmpty()) {
-            throw new OCKException("Hash algorithm is null or empty");
+            throw new NativeException("Hash algorithm is null or empty");
         }
 
         if (password == null) {
-            throw new OCKException("Password is null");
+            throw new NativeException("Password is null");
         }
 
         if ((salt == null) || (salt.length == 0)) {
-            throw new OCKException("Salt is null or length 0");
+            throw new NativeException("Salt is null or length 0");
         }
 
         if (iterations <= 0) {
-            throw new OCKException("Iterations is less then or equal to 0");
+            throw new NativeException("Iterations is less then or equal to 0");
         }
 
         NativeInterface nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
@@ -70,7 +70,7 @@ public final class PBKDF {
                 salt, iterations, keyLength);
 
         if (null == key) {
-            throw new OCKException("Error deriving key using PBKDF2. Key is null.");
+            throw new NativeException("Error deriving key using PBKDF2. Key is null.");
         }
 
         return key;

--- a/src/main/java/com/ibm/crypto/plus/provider/base/PQCKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/PQCKey.java
@@ -29,7 +29,7 @@ public final class PQCKey implements AsymmetricKey {
     private final static String badIdMsg = "Key Identifier is not valid";
 
     public static PQCKey generateKeyPair(String algName, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         long keyId = 0;
         // final String methodName = "generateKeyPair ";
 
@@ -42,16 +42,16 @@ public final class PQCKey implements AsymmetricKey {
             keyId = nativeInterface.MLKEY_generate(NoDashAlg);
 
             if (keyId == 0) {
-                throw new OCKException("PQCKey.generateKeyPair: MLKEY_generate failed");
+                throw new NativeException("PQCKey.generateKeyPair: MLKEY_generate failed");
             }    
         } catch (Exception e) {
-            throw new OCKException("PQCKey.generateKeyPair: Exception " + e.getMessage(), e);
+            throw new NativeException("PQCKey.generateKeyPair: Exception " + e.getMessage(), e);
         }
         return new PQCKey(nativeInterface, keyId, unobtainedKeyBytes, unobtainedKeyBytes, algName, provider);
     }
 
     public static PQCKey createPrivateKey(String algName, byte[] privateKeyBytes, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         // final String methodName = "createPrivateKey ";
         if (privateKeyBytes == null) {
             throw new IllegalArgumentException("key bytes is null");
@@ -69,7 +69,7 @@ public final class PQCKey implements AsymmetricKey {
     }
 
     public static PQCKey createPublicKey(String algName, byte[] publicKeyBytes, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         // final String methodName = "createPublicKey ";
         if (publicKeyBytes == null) {
             throw new IllegalArgumentException("key bytes is null");
@@ -88,14 +88,14 @@ public final class PQCKey implements AsymmetricKey {
     }
 
     private PQCKey(NativeInterface nativeInterface, long keyId, byte[] privateKeyBytes,
-            byte[] publicKeyBytes, String algName, OpenJCEPlusProvider provider) throws OCKException {
+            byte[] publicKeyBytes, String algName, OpenJCEPlusProvider provider) throws NativeException {
         this.nativeInterface = nativeInterface;
         this.pkeyId = keyId;
         this.algName = algName;
         this.provider = provider;
 
         if (!validId(pkeyId)) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
 
         if (provider == null) {
@@ -122,12 +122,12 @@ public final class PQCKey implements AsymmetricKey {
     }
 
     @Override
-    public long getPKeyId() throws OCKException {
+    public long getPKeyId() throws NativeException {
         return pkeyId;
     }
 
     @Override
-    public byte[] getPrivateKeyBytes() throws OCKException {
+    public byte[] getPrivateKeyBytes() throws NativeException {
         // final String methodName = "getPrivateKeyBytes :";
         if (privateKeyBytes == unobtainedKeyBytes) {
             obtainPrivateKeyBytes();
@@ -136,7 +136,7 @@ public final class PQCKey implements AsymmetricKey {
     }
 
     @Override
-    public byte[] getPublicKeyBytes() throws OCKException {
+    public byte[] getPublicKeyBytes() throws NativeException {
         // final String methodName = "getPublicKeyBytes";
         if (publicKeyBytes == unobtainedKeyBytes) {
             obtainPublicKeyBytes();
@@ -144,14 +144,14 @@ public final class PQCKey implements AsymmetricKey {
         return (publicKeyBytes == null) ? null : publicKeyBytes.clone();
     }
 
-    private synchronized void obtainPrivateKeyBytes() throws OCKException {
+    private synchronized void obtainPrivateKeyBytes() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getPrivateKeyBytes at the same time, we only want to call the
         // native code one time.
         //
         if (privateKeyBytes == unobtainedKeyBytes) {
             if (!validId(pkeyId)) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
         
             System.out.println("getPrivKeyBytes - pkeyId :" + pkeyId);
@@ -159,14 +159,14 @@ public final class PQCKey implements AsymmetricKey {
         }
     }
 
-    private synchronized void obtainPublicKeyBytes() throws OCKException {
+    private synchronized void obtainPublicKeyBytes() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getPublicKeyBytes at the same time, we only want to call the
         // native code one time.
         //
         if (publicKeyBytes == unobtainedKeyBytes) {
             if (!validId(pkeyId)) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             this.publicKeyBytes = this.nativeInterface.MLKEY_getPublicKeyBytes(pkeyId);
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/base/PQCSignature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/PQCSignature.java
@@ -29,18 +29,18 @@ public final class PQCSignature {
     private boolean initialized = false;
 
     public static PQCSignature getInstance(OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         return new PQCSignature(provider);
     }
 
-    private PQCSignature(OpenJCEPlusProvider provider) throws OCKException {
+    private PQCSignature(OpenJCEPlusProvider provider) throws NativeException {
         //final String methodName = "Signature(String)";
         this.nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
         //OCKDebug.Msg (debPrefix, methodName, "digestAlgo :" + digestAlgo);
     }
 
     public void initialize(AsymmetricKey key)
-            throws InvalidKeyException, OCKException {
+            throws InvalidKeyException, NativeException {
         //final String methodName = "initialize";
         if (key == null) {
             throw new IllegalArgumentException("key is null");
@@ -51,7 +51,7 @@ public final class PQCSignature {
         //OCKDebug.Msg (debPrefix, methodName,  "this.key=" + key);
     }
 
-    public synchronized byte[] sign(byte[] data) throws OCKException {
+    public synchronized byte[] sign(byte[] data) throws NativeException {
 
         if (!this.initialized) {
             throw new IllegalStateException("Signature not initialized");
@@ -60,13 +60,13 @@ public final class PQCSignature {
         //OCKDebug.Msg (debPrefix, "sign"," pkeyId :" + this.key.getPKeyId());
 
        // if (!validId(this.key.getPKeyId())) {
-       //     throw new OCKException(badIdMsg);
+       //     throw new NativeException(badIdMsg);
        // }
 
         byte[] signature = null;
 
         if (data == null || data.length == 0) {
-            throw new OCKException("No data to sign.");
+            throw new NativeException("No data to sign.");
         }
 
         signature = this.nativeInterface.PQC_SIGNATURE_sign(this.key.getPKeyId(), data);
@@ -75,7 +75,7 @@ public final class PQCSignature {
         return signature;
     }
 
-    public synchronized boolean verify(byte[] sigBytes, byte[] data) throws OCKException {
+    public synchronized boolean verify(byte[] sigBytes, byte[] data) throws NativeException {
         //final String methodName = "verify";
         if (!this.initialized) {
             throw new IllegalStateException("Signature not initialized");

--- a/src/main/java/com/ibm/crypto/plus/provider/base/Poly1305Cipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/Poly1305Cipher.java
@@ -38,7 +38,7 @@ public final class Poly1305Cipher implements Poly1305Constants {
     private final static String badIdMsg = "Cipher Identifier is not valid";
 
     public static Poly1305Cipher getInstance(String cipherName,
-            Padding padding, OpenJCEPlusProvider provider) throws OCKException {
+            Padding padding, OpenJCEPlusProvider provider) throws NativeException {
 
         if (cipherName == null || cipherName.isEmpty()) {
             throw new IllegalArgumentException("cipherName is null/empty");
@@ -56,7 +56,7 @@ public final class Poly1305Cipher implements Poly1305Constants {
     }
 
     private Poly1305Cipher(String cipherName, Padding padding, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         this.padding = padding;
         this.provider = provider;
         this.nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
@@ -65,16 +65,16 @@ public final class Poly1305Cipher implements Poly1305Constants {
         this.provider.registerCleanable(this, cleanOCKResources(ockCipherId, reinitKey, nativeInterface));
     }
 
-    public synchronized void initCipherEncrypt(byte[] key, byte[] iv) throws OCKException {
+    public synchronized void initCipherEncrypt(byte[] key, byte[] iv) throws NativeException {
         initCipher(true, key, iv);
     }
 
-    public synchronized void initCipherDecrypt(byte[] key, byte[] iv) throws OCKException {
+    public synchronized void initCipherDecrypt(byte[] key, byte[] iv) throws NativeException {
         initCipher(false, key, iv);
         byteArrayOutputDelay = new ByteArrayOutputDelay(Poly1305_TAG_SIZE);
     }
 
-    private void initCipher(boolean isEncrypt, byte[] key, byte[] iv) throws OCKException {
+    private void initCipher(boolean isEncrypt, byte[] key, byte[] iv) throws NativeException {
         if ((key == null) || (key.length == 0)) {
             throw new IllegalArgumentException("key is null/empty");
         }
@@ -88,7 +88,7 @@ public final class Poly1305Cipher implements Poly1305Constants {
         }
 
         if (ockCipherId == 0L) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
         this.nativeInterface.POLY1305CIPHER_init(ockCipherId, isEncrypt ? 1 : 0, key,
                 iv);
@@ -126,10 +126,10 @@ public final class Poly1305Cipher implements Poly1305Constants {
         }
     }
 
-    public synchronized int getBlockSize() throws OCKException {
+    public synchronized int getBlockSize() throws NativeException {
         if (blockSize == 0) {
             if (ockCipherId == 0L) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             blockSize = this.nativeInterface.POLY1305CIPHER_getBlockSize(ockCipherId);
         }
@@ -137,10 +137,10 @@ public final class Poly1305Cipher implements Poly1305Constants {
         return blockSize;
     }
 
-    public synchronized int getKeyLength() throws OCKException {
+    public synchronized int getKeyLength() throws NativeException {
         if (keyLength == 0) {
             if (ockCipherId == 0L) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             keyLength = this.nativeInterface.POLY1305CIPHER_getKeyLength(ockCipherId);
         }
@@ -148,10 +148,10 @@ public final class Poly1305Cipher implements Poly1305Constants {
         return keyLength;
     }
 
-    public synchronized int getIVLength() throws OCKException {
+    public synchronized int getIVLength() throws NativeException {
         if (ivLength == 0) {
             if (ockCipherId == 0L) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             ivLength = this.nativeInterface.POLY1305CIPHER_getIVLength(ockCipherId);
         }
@@ -160,7 +160,7 @@ public final class Poly1305Cipher implements Poly1305Constants {
     }
 
     public synchronized int update(byte[] input, int inputOffset, int inputLen, byte[] output,
-            int outputOffset) throws IllegalStateException, ShortBufferException, OCKException {
+            int outputOffset) throws IllegalStateException, ShortBufferException, NativeException {
 
         int outLen = 0;
 
@@ -220,7 +220,7 @@ public final class Poly1305Cipher implements Poly1305Constants {
         try {
 
             if (ockCipherId == 0L) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             if (encrypting) {
                 outLen = this.nativeInterface.POLY1305CIPHER_encryptUpdate(ockCipherId,
@@ -249,7 +249,7 @@ public final class Poly1305Cipher implements Poly1305Constants {
 
     public synchronized int doFinal(byte[] input, int inputOffset, int inputLen, byte[] output,
             int outputOffset) throws IllegalStateException, ShortBufferException,
-            IllegalBlockSizeException, BadPaddingException, OCKException {
+            IllegalBlockSizeException, BadPaddingException, NativeException {
 
         byte[] tag = new byte[Poly1305_TAG_SIZE];
         byte[] cipherText = null;
@@ -337,7 +337,7 @@ public final class Poly1305Cipher implements Poly1305Constants {
 
         try {
             if (ockCipherId == 0L) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             if (encrypting) {
                 // Cipher text length is same as plain text length...
@@ -359,8 +359,8 @@ public final class Poly1305Cipher implements Poly1305Constants {
                         ockCipherId, cipherText, inputOffset, cipherTextLen, output, outputOffset,
                         tag);
             }
-        } catch (OCKException e) {
-            if (e.getCode() == OCKException.GKR_DECRYPT_FINAL_BAD_PADDING_ERROR) {
+        } catch (NativeException e) {
+            if (e.getCode() == e.GKR_DECRYPT_FINAL_BAD_PADDING_ERROR) {
                 throw new BadPaddingException("Unexpected padding");
             } else {
                 throw e;

--- a/src/main/java/com/ibm/crypto/plus/provider/base/RSACipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/RSACipher.java
@@ -56,7 +56,7 @@ public final class RSACipher {
     }
 
     public void initialize(RSAKey key, boolean plainRSAKey)
-            throws OCKException, InvalidKeyException {
+            throws NativeException, InvalidKeyException {
         if (key == null) {
             throw new InvalidKeyException("key is null");
         }
@@ -66,21 +66,21 @@ public final class RSACipher {
 
     // Method not synchronized since ObtainKeySize method used getKeySize is synchronized 
     //
-    public int getOutputSize() throws OCKException {
+    public int getOutputSize() throws NativeException {
         checkInitialized();
         return this.rsaKey.getKeySize();
     }
 
     public synchronized int publicEncrypt(RSAPadding padding, byte[] input, int inOffset, int inLen,
             byte[] output, int outOffset) throws BadPaddingException, IllegalBlockSizeException,
-            ShortBufferException, OCKException {
+            ShortBufferException, NativeException {
         checkInitialized();
         if (inLen == 0)
             return 0;
         checkInputRange(input, inOffset, inLen);
         checkOutputRange(output, outOffset);
         if (!validId(this.rsaKey.getRSAKeyId())) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
         return checkOutLen(this.nativeInterface.RSACIPHER_public_encrypt(
                 this.rsaKey.getRSAKeyId(), padding.getId(), padding.getMessageDigest(),
@@ -89,14 +89,14 @@ public final class RSACipher {
 
     public synchronized int privateEncrypt(RSAPadding padding, byte[] input, int inOffset,
             int inLen, byte[] output, int outOffset) throws BadPaddingException,
-            IllegalBlockSizeException, ShortBufferException, OCKException {
+            IllegalBlockSizeException, ShortBufferException, NativeException {
         checkInitialized();
         if (inLen == 0)
             return 0;
         checkInputRange(input, inOffset, inLen);
         checkOutputRange(output, outOffset);
         if (!validId(this.rsaKey.getRSAKeyId())) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
         return checkOutLen(this.nativeInterface.RSACIPHER_private_encrypt(
                 this.rsaKey.getRSAKeyId(), padding.getId(), input, inOffset, inLen, output,
@@ -105,7 +105,7 @@ public final class RSACipher {
 
     public synchronized int publicDecrypt(RSAPadding padding, byte[] input, int inOffset, int inLen,
             byte[] output, int outOffset) throws BadPaddingException, IllegalBlockSizeException,
-            ShortBufferException, OCKException {
+            ShortBufferException, NativeException {
         checkInitialized();
         if (inLen == 0)
             return 0;
@@ -116,7 +116,7 @@ public final class RSACipher {
                     "Input must be: " + getOutputSize() + " bytes long");
         }
         if (!validId(this.rsaKey.getRSAKeyId())) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
         return checkOutLen(this.nativeInterface.RSACIPHER_public_decrypt(
                 this.rsaKey.getRSAKeyId(), padding.getId(), input, inOffset, inLen, output,
@@ -125,7 +125,7 @@ public final class RSACipher {
 
     public synchronized int privateDecrypt(RSAPadding padding, byte[] input, int inOffset,
             int inLen, byte[] output, int outOffset) throws BadPaddingException,
-            IllegalBlockSizeException, ShortBufferException, OCKException {
+            IllegalBlockSizeException, ShortBufferException, NativeException {
         checkInitialized();
         if (inLen == 0)
             return 0;
@@ -136,7 +136,7 @@ public final class RSACipher {
                     "Input must be: " + getOutputSize() + " bytes long");
         }
         if (!validId(this.rsaKey.getRSAKeyId())) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
         return checkOutLen(this.nativeInterface.RSACIPHER_private_decrypt(
                 this.rsaKey.getRSAKeyId(), padding.getId(), padding.getMessageDigest(),
@@ -150,7 +150,7 @@ public final class RSACipher {
     }
 
     private void checkOutputRange(byte[] output, int offset)
-            throws ShortBufferException, OCKException {
+            throws ShortBufferException, NativeException {
         if (output == null || (offset > output.length)
                 || (output.length - offset) < getOutputSize()) {
             throw new ShortBufferException(

--- a/src/main/java/com/ibm/crypto/plus/provider/base/RSAKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/RSAKey.java
@@ -31,7 +31,7 @@ public final class RSAKey implements AsymmetricKey {
     private final static String debPrefix = "RSAKey";
 
     public static RSAKey generateKeyPair(int numBits, BigInteger e, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         //final String methodName = "generateKeyPair ";
         if (numBits < 0) {
             throw new IllegalArgumentException("key length is invalid");
@@ -48,7 +48,7 @@ public final class RSAKey implements AsymmetricKey {
     }
 
     public static RSAKey createPrivateKey(byte[] privateKeyBytes, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         //final String methodName = "createPrivateKey ";
         if (privateKeyBytes == null) {
             throw new IllegalArgumentException("key bytes is null");
@@ -65,7 +65,7 @@ public final class RSAKey implements AsymmetricKey {
     }
 
     public static RSAKey createPublicKey(byte[] publicKeyBytes, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         //final String methodName = "createPublicKey ";
         if (publicKeyBytes == null) {
             throw new IllegalArgumentException("key bytes is null");
@@ -103,11 +103,11 @@ public final class RSAKey implements AsymmetricKey {
     }
 
     @Override
-    public long getPKeyId() throws OCKException {
+    public long getPKeyId() throws NativeException {
         return this.rsaKeyId;
     }
 
-    public int getKeySize() throws OCKException {
+    public int getKeySize() throws NativeException {
         //final String methodName = "getKeySize";
         if (keySize == 0) {
             obtainKeySize();
@@ -117,7 +117,7 @@ public final class RSAKey implements AsymmetricKey {
     }
 
     @Override
-    public byte[] getPrivateKeyBytes() throws OCKException {
+    public byte[] getPrivateKeyBytes() throws NativeException {
         //final String methodName = "getPrivateKeyBytes :";
         if (privateKeyBytes == unobtainedKeyBytes) {
             obtainPrivateKeyBytes();
@@ -127,7 +127,7 @@ public final class RSAKey implements AsymmetricKey {
     }
 
     @Override
-    public byte[] getPublicKeyBytes() throws OCKException {
+    public byte[] getPublicKeyBytes() throws NativeException {
         //final String methodName = "getPrivateKeyBytes";
         if (publicKeyBytes == unobtainedKeyBytes) {
             obtainPublicKeyBytes();
@@ -136,40 +136,40 @@ public final class RSAKey implements AsymmetricKey {
         return (publicKeyBytes == null) ? null : publicKeyBytes.clone();
     }
 
-    private synchronized void obtainPrivateKeyBytes() throws OCKException {
+    private synchronized void obtainPrivateKeyBytes() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getPrivateKeyBytes at the same time, we only want to call the
         // native code one time.
         //
         if (privateKeyBytes == unobtainedKeyBytes) {
             if (!validId(rsaKeyId)) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             this.privateKeyBytes = this.nativeInterface.RSAKEY_getPrivateKeyBytes(rsaKeyId);
         }
     }
 
-    private synchronized void obtainPublicKeyBytes() throws OCKException {
+    private synchronized void obtainPublicKeyBytes() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getPublicKeyBytes at the same time, we only want to call the
         // native code one time.
         //
         if (publicKeyBytes == unobtainedKeyBytes) {
             if (!validId(rsaKeyId)) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             this.publicKeyBytes = this.nativeInterface.RSAKEY_getPublicKeyBytes(rsaKeyId);
         }
     }
 
-    private synchronized void obtainKeySize() throws OCKException {
+    private synchronized void obtainKeySize() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to obtainKeySize at the same time, we only want to call the
         // native code one time.
         //
         if (this.keySize == 0) {
             if (!validId(rsaKeyId)) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             this.keySize = this.nativeInterface.RSAKEY_size(rsaKeyId);
         }

--- a/src/main/java/com/ibm/crypto/plus/provider/base/Signature.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/Signature.java
@@ -24,19 +24,19 @@ public final class Signature {
     private final static String debPrefix = "SIGNATURE";
 
     public static Signature getInstance(String digestAlgo, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         return new Signature(digestAlgo, provider);
     }
 
 
-    private Signature(String digestAlgo, OpenJCEPlusProvider provider) throws OCKException {
+    private Signature(String digestAlgo, OpenJCEPlusProvider provider) throws NativeException {
         //final String methodName = "Signature(String)";
         this.nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
         this.digest = Digest.getInstance(digestAlgo, provider);
         //OCKDebug.Msg (debPrefix, methodName, "digestAlgo :" + digestAlgo);
     }
 
-    public void update(byte[] input, int offset, int length) throws OCKException {
+    public void update(byte[] input, int offset, int length) throws NativeException {
         if ((input == null) || (length < 0) || (offset < 0) || ((offset + length) > input.length)) {
             throw new IllegalArgumentException("Bad input parameters to Signature update");
         }
@@ -45,7 +45,7 @@ public final class Signature {
     }
 
     public void initialize(AsymmetricKey key, boolean rsaPlain)
-            throws InvalidKeyException, OCKException {
+            throws InvalidKeyException, NativeException {
         //final String methodName = "initialize";
         if (key == null) {
             throw new IllegalArgumentException("key is null");
@@ -60,7 +60,7 @@ public final class Signature {
         //OCKDebug.Msg (debPrefix, methodName,  "this.key=" + key);
     }
 
-    public synchronized byte[] sign() throws OCKException {
+    public synchronized byte[] sign() throws NativeException {
 
         if (!this.initialized) {
             throw new IllegalStateException("Signature not initialized");
@@ -69,7 +69,7 @@ public final class Signature {
         //OCKDebug.Msg (debPrefix, "sign", "digestId :" + digest.getId() + " pkeyId :" + this.key.getPKeyId());
         if ((this.digest == null) || !validId(this.digest.getId())
                 || !validId(this.key.getPKeyId())) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
 
         byte[] signature = null;
@@ -77,7 +77,7 @@ public final class Signature {
             signature = this.nativeInterface.SIGNATURE_sign(digest.getId(),
                     this.key.getPKeyId(), this.convertKey);
         } finally {
-            // Try to reset even if OCKException is thrown
+            // Try to reset even if NativeException is thrown
             this.digest.reset();
         }
 
@@ -85,7 +85,7 @@ public final class Signature {
         return signature;
     }
 
-    public synchronized boolean verify(byte[] sigBytes) throws OCKException {
+    public synchronized boolean verify(byte[] sigBytes) throws NativeException {
         //final String methodName = "verify";
         // create key length function and check sigbytes against key length?
         if (!this.initialized) {
@@ -98,7 +98,7 @@ public final class Signature {
         //OCKDebug.Msg (debPrefix, methodName,  "digestId :" + digest.getId() + " pkeyId :" + this.key.getPKeyId());
         //OCKDebug.Msg (debPrefix, methodName,  " sigBytes :",  sigBytes);
         if ((this.digest == null) || digest.getId() == 0L || this.key.getPKeyId() == 0L) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
 
         boolean verified = false;
@@ -106,7 +106,7 @@ public final class Signature {
             verified = this.nativeInterface.SIGNATURE_verify(digest.getId(),
                     this.key.getPKeyId(), sigBytes);
         } finally {
-            // Try to reset even if OCKException is thrown
+            // Try to reset even if NativeException is thrown
             this.digest.reset();
         }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/base/SignatureDSANONE.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/SignatureDSANONE.java
@@ -25,15 +25,15 @@ public final class SignatureDSANONE {
     private final static String badIdMsg = "DSA Key Identifier is not valid";
 
 
-    public static SignatureDSANONE getInstance(OpenJCEPlusProvider provider) throws OCKException {
+    public static SignatureDSANONE getInstance(OpenJCEPlusProvider provider) throws NativeException {
         return new SignatureDSANONE(provider);
     }
 
-    private SignatureDSANONE(OpenJCEPlusProvider provider) throws OCKException {
+    private SignatureDSANONE(OpenJCEPlusProvider provider) throws NativeException {
         this.nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
     }
 
-    public void initialize(DSAKey key) throws InvalidKeyException, OCKException {
+    public void initialize(DSAKey key) throws InvalidKeyException, NativeException {
         //final String methodName = "initialize";
         if (key == null) {
             throw new IllegalArgumentException("key is null");
@@ -44,7 +44,7 @@ public final class SignatureDSANONE {
         //OCKDebug.Msg (debPrefix, methodName, "this.key=",  this.key);
     }
 
-    public synchronized byte[] sign(byte[] digest) throws OCKException {
+    public synchronized byte[] sign(byte[] digest) throws NativeException {
         //final String methodName = "sign";
         if (!this.initialized) {
             throw new IllegalStateException("Signature not initialized");
@@ -56,7 +56,7 @@ public final class SignatureDSANONE {
 
         //OCKDebug.Msg(debPrefix, methodName, "this.key.DSAKeyId :" + this.key.getDSAKeyId() + " digest :", digest);
         if (!validId(this.key.getDSAKeyId())) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
         byte[] signature = this.nativeInterface.DSANONE_SIGNATURE_sign(digest,
                 this.key.getDSAKeyId());
@@ -64,7 +64,7 @@ public final class SignatureDSANONE {
         return signature;
     }
 
-    public synchronized boolean verify(byte[] digest, byte[] sigBytes) throws OCKException {
+    public synchronized boolean verify(byte[] digest, byte[] sigBytes) throws NativeException {
         //final String methodName = "verify";
         // create key length function and check sigbytes against key length?
         if (!this.initialized) {
@@ -82,7 +82,7 @@ public final class SignatureDSANONE {
         //OCKDebug.Msg(debPrefix, methodName, "this.key.DSAKeyId :" + this.key.getDSAKeyId() + " digest :",   digest);
         //OCKDebug.Msg(debPrefix, methodName, "sigBytes :",  sigBytes);
         if (!validId(this.key.getDSAKeyId())) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
         boolean verified = this.nativeInterface.DSANONE_SIGNATURE_verify(digest,
                 this.key.getDSAKeyId(), sigBytes);

--- a/src/main/java/com/ibm/crypto/plus/provider/base/SignatureEdDSA.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/SignatureEdDSA.java
@@ -22,16 +22,16 @@ public final class SignatureEdDSA {
     private final String badIdMsg = "Digest Identifier or PKey Identifier is not valid";
     private final static String debPrefix = "SIGNATURE";
 
-    public static SignatureEdDSA getInstance(OpenJCEPlusProvider provider) throws OCKException {
+    public static SignatureEdDSA getInstance(OpenJCEPlusProvider provider) throws NativeException {
         return new SignatureEdDSA(provider);
     }
 
-    private SignatureEdDSA(OpenJCEPlusProvider provider) throws OCKException {
+    private SignatureEdDSA(OpenJCEPlusProvider provider) throws NativeException {
         //final String methodName = "SignatureEdDSA(String)";
         this.nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
     }
 
-    public void initialize(AsymmetricKey key) throws InvalidKeyException, OCKException {
+    public void initialize(AsymmetricKey key) throws InvalidKeyException, NativeException {
         //final String methodName = "initialize";
         if (key == null) {
             throw new IllegalArgumentException("key is null");
@@ -42,19 +42,19 @@ public final class SignatureEdDSA {
         //OCKDebug.Msg (debPrefix, methodName,  "this.key=" + key);
     }
 
-    public synchronized byte[] sign(byte[] oneShotData) throws OCKException, SignatureException {
+    public synchronized byte[] sign(byte[] oneShotData) throws NativeException, SignatureException {
         if (!this.initialized) {
             throw new IllegalStateException("SignatureEdDSA not initialized");
         }
         if (!validId(this.key.getPKeyId())) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
         byte[] signature = this.nativeInterface.SIGNATUREEdDSA_signOneShot(
                 this.key.getPKeyId(), oneShotData);
         return signature;
     }
 
-    public synchronized boolean verify(byte[] sigBytes, byte[] dataBytes) throws OCKException {
+    public synchronized boolean verify(byte[] sigBytes, byte[] dataBytes) throws NativeException {
         //final String methodName = "verify";
         // create key length function and check sigbytes against key length?
         if (!this.initialized) {
@@ -65,7 +65,7 @@ public final class SignatureEdDSA {
             throw new IllegalArgumentException("invalid signature");
         }
         if (this.key.getPKeyId() == 0L) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
         boolean verified = this.nativeInterface.SIGNATUREEdDSA_verifyOneShot(
                 this.key.getPKeyId(), sigBytes, dataBytes);

--- a/src/main/java/com/ibm/crypto/plus/provider/base/SignatureRSAPSS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/SignatureRSAPSS.java
@@ -38,7 +38,7 @@ public final class SignatureRSAPSS {
 
 
     public static SignatureRSAPSS getInstance(String digestAlgo, int saltlen,
-            int trailerField, String mgfAlgo, String mgf1SpecAlgo, OpenJCEPlusProvider provider) throws OCKException {
+            int trailerField, String mgfAlgo, String mgf1SpecAlgo, OpenJCEPlusProvider provider) throws NativeException {
         if (provider == null) {
             throw new IllegalArgumentException("provider is null");
         }
@@ -47,7 +47,7 @@ public final class SignatureRSAPSS {
     }
 
     private SignatureRSAPSS(String digestAlgo, int saltlen, int trailerField,
-            String mgfAlgo, String mgf1SpecAlgo, OpenJCEPlusProvider provider) throws OCKException {
+            String mgfAlgo, String mgf1SpecAlgo, OpenJCEPlusProvider provider) throws NativeException {
         this.saltlen = saltlen;
         this.trailerField = trailerField;
         this.mgfAlgo = mgfAlgo;
@@ -67,7 +67,7 @@ public final class SignatureRSAPSS {
                 this.nativeInterface.RSAPSS_releaseContext(rsaPssId.getValue());
                 rsaPssId.setValue(0);;
             }
-        } catch (OCKException e) {
+        } catch (NativeException e) {
             throw new InvalidParameterException("Unable to set the digestAlgoOCK: releaseContext");
         }
 
@@ -167,19 +167,19 @@ public final class SignatureRSAPSS {
                             this.key.getPKeyId(), this.saltlen);
                 }
             }
-        } catch (OCKException e) {
+        } catch (NativeException e) {
             ret = 1;
         }
 
         return (this.rsaPssId.getValue() != 0 && ret == 0) ? 0 : 1;
     }
 
-    public synchronized void update(byte[] input, int offset, int length) throws OCKException {
+    public synchronized void update(byte[] input, int offset, int length) throws NativeException {
         this.nativeInterface.RSAPSS_digestUpdate(this.rsaPssId.getValue(), input, offset, length);
     }
 
     public synchronized void initialize(AsymmetricKey key, InitOp initOp, boolean convert)
-            throws InvalidKeyException, OCKException {
+            throws InvalidKeyException, NativeException {
         if (key == null) {
             throw new IllegalArgumentException("key is null");
         }
@@ -202,13 +202,13 @@ public final class SignatureRSAPSS {
                         this.key.getPKeyId(), this.saltlen);
             }
         } else {
-            throw new OCKException("RSS-PSS context was not created correctly");
+            throw new NativeException("RSS-PSS context was not created correctly");
         }
         this.initialized = true;
     }
 
 
-    public synchronized byte[] signFinal() throws OCKException {
+    public synchronized byte[] signFinal() throws NativeException {
         if (!this.initialized) {
             throw new IllegalStateException("SignatureRSAPSS not initialized");
         }
@@ -219,17 +219,17 @@ public final class SignatureRSAPSS {
                 this.nativeInterface.RSAPSS_signFinal(this.rsaPssId.getValue(), signature,
                         signature.length);
                 return signature;
-            } catch (OCKException e) {
-                // Try to reset if OCKException is thrown
+            } catch (NativeException e) {
+                // Try to reset if NativeException is thrown
                 this.nativeInterface.RSAPSS_resetDigest(this.rsaPssId.getValue());
                 throw e;
             }
         } else {
-            throw new OCKException("RSS-PSS context was not created correctly");
+            throw new NativeException("RSS-PSS context was not created correctly");
         }
     }
 
-    public synchronized boolean verifyFinal(byte[] sigBytes) throws OCKException {
+    public synchronized boolean verifyFinal(byte[] sigBytes) throws NativeException {
 
         // create key length function and check sigbytes against key length?
         if (!this.initialized) {
@@ -244,14 +244,14 @@ public final class SignatureRSAPSS {
             try {
                 verified = this.nativeInterface.RSAPSS_verifyFinal(
                         this.rsaPssId.getValue(), sigBytes, sigBytes.length);
-            } catch (OCKException e) {
-                // Try to reset if OCKException is thrown
+            } catch (NativeException e) {
+                // Try to reset if NativeException is thrown
                 this.nativeInterface.RSAPSS_resetDigest(this.rsaPssId.getValue());
                 throw e;
             }
             return verified;
         } else {
-            throw new OCKException("RSS-PSS context was not created correctly");
+            throw new NativeException("RSS-PSS context was not created correctly");
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/base/SignatureRSASSL.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/SignatureRSASSL.java
@@ -39,15 +39,15 @@ public final class SignatureRSASSL {
     private static final String debPrefix = "SignatureRSASSL";
     private final String badIdMsg = "RSA Key Identifier is not valid";
 
-    public static SignatureRSASSL getInstance(OpenJCEPlusProvider provider) throws OCKException {
+    public static SignatureRSASSL getInstance(OpenJCEPlusProvider provider) throws NativeException {
         return new SignatureRSASSL(provider);
     }
 
-    private SignatureRSASSL(OpenJCEPlusProvider provider) throws OCKException {
+    private SignatureRSASSL(OpenJCEPlusProvider provider) throws NativeException {
         this.nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
     }
 
-    public void initialize(RSAKey key, boolean convert) throws InvalidKeyException, OCKException {
+    public void initialize(RSAKey key, boolean convert) throws InvalidKeyException, NativeException {
         //final String methodName = "initialize";
         if (key == null) {
             throw new IllegalArgumentException("key is null");
@@ -59,7 +59,7 @@ public final class SignatureRSASSL {
         //OCKDebug.Msg (debPrefix, methodName, "this.key :", this.key);
     }
 
-    public synchronized byte[] sign(byte[] digest) throws OCKException {
+    public synchronized byte[] sign(byte[] digest) throws NativeException {
         //final String methodName = "sign";
         if (!this.initialized) {
             throw new IllegalStateException("Signature not initialized");
@@ -71,7 +71,7 @@ public final class SignatureRSASSL {
 
         //OCKDebug.Msg (debPrefix, methodName,  "RSAKeyId=" + this.key.getRSAKeyId() + " digest :",  digest);
         if (!validId(this.key.getRSAKeyId())) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
         byte[] signature = this.nativeInterface.RSASSL_SIGNATURE_sign(digest,
                 this.key.getRSAKeyId());
@@ -79,7 +79,7 @@ public final class SignatureRSASSL {
         return signature;
     }
 
-    public synchronized boolean verify(byte[] digest, byte[] sigBytes) throws OCKException {
+    public synchronized boolean verify(byte[] digest, byte[] sigBytes) throws NativeException {
         //final String methodName = "verify";
         // create key length function and check sigbytes against key length?
         if (!this.initialized) {
@@ -100,7 +100,7 @@ public final class SignatureRSASSL {
         boolean verified = this.nativeInterface.RSASSL_SIGNATURE_verify(digest,
                 this.key.getRSAKeyId(), sigBytes, convertKey);
         if (!validId(this.key.getRSAKeyId())) {
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
         }
         //OCKDebug.Msg(debPrefix, methodName, "verified=" + verified);
         return verified;

--- a/src/main/java/com/ibm/crypto/plus/provider/base/SymmetricCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/SymmetricCipher.java
@@ -58,32 +58,32 @@ public final class SymmetricCipher {
 
 
     public static SymmetricCipher getInstanceChaCha20(Padding padding, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         String algName = "chacha20";
         return getInstance(algName, padding, provider);
     }
 
     public static SymmetricCipher getInstanceChaCha20Poly1305(
-            Padding padding, OpenJCEPlusProvider provider) throws OCKException {
+            Padding padding, OpenJCEPlusProvider provider) throws NativeException {
         String algName = "chacha20-poly1305";
         return getInstance(algName, padding, provider);
     }
 
     public static SymmetricCipher getInstanceAES(String mode,
-            Padding padding, int numKeyBytes, OpenJCEPlusProvider provider) throws OCKException {
+            Padding padding, int numKeyBytes, OpenJCEPlusProvider provider) throws NativeException {
         String algName = "AES-" + Integer.toString(numKeyBytes * 8) + "-" + mode.toUpperCase();
         return getInstance(algName, padding, provider);
     }
 
     public static SymmetricCipher getInstanceDESede(String mode,
-            Padding padding, OpenJCEPlusProvider provider) throws OCKException {
+            Padding padding, OpenJCEPlusProvider provider) throws NativeException {
         String modeUpperCase = mode.toUpperCase();
         String algName = modeUpperCase.equals("ECB") ? "DES-EDE3" : "DES-EDE3-" + modeUpperCase;
         return getInstance(algName, padding, provider);
     }
 
     public static SymmetricCipher getInstanceRC2(String mode,
-            Padding padding, int keysize, OpenJCEPlusProvider provider) throws OCKException {
+            Padding padding, int keysize, OpenJCEPlusProvider provider) throws NativeException {
         String modeUpperCase = mode.toUpperCase();
         String algName;
         if (keysize == 16)
@@ -94,13 +94,13 @@ public final class SymmetricCipher {
     }
 
     public static SymmetricCipher getInstanceRC4(int keysize,
-            OpenJCEPlusProvider provider) throws OCKException {
+            OpenJCEPlusProvider provider) throws NativeException {
         String algName = keysize == 16 ? "RC4" : "RC4-40";
         return getInstance(algName, Padding.NoPadding, provider);
     }
 
     private static SymmetricCipher getInstance(String cipherName,
-            Padding padding, OpenJCEPlusProvider provider) throws OCKException {
+            Padding padding, OpenJCEPlusProvider provider) throws NativeException {
         //final String methodName = "getInstance";
         if (cipherName == null || cipherName.isEmpty()) {
             throw new IllegalArgumentException("cipherName is null/empty");
@@ -118,25 +118,25 @@ public final class SymmetricCipher {
         return new SymmetricCipher(cipherName, padding, provider);
     }
 
-    static void throwOCKException(int errorCode) throws BadPaddingException, OCKException {
+    static void throwNativeException(int errorCode) throws BadPaddingException, NativeException {
         switch (errorCode) {
             case -1:
-                throw new OCKException("ICC_EVP_EncryptUpdate failed!");
+                throw new NativeException("ICC_EVP_EncryptUpdate failed!");
             case -2:
-                throw new OCKException("ICC_EVP_EncryptFinal failed!");
+                throw new NativeException("ICC_EVP_EncryptFinal failed!");
             case -3:
-                throw new OCKException("ICC_EVP_DecryptUpdate failed!");
+                throw new NativeException("ICC_EVP_DecryptUpdate failed!");
             case -4:
-                throw new OCKException("ICC_EVP_DecryptFinal failed!");
+                throw new NativeException("ICC_EVP_DecryptFinal failed!");
             case -5:
                 throw new BadPaddingException("Unexpected padding");
             default:
-                throw new OCKException("Unknow Error Code");
+                throw new NativeException("Unknow Error Code");
         }
     }
 
     private SymmetricCipher(String cipherName, Padding padding, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         // Check whether used algorithm is CBC and whether hardware supports
         this.provider = provider;
         this.nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
@@ -165,15 +165,15 @@ public final class SymmetricCipher {
         this.provider.registerCleanable(this, cleanOCKResources(use_z_fast_command, ockCipherId, reinitKey, this.nativeInterface));
     }
 
-    public synchronized void initCipherEncrypt(byte[] key, byte[] iv) throws OCKException {
+    public synchronized void initCipherEncrypt(byte[] key, byte[] iv) throws NativeException {
         initCipher(true, key, iv);
     }
 
-    public synchronized void initCipherDecrypt(byte[] key, byte[] iv) throws OCKException {
+    public synchronized void initCipherDecrypt(byte[] key, byte[] iv) throws NativeException {
         initCipher(false, key, iv);
     }
 
-    private void initCipher(boolean isEncrypt, byte[] key, byte[] iv) throws OCKException {
+    private void initCipher(boolean isEncrypt, byte[] key, byte[] iv) throws NativeException {
         if ((key == null) || (key.length == 0)) {
             throw new IllegalArgumentException("key is null/empty");
         }
@@ -186,7 +186,7 @@ public final class SymmetricCipher {
                 throw new IllegalArgumentException("key is the wrong size");
             }
             if (ockCipherId == 0L) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             this.nativeInterface.CIPHER_init(ockCipherId, isEncrypt ? 1 : 0,
                     padding.getId(), key, iv);
@@ -255,15 +255,15 @@ public final class SymmetricCipher {
         }
     }
 
-    // public synchronized void clean() throws OCKException {
+    // public synchronized void clean() throws NativeException {
     // NativeInterface.CIPHER_clean(ockContext.getId(), ockCipherId);
     // this.bufferedCount = 0;
     // }
-    public int getOutputSize(int inputLen) throws OCKException {
+    public int getOutputSize(int inputLen) throws NativeException {
         return getOutputSize(inputLen, true);
     }
 
-    public synchronized int getOutputSize(int inputLen, boolean isFinal) throws OCKException {
+    public synchronized int getOutputSize(int inputLen, boolean isFinal) throws NativeException {
         //final String methodName = "getOutputSize";
         if (inputLen < 0) {
             return 0;
@@ -302,10 +302,10 @@ public final class SymmetricCipher {
      * buffer size needed for the OCKC library.
      * @return the necessary buffer size needed by OCK.
      */
-    private synchronized int getOutputSizeForOCK(int inputLen) throws OCKException {
+    private synchronized int getOutputSizeForOCK(int inputLen) throws NativeException {
         //final String methodName = "getOutputSize";
         if (inputLen < 0) {
-            throw new OCKException("Input length not expected to be < 0");
+            throw new NativeException("Input length not expected to be < 0");
         }
         //OCKDebug.Msg (debPrefix, methodName, "inputLen=" + inputLen + " isFinal=" + isFinal + "encrypting=" + encrypting );
         int totalLen = this.bufferedCount + inputLen;
@@ -320,11 +320,11 @@ public final class SymmetricCipher {
         return retLen;
     }
 
-    public synchronized int getBlockSize() throws OCKException {
+    public synchronized int getBlockSize() throws NativeException {
         if (blockSize == 0) {
             if (!use_z_fast_command) {
                 if (ockCipherId == 0L)
-                    throw new OCKException(badIdMsg);
+                    throw new NativeException(badIdMsg);
                 blockSize = this.nativeInterface.CIPHER_getBlockSize(ockCipherId);
             } else {
                 blockSize = 16;
@@ -333,11 +333,11 @@ public final class SymmetricCipher {
         return blockSize;
     }
 
-    public synchronized int getKeyLength() throws OCKException {
+    public synchronized int getKeyLength() throws NativeException {
         if (keyLength == 0) {
             if (!use_z_fast_command) {
                 if (ockCipherId == 0L) {
-                    throw new OCKException(badIdMsg);
+                    throw new NativeException(badIdMsg);
                 }
                 keyLength = this.nativeInterface.CIPHER_getKeyLength(ockCipherId);
             } else {
@@ -347,10 +347,10 @@ public final class SymmetricCipher {
         return keyLength;
     }
 
-    public synchronized int getIVLength() throws OCKException {
+    public synchronized int getIVLength() throws NativeException {
         if (ivLength == 0 && !use_z_fast_command) {
             if (ockCipherId == 0L)
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             ivLength = this.nativeInterface.CIPHER_getIVLength(ockCipherId);
         }
         return ivLength;
@@ -362,7 +362,7 @@ public final class SymmetricCipher {
 
     public synchronized int update(byte[] input, int inputOffset, int inputLen, byte[] output,
             int outputOffset)
-            throws IllegalStateException, ShortBufferException, BadPaddingException, OCKException {
+            throws IllegalStateException, ShortBufferException, BadPaddingException, NativeException {
         //final String methodName = "update";
         int outLen = 0;
         //        OCKDebug.Msg (debPrefix, methodName, "input.length=" + input.length +
@@ -416,7 +416,7 @@ public final class SymmetricCipher {
         try {
             //OCKDebug.Msg (debPrefix, methodName, "ockCipherId :" + ockCipherId + " inputOffset :" + inputOffset + " inputLen :" + inputLen + "encrypting :" + encrypting);
             if (ockCipherId == 0L) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             if (encrypting) {
                 outLen = this.nativeInterface.CIPHER_encryptUpdate(ockCipherId,
@@ -426,7 +426,7 @@ public final class SymmetricCipher {
                         input, inputOffset, inputLen, tmpBuf, 0, needsReinit);
             }
             if (outLen < 0) {
-                throwOCKException(outLen);
+                throwNativeException(outLen);
             }
             if (outLen > (output.length - outputOffset)) {
                 throw new ShortBufferException(
@@ -447,7 +447,7 @@ public final class SymmetricCipher {
     }
 
     public synchronized int z_update(byte[] input, int inputOffset, int inputLen, byte[] output,
-            int outputOffset) throws IllegalStateException, ShortBufferException, OCKException {
+            int outputOffset) throws IllegalStateException, ShortBufferException, NativeException {
         int outLen = 0;
 
         if (needsReinit) {
@@ -469,7 +469,7 @@ public final class SymmetricCipher {
 
     public synchronized int doFinal(byte[] input, int inputOffset, int inputLen, byte[] output,
             int outputOffset) throws IllegalStateException, ShortBufferException,
-            IllegalBlockSizeException, BadPaddingException, OCKException {
+            IllegalBlockSizeException, BadPaddingException, NativeException {
         //final String methodName = "doFinal";
 
         int outLen = 0;
@@ -548,7 +548,7 @@ public final class SymmetricCipher {
             //OCKDebug.Msg (debPrefix, methodName, "ockCipherId :" + ockCipherId + " inputOffset :" + inputOffset + " inputLen :" + inputLen + "encrypting :" + encrypting);
             //OCKDebug.Msg(debPrefix, methodName, "input bytes :", input);
             if (ockCipherId == 0L) {
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             }
             if (encrypting) {
                 outLen = this.nativeInterface.CIPHER_encryptFinal(ockCipherId, input,
@@ -558,14 +558,14 @@ public final class SymmetricCipher {
                         inputOffset, inputLen, tmpBuf, 0, needsReinit);
             }
             if (outLen < 0) {
-                throwOCKException(outLen);
+                throwNativeException(outLen);
             }
             if (outLen > (output.length - outputOffset)) {
                 throw new ShortBufferException(
                         "Output buffer must be (at least) " + outLen + " bytes long");
             }
             System.arraycopy(tmpBuf, 0, output, outputOffset, outLen);
-        } catch (OCKException e) {
+        } catch (NativeException e) {
             throw e;
         } finally {
             if ((copyOfInput != null) && encrypting) {
@@ -587,7 +587,7 @@ public final class SymmetricCipher {
 
     public synchronized int z_doFinal(byte[] input, int inputOffset, int inputLen, byte[] output,
             int outputOffset) throws IllegalStateException, ShortBufferException,
-            IllegalBlockSizeException, BadPaddingException, OCKException {
+            IllegalBlockSizeException, BadPaddingException, NativeException {
 
         int outLen = 0;
 

--- a/src/main/java/com/ibm/crypto/plus/provider/base/XECKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/XECKey.java
@@ -47,7 +47,7 @@ public final class XECKey implements AsymmetricKey {
 
 
     public static XECKey generateKeyPair(int curveNum, int pub_size, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         //final String methodName = "generateKeyPair(NamedParameterSpec.CURVE) ";
         FastJNIBuffer buffer = XECKey.buffer.get();
 
@@ -59,7 +59,7 @@ public final class XECKey implements AsymmetricKey {
         long xecKeyId = nativeInterface.XECKEY_generate(curveNum,
                 buffer.pointer());
         if (!validId(xecKeyId))
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
 
         byte[] publicKeyBytes = new byte[pub_size];
         buffer.get(0, publicKeyBytes, 0, pub_size);
@@ -68,7 +68,7 @@ public final class XECKey implements AsymmetricKey {
     }
 
     public static byte[] computeECDHSecret(long genCtx, long pubId,
-            long privId, int secrectBufferSize, OpenJCEPlusProvider provider) throws OCKException {
+            long privId, int secrectBufferSize, OpenJCEPlusProvider provider) throws NativeException {
         if (pubId == 0)
             throw new IllegalArgumentException("The public key parameter is not valid");
         if (privId == 0)
@@ -87,20 +87,20 @@ public final class XECKey implements AsymmetricKey {
         return (id != 0L);
     }
 
-    private synchronized void obtainPrivateKeyBytes() throws OCKException {
+    private synchronized void obtainPrivateKeyBytes() throws NativeException {
         // Leave this duplicate check in here. If two threads are both trying
         // to getPrivateKeyBytes at the same time, we only want to call the
         // native code one time.
         //
         if (privateKeyBytes == unobtainedKeyBytes) {
             if (!validId(xecKeyId))
-                throw new OCKException(badIdMsg);
+                throw new NativeException(badIdMsg);
             this.privateKeyBytes = this.nativeInterface.XECKEY_getPrivateKeyBytes(xecKeyId); // Returns DER encoded bytes
         }
     }
 
     @Override
-    public byte[] getPrivateKeyBytes() throws OCKException {
+    public byte[] getPrivateKeyBytes() throws NativeException {
         //final String methodName = "getPrivateKeyBytes()";
         if (privateKeyBytes == unobtainedKeyBytes)
             obtainPrivateKeyBytes();
@@ -108,17 +108,17 @@ public final class XECKey implements AsymmetricKey {
     }
 
     @Override
-    public byte[] getPublicKeyBytes() throws OCKException {
+    public byte[] getPublicKeyBytes() throws NativeException {
         //final String methodName = "getPublickeyBytes()";
         if (publicKeyBytes == unobtainedKeyBytes) {
-            throw new OCKException(
+            throw new NativeException(
                     "Public key should always be loaded on creation. Reaching this state means this object was initialized without a public key...");
         }
         return (publicKeyBytes == null) ? null : publicKeyBytes.clone();
     }
 
     public synchronized static XECKey createPrivateKey(
-            byte[] privateKeyBytes, int priv_size, OpenJCEPlusProvider provider) throws OCKException {
+            byte[] privateKeyBytes, int priv_size, OpenJCEPlusProvider provider) throws NativeException {
         //final String methodName = "createPrivateKey";
         if (privateKeyBytes == null)
             throw new IllegalArgumentException("key bytes is null");
@@ -131,7 +131,7 @@ public final class XECKey implements AsymmetricKey {
         long xecKeyId = nativeInterface.XECKEY_createPrivateKey(privateKeyBytes,
                 buffer.pointer());
         if (!validId(xecKeyId))
-            throw new OCKException(badIdMsg);
+            throw new NativeException(badIdMsg);
 
         // buffer now contains public key
         byte[] publicKeyBytes = new byte[priv_size];
@@ -141,7 +141,7 @@ public final class XECKey implements AsymmetricKey {
     }
 
     public static XECKey createPublicKey(byte[] publicKeyBytes, OpenJCEPlusProvider provider)
-            throws OCKException {
+            throws NativeException {
         //final String methodName = "createPublicKey";
         if (publicKeyBytes == null)
             throw new IllegalArgumentException("key bytes is null");
@@ -159,7 +159,7 @@ public final class XECKey implements AsymmetricKey {
     }
 
     @Override
-    public long getPKeyId() throws OCKException {
+    public long getPKeyId() throws NativeException {
         return xecKeyId;
     }
 
@@ -172,7 +172,7 @@ public final class XECKey implements AsymmetricKey {
                 if (xecKeyId != 0) {
                     nativeInterface.XECKEY_delete(xecKeyId);
                 }
-            } catch (OCKException e) {
+            } catch (NativeException e) {
                 if (OpenJCEPlusProvider.getDebug() != null) {
                     OpenJCEPlusProvider.getDebug().println("An error occurred while cleaning : " + e.getMessage());
                     e.printStackTrace();

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKAdapter.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKAdapter.java
@@ -9,7 +9,6 @@
 package com.ibm.crypto.plus.provider.ock;
 
 import com.ibm.crypto.plus.provider.base.NativeInterface;
-import com.ibm.crypto.plus.provider.base.OCKException;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -190,16 +189,8 @@ public abstract class NativeOCKAdapter implements NativeInterface {
         }
     }
 
-    static public ProviderException providerException(String message, Throwable ockException) {
-        ProviderException providerException = new ProviderException(message, ockException);
-        setOCKExceptionCause(providerException, ockException);
-        return providerException;
-    }
-
-    static public void setOCKExceptionCause(Exception exception, Throwable ockException) {
-        if (debug != null) {
-            exception.initCause(ockException);
-        }
+    static public ProviderException providerException(String message, Throwable throwable) {
+        return new ProviderException(message, throwable);
     }
 
     @Override

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKImplementation.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKImplementation.java
@@ -8,7 +8,6 @@
 
 package com.ibm.crypto.plus.provider.ock;
 
-import com.ibm.crypto.plus.provider.base.OCKException;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.security.ProviderException;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/OCKContext.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/OCKContext.java
@@ -8,8 +8,6 @@
 
 package com.ibm.crypto.plus.provider.ock;
 
-import com.ibm.crypto.plus.provider.base.OCKException;
-
 public final class OCKContext {
 
     private long ockContextId;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/OCKException.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/OCKException.java
@@ -6,28 +6,28 @@
  * this code, including the "Classpath" Exception described therein.
  */
 
-package com.ibm.crypto.plus.provider.base;
+package com.ibm.crypto.plus.provider.ock;
 
+import com.ibm.crypto.plus.provider.base.NativeException;
 import java.util.Hashtable;
 import java.util.Map;
 
-public final class OCKException extends java.lang.Exception {
+public class OCKException extends NativeException {
 
     /**
      * 
      */
     private static final long serialVersionUID = -3104732494450550839L;
 
-    // These codes must match those defined in ExceptionCodes.h.
-    // 
+    /* These codes are overriding the ones specified in the superclass NativeException
+     * and must match those defined in native/ock/ExceptionCodes.h.
+     */
     public static final int GKR_FIPS_MODE_INVALID = 0x00000001;
     public static final int GKR_OCK_ATTACH_FAILED = 0x00000002;
     public static final int GKR_DECRYPT_FINAL_BAD_PADDING_ERROR = 0x00000003;
     public static final int GKR_UNSPECIFIED = 0x80000000;
 
     private static final Map<Integer, String> errorCodeMap = buildErrorCodeMap();
-
-    private int code;
 
     private static Map<Integer, String> buildErrorCodeMap() {
         Hashtable<Integer, String> map = new Hashtable<Integer, String>();
@@ -52,15 +52,12 @@ public final class OCKException extends java.lang.Exception {
         this.code = code;
     }
 
-    public int getCode() {
-        return code;
-    }
-
-    static String errorMessage(int code) {
+    private static String errorMessage(int code) {
         String message = errorCodeMap.get(Integer.valueOf(code));
         if (message == null) {
             message = "0x" + Integer.toHexString(code);
         }
         return message;
     }
+    
 }

--- a/src/main/native/ock/Utils.c
+++ b/src/main/native/ock/Utils.c
@@ -148,7 +148,7 @@ void ockCheckStatus(ICC_CTX *ctx) {
 //
 //
 void throwOCKException(JNIEnv *env, int code, const char *msg) {
-#define EXCEPTION_CLASS "com/ibm/crypto/plus/provider/base/OCKException"
+#define EXCEPTION_CLASS "com/ibm/crypto/plus/provider/ock/OCKException"
     static const char *exceptionClass = EXCEPTION_CLASS;
 #ifdef __MVS__
 #pragma convert("ISO8859-1")
@@ -213,7 +213,7 @@ void throwOCKException(JNIEnv *env, int code, const char *msg) {
 #ifdef __MVS__
 #pragma convert(pop)
 #endif
-            gslogError("Can't find constuctor(message) for %s", exceptionClass);
+            gslogError("Can't find constructor(message) for %s", exceptionClass);
             return;
         }
 


### PR DESCRIPTION
A new native exception hierarchy is created to include a `NativeException` superclass. This will allow for different native exception subclassses thrown by different native libraries.

The `try-catch` blocks were also simplified to improve readability.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1412

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>