### PR TITLE
Extract library-specific elements to separate files

### DIFF
--- a/src/main/native/ock/jgskit.mac.mak
+++ b/src/main/native/ock/jgskit.mac.mak
@@ -7,33 +7,12 @@
 # this code, including the "Classpath" Exception described therein.
 ###############################################################################
 
-TOPDIR=../../../..
-
-CFLAGS= -fPIC -DMAC -Werror -std=gnu99 -pedantic -Wall -fstack-protector -m64
-LDFLAGS= -shared -m64
-CC ?= clang
-
-ifeq (${PLATFORM},x86_64-mac)
-  ARCHFLAGS= -arch x86_64
-else ifeq (${PLATFORM},aarch64-mac)
-  ARCHFLAGS= -arch arm64
-endif
-
-#Setting this flag will result non key material such as handle to OCK Objects etc being logged to the trace file.
-#This flag must be disabled before building production version
-#DEBUG_FLAGS += -DDEBUG
-#DEBUG_DETAIL = -DDEBUG_RANDOM_DETAIL -DDEBUG_RAND_DETAIL -DDEBUG_DH_DETAIL -DDEBUG_DSA_DETAIL -DDEBUG_DIGEST_DETAIL -DDEBUG_EC_DETAIL -DDEBUG_EXTENDED_RANDOM_DETAIL -DDEBUG_GCM_DETAIL -DDEBUG_CCM_DETAIL -DDEBUG_HMAC_DETAIL -DDEBUG_PKEY_DETAIL -DDEBUG_CIPHER_DETAIL -DDEBUG_RSA_DETAIL -DDEBUG_SIGNATURE_DETAIL -DDEBUG_SIGNATURE_DSANONE_DETAIL -DDEBUG_SIGNATURE_RSASSL_DETAIL -DDEBUG_HKDF_DETAIL -DDEBUG_RSAPSS_DETAIL -DDEBUG_SIGNATURE_EDDSA_DETAIL -DDEBUG_PBKDF_DETAIL -DDEBUG_PQC_KEY_DETAIL
-
-#Setting this flag will result sensitive key material such as private/public key bytes/parameter bytes being logged to the trace file.
-#Please warn the customer know that it not suitable to deploy jgskit library on production system, enabling this flag.
-#This flag must be disabled before building production version
-#DEBUG_DATA = -DDEBUG_DH_DATA -DDEBUG_DSA_DATA -DDEBUG_EC_DATA -DDEBUG_GCM_DATA -DDEBUG_CCM_DATA -DDEBUG_HMAC_DATA -DDEBUG_CIPHER_DATA -DDEBUG_RSA_DATA -DDEBUG_SIGNATURE_DATA -DDEBUG_SIGNATURE_DSANONE_DATA -DDEBUG_SIGNATURE_RSASSL_DATA -DDEBUG_HKDF_DATA -DDEBUG_RSAPSS_DATA -DDEBUG_SIGNATURE_EDDSA_DATA
-#DEBUG_FLAGS+= -g ${DEBUG_DETAIL} ${DEBUG_DATA}
-
-BUILDTOP = ${TOPDIR}/target
 HOSTOUT = ${BUILDTOP}/jgskit-${PLATFORM}
-OPENJCEPLUS_HEADER_FILES ?= ${TOPDIR}/src/main/native/ock
-JAVACLASSDIR=${BUILDTOP}/classes
+NATIVE_DIR = ${NATIVE_TOPDIR}/ock
+NATIVE_LIB_HOME = ${GSKIT_HOME}
+JNI_CLASS = ${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKImplementation.java
+JNI_HEADER = com_ibm_crypto_plus_provider_ock_NativeOCKImplementation.h
+TARGET_LIBS := -L ${GSKIT_HOME}/lib64 -l jgsk8iccs
 
 OBJS = \
 	${HOSTOUT}/AESKeyWrap.o \
@@ -67,57 +46,4 @@ OBJS = \
 
 TARGET = ${HOSTOUT}/libjgskit.dylib
 
-all : displaycompiler ${TARGET}
-
-${TARGET} : ${OBJS}
-	${CC} ${LDFLAGS} ${ARCHFLAGS} -o ${TARGET} ${OBJS} -L ${GSKIT_HOME}/lib64 -l jgsk8iccs
-
-${HOSTOUT}/%.o : %.c
-	test -d ${@D} || mkdir -p ${@D} 2>/dev/null
-	${CC} \
-		${ARCHFLAGS} \
-		${CFLAGS} \
-		${DEBUG_FLAGS} \
-		-c \
-		-I${GSKIT_HOME}/inc \
-		-I${JAVA_HOME}/include \
-		-I${JAVA_HOME}/include/darwin \
-		-I${OPENJCEPLUS_HEADER_FILES} \
-		-o $@ \
-		$<
-
-displaycompiler :
-	@echo "-------------------------------------"
-	@echo "Compiler version: " && ${CC} --version
-	@echo "Building with ${CC} compiler..."
-	@echo "-------------------------------------"
-
-# Force BuildDate to be compiled every time.
-#
-${HOSTOUT}/BuildDate.o : FORCE
-
-FORCE :
-
-ifneq (${EXTERNAL_HEADERS},true)
-
-${OBJS} : | headers
-
-headers :
-	echo "Compiling OpenJCEPlus headers"
-	${JAVA_HOME}/bin/javac \
-		--add-exports java.base/sun.security.util=openjceplus \
-		--add-exports java.base/sun.security.util=ALL-UNNAMED \
-		-d ${JAVACLASSDIR} \
-		-h ${TOPDIR}/src/main/native/ock/ \
-		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/base/FastJNIBuffer.java \
-		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKImplementation.java
-
-endif # ! EXTERNAL_HEADERS
-
-clean :
-	rm -f ${HOSTOUT}/*.o
-	rm -f ${HOSTOUT}/*.dylib
-	rm -f com_ibm_crypto_plus_provider_base_FastJNIBuffer.h
-	rm -f com_ibm_crypto_plus_provider_ock_NativeOCKImplementation.h
-
-.PHONY : all headers clean FORCE displaycompiler
+include ../share/common.mac.mak

--- a/src/main/native/ock/jgskit.mak
+++ b/src/main/native/ock/jgskit.mak
@@ -48,9 +48,9 @@ TARGET = ${HOSTOUT}/libjgskit.so
 GSK8ICCS64=jgsk8iccs_64
 
 ifneq (,$(filter s390-zos64,${PLATFORM}))
-  TARGET_LIBS := ${ICCARCHIVE}
+  TARGET_LIBS := $(NATIVE_LIB_HOME)/libjgsk8iccs_64.x
 else
-  TARGET_LIBS := -L ${GSKIT_HOME}/lib64 -l ${GSK8ICCS64}
+  TARGET_LIBS := -L ${NATIVE_LIB_HOME}/lib64 -l ${GSK8ICCS64}
 endif
 
 include ../share/common.mak

--- a/src/main/native/ock/jgskit.mak
+++ b/src/main/native/ock/jgskit.mak
@@ -7,65 +7,11 @@
 # this code, including the "Classpath" Exception described therein.
 ###############################################################################
 
-TOPDIR=../../../..
-
-PLAT=x86
-CC ?= gcc
-CFLAGS= -fPIC -Werror -std=gnu99 -pedantic -Wall -fstack-protector
-LDFLAGS= -shared
-
-ifeq (${PLATFORM},arm-linux64)
-  PLAT=xr
-  CFLAGS+= -DLINUX
-  OSINCLUDEDIR=linux
-else ifeq (${PLATFORM},ppc-aix64)
-  PLAT=ap
-  CC=xlclang
-  CFLAGS+= -DAIX -m64
-  LDFLAGS+= -brtl -m64
-  OSINCLUDEDIR=aix
-else ifeq (${PLATFORM},ppcle-linux64)
-  PLAT=xl
-  CFLAGS+= -DLINUX -m64
-  LDFLAGS+= -m64
-  OSINCLUDEDIR=linux
-else ifeq (${PLATFORM},s390-linux64)
-  PLAT=xz
-  CFLAGS+= -DS390_PLATFORM -DLINUX -m64
-  LDFLAGS+= -m64
-  OSINCLUDEDIR=linux
-else ifeq (${PLATFORM},s390-zos64)
-  CC=xlc
-  PLAT=mz
-  CFLAGS= -DS390 -m64
-  CFLAGS+= -O3 -Wc,strict,hgpr,hot
-  CFLAGS+= -Wc,XPLINK,LP64,DLL,exportall
-  LDFLAGS= -Wl,XPLINK,LP64,DLL,AMODE=64
-  ICCARCHIVE = ${GSKIT_HOME}/libjgsk8iccs_64.x
-  OSINCLUDEDIR=zos
-else ifeq (${PLATFORM},x86-linux64)
-  PLAT=xa
-  CFLAGS+= -DLINUX -m64
-  LDFLAGS+= -m64
-  OSINCLUDEDIR=linux
-endif
-
-#Setting this flag will result non key material such as handle to OCK Objects etc being logged to the trace file.
-#This flag must be disabled before building production version
-#DEBUG_FLAGS += -DDEBUG
-#DEBUG_DETAIL = -DDEBUG_RANDOM_DETAIL -DDEBUG_RAND_DETAIL -DDEBUG_DH_DETAIL -DDEBUG_DSA_DETAIL -DDEBUG_DIGEST_DETAIL -DDEBUG_EC_DETAIL -DDEBUG_EXTENDED_RANDOM_DETAIL -DDEBUG_GCM_DETAIL -DDEBUG_CCM_DETAIL -DDEBUG_HMAC_DETAIL -DDEBUG_PKEY_DETAIL -DDEBUG_CIPHER_DETAIL -DDEBUG_RSA_DETAIL -DDEBUG_SIGNATURE_DETAIL -DDEBUG_SIGNATURE_DSANONE_DETAIL -DDEBUG_SIGNATURE_RSASSL_DETAIL -DDEBUG_HKDF_DETAIL -DDEBUG_RSAPSS_DETAIL -DDEBUG_SIGNATURE_EDDSA_DETAIL -DDEBUG_PBKDF_DETAIL -DDEBUG_PQC_KEY_DETAIL
-
-#Setting this flag will result sensitive key material such as private/public key bytes/parameter bytes being logged to the trace file.
-#Please warn the customer know that it not suitable to deploy jgskit library on production system, enabling this flag.
-#This flag must be disabled before building production version
-#DEBUG_DATA = -DDEBUG_DH_DATA -DDEBUG_DSA_DATA -DDEBUG_EC_DATA -DDEBUG_GCM_DATA -DDEBUG_CCM_DATA -DDEBUG_HMAC_DATA -DDEBUG_CIPHER_DATA -DDEBUG_RSA_DATA -DDEBUG_SIGNATURE_DATA -DDEBUG_SIGNATURE_DSANONE_DATA -DDEBUG_SIGNATURE_RSASSL_DATA -DDEBUG_HKDF_DATA -DDEBUG_RSAPSS_DATA -DDEBUG_SIGNATURE_EDDSA_DATA
-#DEBUG_FLAGS+= -g ${DEBUG_DETAIL} ${DEBUG_DATA}
-
-BUILDTOP = ${TOPDIR}/target
 HOSTOUT = ${BUILDTOP}/jgskit-${PLAT}-64
-
-OPENJCEPLUS_HEADER_FILES ?= ${TOPDIR}/src/main/native/ock
-JAVACLASSDIR=${BUILDTOP}/classes
+NATIVE_DIR = ${NATIVE_TOPDIR}/ock
+NATIVE_LIB_HOME = ${GSKIT_HOME}
+JNI_CLASS = ${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKImplementation.java
+JNI_HEADER = com_ibm_crypto_plus_provider_ock_NativeOCKImplementation.h
 
 OBJS = \
 	${HOSTOUT}/AESKeyWrap.o \
@@ -101,64 +47,10 @@ TARGET = ${HOSTOUT}/libjgskit.so
 
 GSK8ICCS64=jgsk8iccs_64
 
-all : displaycompiler ${TARGET}
-
 ifneq (,$(filter s390-zos64,${PLATFORM}))
   TARGET_LIBS := ${ICCARCHIVE}
 else
   TARGET_LIBS := -L ${GSKIT_HOME}/lib64 -l ${GSK8ICCS64}
 endif
 
-${TARGET} : ${OBJS}
-	${CC} ${LDFLAGS} -o ${TARGET} ${OBJS} ${TARGET_LIBS}
-
-${HOSTOUT}/%.o : %.c
-	test -d ${@D} || mkdir -p ${@D}
-	${CC} \
-		${CFLAGS} \
-		${DEBUG_FLAGS} \
-		-c \
-		-I${GSKIT_HOME}/inc \
-		-I${JAVA_HOME}/include \
-		-I${JAVA_HOME}/include/${OSINCLUDEDIR} \
-		-I${OPENJCEPLUS_HEADER_FILES} \
-		-o $@ \
-		$<
-
-displaycompiler :
-	@echo "Compiler version: " && ${CC} --version
-	@echo "Building with ${CC} compiler..."
-	@echo "-------------------------------------"
-
-# Force BuildDate to be compiled every time.
-#
-${HOSTOUT}/BuildDate.o : FORCE
-
-FORCE :
-
-ifneq (${EXTERNAL_HEADERS},true)
-
-${OBJS} : | headers
-
-headers :
-	echo "Compiling OpenJCEPlus headers"
-	${JAVA_HOME}/bin/javac \
-		--add-exports java.base/sun.security.util=openjceplus \
-		--add-exports java.base/sun.security.util=ALL-UNNAMED \
-		-d ${JAVACLASSDIR} \
-		-h ${TOPDIR}/src/main/native/ock/ \
-		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/base/FastJNIBuffer.java \
-		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKImplementation.java; \
-		if  [ "${PLATFORM}" = "s390-zos64" ]; \
-			then chtag -t -c ISO8859-1 com_ibm_crypto_plus_provider_ock_NativeOCKImplementation.h; \
-		fi
-
-endif # ! EXTERNAL_HEADERS
-
-clean :
-	rm -f ${HOSTOUT}/*.o
-	rm -f ${HOSTOUT}/*.so
-	rm -f com_ibm_crypto_plus_provider_base_FastJNIBuffer.h
-	rm -f com_ibm_crypto_plus_provider_ock_NativeOCKImplementation.h
-
-.PHONY : all headers clean FORCE displaycompiler
+include ../share/common.mak

--- a/src/main/native/ock/jgskit.win64.cygwin.mak
+++ b/src/main/native/ock/jgskit.win64.cygwin.mak
@@ -7,23 +7,11 @@
 # this code, including the "Classpath" Exception described therein.
 ###############################################################################
 
-TOPDIR = $(MAKEDIR)\..\..\..\..
-
-PLAT = win
-CFLAGS= -nologo -DWINDOWS
-CC = cl
-
-#DEBUG_DETAIL = -DDEBUG_RANDOM_DETAIL -DDEBUG_RAND_DETAIL -DDEBUG_DH_DETAIL -DDEBUG_DSA_DETAIL -DDEBUG_DIGEST_DETAIL -DDEBUG_EC_DETAIL  -DDEBUG_EXTENDED_RANDOM_DETAIL -DDEBUG_GCM_DETAIL -DDEBUG_CCM_DETAIL -DDEBUG_HMAC_DETAIL -DDEBUG_PKEY_DETAIL -DDEBUG_CIPHER_DETAIL -DDEBUG_RSA_DETAIL -DDEBUG_SIGNATURE_DETAIL -DDEBUG_SIGNATURE_DSANONE_DETAIL -DDEBUG_SIGNATURE_RSASSL_DETAIL -DDEBUG_HKDF_DETAIL -DDEBUG_RSAPSS_DETAIL -DDEBUG_SIGNATURE_EDDSA_DETAIL -DDEBUG_PBKDF_DETAIL -DDEBUG_PQC_KEY_DETAIL
-
-#Setting this flag will result sensitive key material such as private/public key bytes/parameter bytes being logged to the trace file.
-#Please warn the customer know that it not suitable to deploy jgskit library on production system,  enabling this flag.
-#This flag must be disabled before building production version
-#DEBUG_DATA =  -DDEBUG_DH_DATA -DDEBUG_DSA_DATA -DDEBUG_EC_DATA -DDEBUG_GCM_DATA -DDEBUG_CCM_DATA -DDEBUG_HMAC_DATA -DDEBUG_CIPHER_DATA -DDEBUG_RSA_DATA -DDEBUG_SIGNATURE_DATA -DDEBUG_SIGNATURE_DSANONE_DATA -DDEBUG_SIGNATURE_RSASSL_DATA -DDEBUG_HKDF_DATA -DDEBUG_RSAPSS_DATA -DDEBUG_SIGNATURE_EDDSA_DATA
-#DEBUG_FLAGS = -DDEBUG $(DEBUG_DETAIL)  $(DEBUG_DATA)
-
-BUILDTOP = $(TOPDIR)\target\build$(PLAT)
 HOSTOUT = $(BUILDTOP)\host64
-JAVACLASSDIR = $(TOPDIR)\target\classes
+NATIVE_DIR = $(NATIVE_TOPDIR)\ock
+NATIVE_LIB_HOME = $(GSKIT_HOME)
+JNI_CLASS = $(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\ock\NativeOCKImplementation.java
+JNI_HEADER = com_ibm_crypto_plus_provider_ock_NativeOCKImplementation.h
 
 OBJS= \
 	AESKeyWrap.obj \
@@ -57,61 +45,10 @@ OBJS= \
 
 TARGET = libjgskit_64.dll
 
-JGSKIT_RC_SRC = jgskit_resource.rc
-JGSKIT_RC_OBJ = jgskit_resource.res
+RC_SRC = jgskit_resource.rc
+RC_OBJ = jgskit_resource.res
 
-all : displaycompiler copy
+TARGET_LIBS = -LIBPATH:"$(NATIVE_LIB_HOME)\lib" jgsk8iccs_64.lib
 
-copy : $(TARGET)
-	-@mkdir -p $(HOSTOUT) 2>nul
-	-@cp *.obj $(HOSTOUT)
-	-@cp jgskit_resource.res $(HOSTOUT)
-	-@cp libjgskit_64.dll $(HOSTOUT)
+!INCLUDE ../share/common.win64.cygwin.mak
 
-$(TARGET) : $(OBJS) $(JGSKIT_RC_OBJ)
-	link -dll -out:$@ $(OBJS) $(JGSKIT_RC_OBJ) -LIBPATH:"$(GSKIT_HOME)/lib" jgsk8iccs_64.lib
-
-$(JGSKIT_RC_OBJ) : $(JGSKIT_RC_SRC)
-	rc $(BUILD_CFLAGS) -Fo$@ $(JGSKIT_RC_SRC)
-
-.c.obj :
-	$(CC) \
-		$(DEBUG_FLAGS) \
-		$(CFLAGS) \
-		-c \
-		-I"$(GSKIT_HOME)/inc" \
-		-I"$(JAVA_HOME)/include" \
-		-I"$(JAVA_HOME)/include/win32" \
-		$*.c
-
-displaycompiler :
-	@echo "Compiler version: " && $(CC)
-	@echo "Building with $(CC) compiler..."
-	@echo "-------------------------------------"
-
-# Force BuildDate to be recompiled every time
-#
-BuildDate.obj : FORCE
-
-FORCE :
-
-$(OBJS) : headers
-
-headers :
-	echo "Compiling OpenJCEPlus headers"
-	$(JAVA_HOME)\bin\javac \
-		--add-exports java.base/sun.security.util=openjceplus \
-		--add-exports java.base/sun.security.util=ALL-UNNAMED \
-		-d $(JAVACLASSDIR) \
-		-h $(TOPDIR)\src\main\native\ock\ \
-		$(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\base\FastJNIBuffer.java \
-		$(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\ock\NativeOCKImplementation.java
-
-clean :
-	-@del $(HOSTOUT)\*.obj
-	-@del $(HOSTOUT)\*.exp
-	-@del $(HOSTOUT)\*.lib
-	-@del $(HOSTOUT)\*.dll
-	-@del $(HOSTOUT)\*.res
-
-.PHONY : all clean copy headers displaycompiler

--- a/src/main/native/ock/jgskit.win64.mak
+++ b/src/main/native/ock/jgskit.win64.mak
@@ -7,24 +7,11 @@
 # this code, including the "Classpath" Exception described therein.
 ###############################################################################
 
-TOPDIR = $(MAKEDIR)../../../..
-
-PLAT = win
-CFLAGS= -nologo -DWINDOWS
-CC = cl
-
-#DEBUG_DETAIL = -DDEBUG_RANDOM_DETAIL -DDEBUG_RAND_DETAIL -DDEBUG_DH_DETAIL -DDEBUG_DSA_DETAIL -DDEBUG_DIGEST_DETAIL -DDEBUG_EC_DETAIL  -DDEBUG_EXTENDED_RANDOM_DETAIL -DDEBUG_GCM_DETAIL -DDEBUG_CCM_DETAIL -DDEBUG_HMAC_DETAIL -DDEBUG_PKEY_DETAIL -DDEBUG_CIPHER_DETAIL -DDEBUG_RSA_DETAIL -DDEBUG_SIGNATURE_DETAIL -DDEBUG_SIGNATURE_DSANONE_DETAIL -DDEBUG_SIGNATURE_RSASSL_DETAIL -DDEBUG_HKDF_DETAIL -DDEBUG_RSAPSS_DETAIL -DDEBUG_SIGNATURE_EDDSA_DETAIL -DDEBUG_PBKDF_DETAIL -DDEBUG_PQC_KEY_DETAIL
-
-#Setting this flag will result sensitive key material such as private/public key bytes/parameter bytes being logged to the trace file.
-#Please warn the customer know that it not suitable to deploy jgskit library on production system,  enabling this flag.
-#This flag must be disabled before building production version
-#DEBUG_DATA =  -DDEBUG_DH_DATA -DDEBUG_DSA_DATA -DDEBUG_EC_DATA -DDEBUG_GCM_DATA -DDEBUG_CCM_DATA -DDEBUG_HMAC_DATA -DDEBUG_CIPHER_DATA -DDEBUG_RSA_DATA -DDEBUG_SIGNATURE_DATA -DDEBUG_SIGNATURE_DSANONE_DATA -DDEBUG_SIGNATURE_RSASSL_DATA -DDEBUG_HKDF_DATA -DDEBUG_RSAPSS_DATA -DDEBUG_SIGNATURE_EDDSA_DATA
-#DEBUG_FLAGS = -DDEBUG $(DEBUG_DETAIL)  $(DEBUG_DATA)
-
-BUILDTOP = $(TOPDIR)/target/build$(PLAT)
 HOSTOUT = $(BUILDTOP)/host64
-OPENJCEPLUS_HEADER_FILES ?= $(TOPDIR)/src/main/native/ock
-JAVACLASSDIR = $(TOPDIR)/target/classes
+NATIVE_DIR = $(NATIVE_TOPDIR)/ock
+NATIVE_LIB_HOME = $(GSKIT_HOME)
+JNI_CLASS = $(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKImplementation.java
+JNI_HEADER = com_ibm_crypto_plus_provider_ock_NativeOCKImplementation.h
 
 OBJS= \
 	$(HOSTOUT)/AESKeyWrap.obj \
@@ -58,61 +45,9 @@ OBJS= \
 
 TARGET = $(HOSTOUT)/libjgskit_64.dll
 
-JGSKIT_RC_SRC = jgskit_resource.rc
-JGSKIT_RC_OBJ = $(HOSTOUT)/jgskit_resource.res
+RC_SRC = jgskit_resource.rc
+RC_OBJ = $(HOSTOUT)/jgskit_resource.res
 
-all : displaycompiler $(TARGET)
+TARGET_LIBS = -LIBPATH:"$(NATIVE_LIB_HOME)/lib" jgsk8iccs_64.lib
 
-$(TARGET) : $(OBJS) $(JGSKIT_RC_OBJ)
-	link -dll -out:$@ $(OBJS) $(JGSKIT_RC_OBJ) -LIBPATH:"$(GSKIT_HOME)/lib" jgsk8iccs_64.lib
-
-$(JGSKIT_RC_OBJ) : $(JGSKIT_RC_SRC)
-	rc $(BUILD_CFLAGS) -Fo$@ $(JGSKIT_RC_SRC)
-
-$(HOSTOUT)/%.obj : %.c
-	-@mkdir -p $(HOSTOUT) 2>nul
-	$(CC) \
-		$(DEBUG_FLAGS) \
-		$(CFLAGS) \
-		-c \
-		-I"$(GSKIT_HOME)/inc" \
-		-I"$(JAVA_HOME)/include" \
-		-I"$(JAVA_HOME)/include/win32" \
-		-I"$(OPENJCEPLUS_HEADER_FILES)" \
-		-Fo$@ \
-		$<
-
-displaycompiler :
-	@echo "Compiler version: " && $(CC)
-	@echo "Building with $(CC) compiler..."
-	@echo "-------------------------------------"
-
-# Force BuildDate to be recompiled every time
-#
-$(HOSTOUT)/BuildDate.obj : FORCE
-
-FORCE :
-
-ifneq (${EXTERNAL_HEADERS},true)
-
-$(OBJS) : | headers
-
-headers :
-	echo "Compiling OpenJCEPlus headers"
-	$(JAVA_HOME)/bin/javac \
-		--add-exports java.base/sun.security.util=openjceplus \
-		--add-exports java.base/sun.security.util=ALL-UNNAMED \
-		-d $(JAVACLASSDIR) \
-		-h $(TOPDIR)/src/main/native/ock/ \
-		$(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/base/FastJNIBuffer.java \
-		$(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKImplementation.java
-
-endif # ! EXTERNAL_HEADERS
-
-clean :
-	-@del $(HOSTOUT)/*.obj
-	-@del $(HOSTOUT)/*.exp
-	-@del $(HOSTOUT)/*.lib
-	-@del $(HOSTOUT)/*.dll
-	-@del $(HOSTOUT)/*.res
-
+include ../share/common.win64.mak

--- a/src/main/native/share/common.mac.mak
+++ b/src/main/native/share/common.mac.mak
@@ -1,0 +1,91 @@
+###############################################################################
+#
+# Copyright IBM Corp. 2026
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms provided by IBM in the LICENSE file that accompanied
+# this code, including the "Classpath" Exception described therein.
+###############################################################################
+
+TOPDIR=../../../..
+
+CFLAGS= -fPIC -DMAC -Werror -std=gnu99 -pedantic -Wall -fstack-protector -m64
+LDFLAGS= -shared -m64
+CC ?= clang
+
+ifeq (${PLATFORM},x86_64-mac)
+  ARCHFLAGS= -arch x86_64
+else ifeq (${PLATFORM},aarch64-mac)
+  ARCHFLAGS= -arch arm64
+endif
+
+#Setting this flag will result non key material such as handles to native contexts etc being logged to the trace file.
+#This flag must be disabled before building production version
+#DEBUG_FLAGS += -DDEBUG
+#DEBUG_DETAIL = -DDEBUG_RANDOM_DETAIL -DDEBUG_RAND_DETAIL -DDEBUG_DH_DETAIL -DDEBUG_DSA_DETAIL -DDEBUG_DIGEST_DETAIL -DDEBUG_EC_DETAIL -DDEBUG_EXTENDED_RANDOM_DETAIL -DDEBUG_GCM_DETAIL -DDEBUG_CCM_DETAIL -DDEBUG_HMAC_DETAIL -DDEBUG_PKEY_DETAIL -DDEBUG_CIPHER_DETAIL -DDEBUG_RSA_DETAIL -DDEBUG_SIGNATURE_DETAIL -DDEBUG_SIGNATURE_DSANONE_DETAIL -DDEBUG_SIGNATURE_RSASSL_DETAIL -DDEBUG_HKDF_DETAIL -DDEBUG_RSAPSS_DETAIL -DDEBUG_SIGNATURE_EDDSA_DETAIL -DDEBUG_PBKDF_DETAIL -DDEBUG_PQC_KEY_DETAIL
+
+#Setting this flag will result in sensitive key material such as private/public key bytes/parameter bytes being logged to the trace file.
+#Please warn the user that it not suitable to deploy this native library on a production system, while enabling this flag.
+#This flag must be disabled before building production version.
+#DEBUG_DATA = -DDEBUG_DH_DATA -DDEBUG_DSA_DATA -DDEBUG_EC_DATA -DDEBUG_GCM_DATA -DDEBUG_CCM_DATA -DDEBUG_HMAC_DATA -DDEBUG_CIPHER_DATA -DDEBUG_RSA_DATA -DDEBUG_SIGNATURE_DATA -DDEBUG_SIGNATURE_DSANONE_DATA -DDEBUG_SIGNATURE_RSASSL_DATA -DDEBUG_HKDF_DATA -DDEBUG_RSAPSS_DATA -DDEBUG_SIGNATURE_EDDSA_DATA
+#DEBUG_FLAGS+= -g ${DEBUG_DETAIL} ${DEBUG_DATA}
+
+BUILDTOP = ${TOPDIR}/target
+NATIVE_TOPDIR = ${TOPDIR}/src/main/native
+OPENJCEPLUS_HEADER_FILES ?= ${NATIVE_DIR}
+JAVACLASSDIR=${BUILDTOP}/classes
+
+all : displaycompiler ${TARGET}
+
+${TARGET} : ${OBJS}
+	${CC} ${LDFLAGS} ${ARCHFLAGS} -o ${TARGET} ${OBJS} ${TARGET_LIBS}
+
+${HOSTOUT}/%.o : %.c
+	test -d ${@D} || mkdir -p ${@D} 2>/dev/null
+	${CC} \
+		${ARCHFLAGS} \
+		${CFLAGS} \
+		${DEBUG_FLAGS} \
+		-c \
+		-I${NATIVE_LIB_HOME}/inc \
+		-I${JAVA_HOME}/include \
+		-I${JAVA_HOME}/include/darwin \
+		-I${OPENJCEPLUS_HEADER_FILES} \
+		-o $@ \
+		$<
+
+displaycompiler :
+	@echo "-------------------------------------"
+	@echo "Compiler version: " && ${CC} --version
+	@echo "Building with ${CC} compiler..."
+	@echo "-------------------------------------"
+
+# Force BuildDate to be compiled every time.
+#
+${HOSTOUT}/BuildDate.o : FORCE
+
+FORCE :
+
+ifneq (${EXTERNAL_HEADERS},true)
+
+${OBJS} : | headers
+
+headers :
+	echo "Compiling OpenJCEPlus headers"
+	${JAVA_HOME}/bin/javac \
+		--add-exports java.base/sun.security.util=openjceplus \
+		--add-exports java.base/sun.security.util=ALL-UNNAMED \
+		-d ${JAVACLASSDIR} \
+		-h ${TOPDIR}/src/main/native/ock/ \
+		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/base/FastJNIBuffer.java \
+		${JNI_CLASS}
+
+endif # ! EXTERNAL_HEADERS
+
+clean :
+	rm -f ${HOSTOUT}/*.o
+	rm -f ${HOSTOUT}/*.dylib
+	rm -f com_ibm_crypto_plus_provider_base_FastJNIBuffer.h
+	rm -f ${JNI_HEADER}
+
+.PHONY : all headers clean FORCE displaycompiler

--- a/src/main/native/share/common.mak
+++ b/src/main/native/share/common.mak
@@ -1,0 +1,133 @@
+###############################################################################
+#
+# Copyright IBM Corp. 2026
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms provided by IBM in the LICENSE file that accompanied
+# this code, including the "Classpath" Exception described therein.
+###############################################################################
+
+TOPDIR=../../../..
+
+PLAT=x86
+CC ?= gcc
+CFLAGS= -fPIC -Werror -std=gnu99 -pedantic -Wall -fstack-protector
+LDFLAGS= -shared
+
+ifeq (${PLATFORM},arm-linux64)
+  PLAT=xr
+  CFLAGS+= -DLINUX
+  OSINCLUDEDIR=linux
+else ifeq (${PLATFORM},ppc-aix64)
+  PLAT=ap
+  CC=xlclang
+  CFLAGS+= -DAIX -m64
+  LDFLAGS+= -brtl -m64
+  OSINCLUDEDIR=aix
+else ifeq (${PLATFORM},ppcle-linux64)
+  PLAT=xl
+  CFLAGS+= -DLINUX -m64
+  LDFLAGS+= -m64
+  OSINCLUDEDIR=linux
+else ifeq (${PLATFORM},s390-linux64)
+  PLAT=xz
+  CFLAGS+= -DS390_PLATFORM -DLINUX -m64
+  LDFLAGS+= -m64
+  OSINCLUDEDIR=linux
+else ifeq (${PLATFORM},s390-zos64)
+  CC=ibm-clang64
+  PLAT=mz
+  CFLAGS= -DS390 -m64
+
+  # Open XL implies strict
+  # https://www.ibm.com/docs/en/open-xl-c-cpp-zos/1.1?topic=options-qstrict
+  # HGPR options seems unnecessary for 64-bit environment
+  # HOT option not supported
+  CFLAGS+= -O3
+  CFLAGS+= -fvisibility=default
+  CFLAGS+= -fstack-protector-strong
+  LDFLAGS= -Wl,-bAMODE=64
+  ICCARCHIVE = $(GSKIT_HOME)/libjgsk8iccs_64.x
+  OSINCLUDEDIR=zos
+else ifeq (${PLATFORM},x86-linux64)
+  PLAT=xa
+  CFLAGS+= -DLINUX -m64
+  LDFLAGS+= -m64
+  OSINCLUDEDIR=linux
+endif
+
+#Setting this flag will result non key material such as handles to native contexts etc being logged to the trace file.
+#This flag must be disabled before building production version
+#DEBUG_FLAGS += -DDEBUG
+#DEBUG_DETAIL = -DDEBUG_RANDOM_DETAIL -DDEBUG_RAND_DETAIL -DDEBUG_DH_DETAIL -DDEBUG_DSA_DETAIL -DDEBUG_DIGEST_DETAIL -DDEBUG_EC_DETAIL -DDEBUG_EXTENDED_RANDOM_DETAIL -DDEBUG_GCM_DETAIL -DDEBUG_CCM_DETAIL -DDEBUG_HMAC_DETAIL -DDEBUG_PKEY_DETAIL -DDEBUG_CIPHER_DETAIL -DDEBUG_RSA_DETAIL -DDEBUG_SIGNATURE_DETAIL -DDEBUG_SIGNATURE_DSANONE_DETAIL -DDEBUG_SIGNATURE_RSASSL_DETAIL -DDEBUG_HKDF_DETAIL -DDEBUG_RSAPSS_DETAIL -DDEBUG_SIGNATURE_EDDSA_DETAIL -DDEBUG_PBKDF_DETAIL -DDEBUG_PQC_KEY_DETAIL
+
+#Setting this flag will result in sensitive key material such as private/public key bytes/parameter bytes being logged to the trace file.
+#Please warn the user that it not suitable to deploy this native library on a production system, while enabling this flag.
+#This flag must be disabled before building production version.
+#DEBUG_DATA = -DDEBUG_DH_DATA -DDEBUG_DSA_DATA -DDEBUG_EC_DATA -DDEBUG_GCM_DATA -DDEBUG_CCM_DATA -DDEBUG_HMAC_DATA -DDEBUG_CIPHER_DATA -DDEBUG_RSA_DATA -DDEBUG_SIGNATURE_DATA -DDEBUG_SIGNATURE_DSANONE_DATA -DDEBUG_SIGNATURE_RSASSL_DATA -DDEBUG_HKDF_DATA -DDEBUG_RSAPSS_DATA -DDEBUG_SIGNATURE_EDDSA_DATA
+#DEBUG_FLAGS+= -g ${DEBUG_DETAIL} ${DEBUG_DATA}
+
+BUILDTOP = ${TOPDIR}/target
+NATIVE_TOPDIR = ${TOPDIR}/src/main/native
+OPENJCEPLUS_HEADER_FILES ?= ${NATIVE_DIR}
+JAVACLASSDIR=${BUILDTOP}/classes
+
+all : displaycompiler ${TARGET}
+
+${TARGET} : ${OBJS}
+	${CC} ${LDFLAGS} -o ${TARGET} ${OBJS} ${TARGET_LIBS}
+
+${HOSTOUT}/%.o : %.c
+	test -d ${@D} || mkdir -p ${@D}
+	${CC} \
+		${CFLAGS} \
+		${DEBUG_FLAGS} \
+		-c \
+		-I${NATIVE_LIB_HOME}/inc \
+		-I${JAVA_HOME}/include \
+		-I${JAVA_HOME}/include/${OSINCLUDEDIR} \
+		-I${OPENJCEPLUS_HEADER_FILES} \
+		-o $@ \
+		$<
+
+displaycompiler :
+	@echo "Compiler version: " && ${CC} --version
+	@echo "Building with ${CC} compiler..."
+	@echo "PLATFORM: ${PLATFORM}"
+	@echo "PLAT: ${PLAT}"
+	@echo "CFLAGS: ${CFLAGS}"
+	@echo "LDFLAGS: ${LDFLAGS}"
+	@echo "-------------------------------------"
+
+# Force BuildDate to be compiled every time.
+#
+${HOSTOUT}/BuildDate.o : FORCE
+
+FORCE :
+
+ifneq (${EXTERNAL_HEADERS},true)
+
+${OBJS} : | headers
+
+headers :
+	echo "Compiling OpenJCEPlus headers"
+	${JAVA_HOME}/bin/javac \
+		--add-exports java.base/sun.security.util=openjceplus \
+		--add-exports java.base/sun.security.util=ALL-UNNAMED \
+		-d ${JAVACLASSDIR} \
+		-h ${TOPDIR}/src/main/native/ock/ \
+		${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/base/FastJNIBuffer.java \
+		${JNI_CLASS}; \
+		if  [ "${PLATFORM}" = "s390-zos64" ]; \
+			then chtag -t -c ISO8859-1 ${JNI_HEADER}; \
+		fi
+
+endif # ! EXTERNAL_HEADERS
+
+clean :
+	rm -f ${HOSTOUT}/*.o
+	rm -f ${HOSTOUT}/*.so
+	rm -f com_ibm_crypto_plus_provider_base_FastJNIBuffer.h
+	rm -f ${JNI_HEADER}
+
+.PHONY : all headers clean FORCE displaycompiler

--- a/src/main/native/share/common.mak
+++ b/src/main/native/share/common.mak
@@ -47,7 +47,6 @@ else ifeq (${PLATFORM},s390-zos64)
   CFLAGS+= -fvisibility=default
   CFLAGS+= -fstack-protector-strong
   LDFLAGS= -Wl,-bAMODE=64
-  ICCARCHIVE = $(GSKIT_HOME)/libjgsk8iccs_64.x
   OSINCLUDEDIR=zos
 else ifeq (${PLATFORM},x86-linux64)
   PLAT=xa

--- a/src/main/native/share/common.win64.cygwin.mak
+++ b/src/main/native/share/common.win64.cygwin.mak
@@ -1,0 +1,81 @@
+###############################################################################
+#
+# Copyright IBM Corp. 2026
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms provided by IBM in the LICENSE file that accompanied
+# this code, including the "Classpath" Exception described therein.
+###############################################################################
+
+TOPDIR = $(MAKEDIR)\..\..\..\..
+
+PLAT = win
+CFLAGS= -nologo -DWINDOWS
+CC = cl
+
+#DEBUG_DETAIL = -DDEBUG_RANDOM_DETAIL -DDEBUG_RAND_DETAIL -DDEBUG_DH_DETAIL -DDEBUG_DSA_DETAIL -DDEBUG_DIGEST_DETAIL -DDEBUG_EC_DETAIL  -DDEBUG_EXTENDED_RANDOM_DETAIL -DDEBUG_GCM_DETAIL -DDEBUG_CCM_DETAIL -DDEBUG_HMAC_DETAIL -DDEBUG_PKEY_DETAIL -DDEBUG_CIPHER_DETAIL -DDEBUG_RSA_DETAIL -DDEBUG_SIGNATURE_DETAIL -DDEBUG_SIGNATURE_DSANONE_DETAIL -DDEBUG_SIGNATURE_RSASSL_DETAIL -DDEBUG_HKDF_DETAIL -DDEBUG_RSAPSS_DETAIL -DDEBUG_SIGNATURE_EDDSA_DETAIL -DDEBUG_PBKDF_DETAIL -DDEBUG_PQC_KEY_DETAIL
+
+#Setting this flag will result in sensitive key material such as private/public key bytes/parameter bytes being logged to the trace file.
+#Please warn the user that it not suitable to deploy this native library on a production system, while enabling this flag.
+#This flag must be disabled before building production version.
+#DEBUG_DATA =  -DDEBUG_DH_DATA -DDEBUG_DSA_DATA -DDEBUG_EC_DATA -DDEBUG_GCM_DATA -DDEBUG_CCM_DATA -DDEBUG_HMAC_DATA -DDEBUG_CIPHER_DATA -DDEBUG_RSA_DATA -DDEBUG_SIGNATURE_DATA -DDEBUG_SIGNATURE_DSANONE_DATA -DDEBUG_SIGNATURE_RSASSL_DATA -DDEBUG_HKDF_DATA -DDEBUG_RSAPSS_DATA -DDEBUG_SIGNATURE_EDDSA_DATA
+#DEBUG_FLAGS = -DDEBUG $(DEBUG_DETAIL)  $(DEBUG_DATA)
+
+BUILDTOP = $(TOPDIR)\target\build$(PLAT)
+JAVACLASSDIR = $(TOPDIR)\target\classes
+
+all : displaycompiler copy
+
+$(TARGET) : $(OBJS) $(RC_OBJ)
+	link -dll -out:$@ $(OBJS) $(RC_OBJ) $(TARGET_LIBS)
+
+$(RC_OBJ) : $(RC_SRC)
+	rc $(BUILD_CFLAGS) -Fo$@ $(RC_SRC)
+
+.c.obj :
+	$(CC) \
+		$(DEBUG_FLAGS) \
+		$(CFLAGS) \
+		-c \
+		-I"$(NATIVE_LIB_HOME)\inc" \
+		-I"$(JAVA_HOME)\include" \
+		-I"$(JAVA_HOME)\include\win32" \
+		$*.c
+
+displaycompiler :
+	@echo "Compiler version: " && $(CC)
+	@echo "Building with $(CC) compiler..."
+	@echo "-------------------------------------"
+
+copy : $(TARGET)
+	-@mkdir -p $(HOSTOUT) 2>nul
+	-@cp *.obj $(HOSTOUT)
+	-@cp $(RC_OBJ) $(HOSTOUT)
+	-@cp $(TARGET) $(HOSTOUT)
+
+# Force BuildDate to be recompiled every time
+#
+BuildDate.obj : FORCE
+
+FORCE :
+
+$(OBJS) : headers
+
+headers :
+	@echo "Compiling OpenJCEPlus headers"
+	$(JAVA_HOME)\bin\javac \
+		--add-exports java.base/sun.security.util=openjceplus \
+		--add-exports java.base/sun.security.util=ALL-UNNAMED \
+		-d $(JAVACLASSDIR) \
+		-h $(TOPDIR)\src\main\native\ock\ \
+		$(TOPDIR)\src\main\java\com\ibm\crypto\plus\provider\base\FastJNIBuffer.java \
+		$(JNI_CLASS)
+
+clean :
+	-@del $(HOSTOUT)\*.obj
+	-@del $(HOSTOUT)\*.exp
+	-@del $(HOSTOUT)\*.lib
+	-@del $(HOSTOUT)\*.dll
+	-@del $(HOSTOUT)\*.res
+
+.PHONY : all clean copy headers displaycompiler

--- a/src/main/native/share/common.win64.mak
+++ b/src/main/native/share/common.win64.mak
@@ -1,0 +1,83 @@
+###############################################################################
+#
+# Copyright IBM Corp. 2026
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms provided by IBM in the LICENSE file that accompanied
+# this code, including the "Classpath" Exception described therein.
+###############################################################################
+
+TOPDIR = $(MAKEDIR)../../../..
+
+PLAT = win
+CFLAGS= -nologo -DWINDOWS
+CC = cl
+
+#DEBUG_DETAIL = -DDEBUG_RANDOM_DETAIL -DDEBUG_RAND_DETAIL -DDEBUG_DH_DETAIL -DDEBUG_DSA_DETAIL -DDEBUG_DIGEST_DETAIL -DDEBUG_EC_DETAIL  -DDEBUG_EXTENDED_RANDOM_DETAIL -DDEBUG_GCM_DETAIL -DDEBUG_CCM_DETAIL -DDEBUG_HMAC_DETAIL -DDEBUG_PKEY_DETAIL -DDEBUG_CIPHER_DETAIL -DDEBUG_RSA_DETAIL -DDEBUG_SIGNATURE_DETAIL -DDEBUG_SIGNATURE_DSANONE_DETAIL -DDEBUG_SIGNATURE_RSASSL_DETAIL -DDEBUG_HKDF_DETAIL -DDEBUG_RSAPSS_DETAIL -DDEBUG_SIGNATURE_EDDSA_DETAIL -DDEBUG_PBKDF_DETAIL -DDEBUG_PQC_KEY_DETAIL
+
+#Setting this flag will result in sensitive key material such as private/public key bytes/parameter bytes being logged to the trace file.
+#Please warn the user that it not suitable to deploy this native library on a production system, while enabling this flag.
+#This flag must be disabled before building production version.
+#DEBUG_DATA =  -DDEBUG_DH_DATA -DDEBUG_DSA_DATA -DDEBUG_EC_DATA -DDEBUG_GCM_DATA -DDEBUG_CCM_DATA -DDEBUG_HMAC_DATA -DDEBUG_CIPHER_DATA -DDEBUG_RSA_DATA -DDEBUG_SIGNATURE_DATA -DDEBUG_SIGNATURE_DSANONE_DATA -DDEBUG_SIGNATURE_RSASSL_DATA -DDEBUG_HKDF_DATA -DDEBUG_RSAPSS_DATA -DDEBUG_SIGNATURE_EDDSA_DATA
+#DEBUG_FLAGS = -DDEBUG $(DEBUG_DETAIL)  $(DEBUG_DATA)
+
+BUILDTOP = $(TOPDIR)/target/build$(PLAT)
+NATIVE_TOPDIR = $(TOPDIR)/src/main/native
+OPENJCEPLUS_HEADER_FILES ?= $(NATIVE_DIR)
+JAVACLASSDIR = $(TOPDIR)/target/classes
+
+all : displaycompiler $(TARGET)
+
+$(TARGET) : $(OBJS) $(RC_OBJ)
+	link -dll -out:$@ $(OBJS) $(RC_OBJ) $(TARGET_LIBS)
+
+$(RC_OBJ) : $(RC_SRC)
+	rc $(BUILD_CFLAGS) -Fo$@ $(RC_SRC)
+
+$(HOSTOUT)/%.obj : %.c
+	-@mkdir -p $(HOSTOUT) 2>nul
+	$(CC) \
+		$(DEBUG_FLAGS) \
+		$(CFLAGS) \
+		-c \
+		-I"$(NATIVE_LIB_HOME)/inc" \
+		-I"$(JAVA_HOME)/include" \
+		-I"$(JAVA_HOME)/include/win32" \
+		-I"$(OPENJCEPLUS_HEADER_FILES)" \
+		-Fo$@ \
+		$<
+
+displaycompiler :
+	@echo "Compiler version: " && $(CC)
+	@echo "Building with $(CC) compiler..."
+	@echo "-------------------------------------"
+
+# Force BuildDate to be recompiled every time
+#
+$(HOSTOUT)/BuildDate.obj : FORCE
+
+FORCE :
+
+ifneq (${EXTERNAL_HEADERS},true)
+
+$(OBJS) : | headers
+
+headers :
+	echo "Compiling OpenJCEPlus headers"
+	$(JAVA_HOME)/bin/javac \
+		--add-exports java.base/sun.security.util=openjceplus \
+		--add-exports java.base/sun.security.util=ALL-UNNAMED \
+		-d $(JAVACLASSDIR) \
+		-h $(TOPDIR)/src/main/native/ock/ \
+		$(TOPDIR)/src/main/java/com/ibm/crypto/plus/provider/base/FastJNIBuffer.java \
+		$(JNI_CLASS)
+
+endif # ! EXTERNAL_HEADERS
+
+clean :
+	-@del $(HOSTOUT)/*.obj
+	-@del $(HOSTOUT)/*.exp
+	-@del $(HOSTOUT)/*.lib
+	-@del $(HOSTOUT)/*.dll
+	-@del $(HOSTOUT)/*.res
+


### PR DESCRIPTION
For each of the platform-specific makefiles, the rules and variables that are applicable to all potential native libraries are extracted to common makefiles.

The original makefiles only maintain the library-specific elements and include the equivalent common makefiles for the rest of them.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1419

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>