### PR TITLE
Update MacOS lib name and OCKC version to 8.9.22

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: IBM/OpenCryptographyKitC
-          ref: f3dde51a02675270adf994dc22c7f2853dc86ba6 # Branch V_8.9.18 on Jan 2nd 2026.
+          ref: dc6dbf5c79365cba7092f917162124eb24c2b5a6 # Branch V_8.9.21 on May 19th 2026.
           path: ${{ github.workspace }}/OpenCryptographyKitC
       - name: Compile Open Cryptography Kit C
         run: |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Follow these steps to build the `OpenJCEPlus` and `OpenJCEPlusFIPS` providers al
 
     Based on the platform, the library file (i.e., `$LIBJGSKIT_LIBRARY`) is named differently. The  values are as follows:
    * AIX/Linux: `libjgsk8iccs_64.so`
-   * Mac OS X: `libjgsk8iccs.dylib`
+   * Mac OS X (aarch64): `libjgsk8iccs_64.dylib`
+   * Mac OS X (x86-64): `libjgsk8iccs.dylib`
    * Windows: `jgsk8iccs_64.dll`
 
    Create the `lib64` directory and copy the `$LIBJGSKIT_LIBRARY` library to that location:

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKImplementation.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKImplementation.java
@@ -153,7 +153,9 @@ final class NativeOCKImplementation {
         // Mac OS X: lib<OCK_CORE_LIBRARY_NAME>_64.so
         // Windows* amd64: <OCK_CORE_LIBRARY_NAME>_64.dll
         // --------------------------------------------------------------
-        if (osName.equals("Mac OS X")) {
+        if (osName.equals("Mac OS X") && osArch.equals("aarch64")) {
+            loadFile = new File(ockPath, "lib" + OCK_CORE_LIBRARY_NAME + "_64.dylib");
+        } else if (osName.equals("Mac OS X")) {
             loadFile = new File(ockPath, "lib" + OCK_CORE_LIBRARY_NAME + ".dylib");
         } else if (osName.startsWith("Windows") && osArch.equals("amd64")) {
             loadFile = new File(ockPath, OCK_CORE_LIBRARY_NAME + "_64.dll");

--- a/src/main/native/ock/jgskit.mac.mak
+++ b/src/main/native/ock/jgskit.mac.mak
@@ -12,7 +12,12 @@ NATIVE_DIR = ${NATIVE_TOPDIR}/ock
 NATIVE_LIB_HOME = ${GSKIT_HOME}
 JNI_CLASS = ${TOPDIR}/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKImplementation.java
 JNI_HEADER = com_ibm_crypto_plus_provider_ock_NativeOCKImplementation.h
-TARGET_LIBS := -L ${GSKIT_HOME}/lib64 -l jgsk8iccs
+
+ifeq (${PLATFORM},aarch64-mac)
+  TARGET_LIBS := -L ${GSKIT_HOME}/lib64 -l jgsk8iccs_64
+else
+  TARGET_LIBS := -L ${GSKIT_HOME}/lib64 -l jgsk8iccs
+endif
 
 OBJS = \
 	${HOSTOUT}/AESKeyWrap.o \

--- a/utils.groovy
+++ b/utils.groovy
@@ -65,11 +65,7 @@ def getOCKTarget(hardware, software) {
 def getBinaries(hardware, software) {
     def ockRelease = OCK_RELEASE
     if (ockRelease == "") {
-        if (hardware == "s390x") { // covers LoZ and z/OS
-            ockRelease = "20260219_8.9.21"
-        } else {
-            ockRelease = "20251128_8.9.18"
-        }
+        ockRelease = "20260415_8.9.22"
     }
     def target = getOCKTarget(hardware, software)
     def gskit_bin = "https://na.artifactory.swg-devops.com/artifactory/sec-gskit-javasec-generic-local/gskit8/$ockRelease/$target/jgsk_crypto.tar"
@@ -96,7 +92,9 @@ def getBinaries(hardware, software) {
         }
 
         def jgsk8Lib = 'libjgsk8iccs_64.so'
-        if (target.contains('osx')) {
+        if (target == 'osx64_arm') {
+            jgsk8Lib = 'libjgsk8iccs_64.dylib'
+        } else if (target == 'osx64_x86') {
             jgsk8Lib = 'libjgsk8iccs.dylib'
         } else if (target.contains('win')) {
             jgsk8Lib = 'jgsk8iccs_64.dll'


### PR DESCRIPTION
- Update macOS aarch64 OCKC library name from libjgsk8iccs.dylib to libjgsk8iccs_64.dylib for consistency with other platforms. OCKC version 8.9.22 has renamed the library so this is required.
- Update OpenCryptographyKitC reference to V_8.9.21 (May 19th 2026)
- Standardize OCK release version to 20260415_8.9.22 across all platforms, removing platform-specific version logic
- Update documentation and build configuration to reflect new library naming convention

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1478

Signed-off-by: Jason Katonica <katonica@us.ibm.com>