### PR TITLE
Set XEC secret buffer size explicitly on z/OS

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
@@ -102,8 +102,17 @@ abstract class XDHKeyAgreement extends KeyAgreementSpi {
         }
 
         try {
+            int secrectBufferSize = 0;
+            if (System.getProperty("os.name").equals("z/OS")) {
+                String curveName = ((NamedParameterSpec) xdhPublicKeyImpl.getParams()).getName();
+                if (NamedParameterSpec.X25519.getName().equalsIgnoreCase(curveName)) {
+                    secrectBufferSize = SECRET_BUFFER_SIZE_X25519; // X25519 secret buffer size
+                } else if (NamedParameterSpec.X448.getName().equalsIgnoreCase(curveName)) {
+                    secrectBufferSize = SECRET_BUFFER_SIZE_X448; // X448 secret buffer size
+                }
+            }
             this.secret = XECKey.computeECDHSecret(genCtx,
-                    ockXecKeyPub.getPKeyId(), ockXecKeyPriv.getPKeyId(), provider);
+                    ockXecKeyPub.getPKeyId(), ockXecKeyPriv.getPKeyId(), secrectBufferSize, provider);
         } catch (NativeException e) {
             //Validate the secret value for a small order point condition.
             byte orValue = (byte) 0;

--- a/src/main/java/com/ibm/crypto/plus/provider/base/NativeInterface.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/NativeInterface.java
@@ -548,7 +548,7 @@ public interface NativeInterface {
             long privEcKeyId) throws NativeException;
 
     public byte[] XECKEY_computeECDHSecret(long genCtx,
-            long pubEcKeyId, long privEcKeyId) throws NativeException;
+            long pubEcKeyId, long privEcKeyId, int secrectBufferSize) throws NativeException;
 
 
     public byte[] ECKEY_signDatawithECDSA(byte[] digestBytes,

--- a/src/main/java/com/ibm/crypto/plus/provider/base/XECKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/XECKey.java
@@ -68,7 +68,7 @@ public final class XECKey implements AsymmetricKey {
     }
 
     public static byte[] computeECDHSecret(long genCtx, long pubId,
-            long privId, OpenJCEPlusProvider provider) throws NativeException {
+            long privId, int secrectBufferSize, OpenJCEPlusProvider provider) throws NativeException {
         if (pubId == 0)
             throw new IllegalArgumentException("The public key parameter is not valid");
         if (privId == 0)
@@ -76,7 +76,7 @@ public final class XECKey implements AsymmetricKey {
 
         NativeInterface nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
         byte[] sharedSecretBytes = nativeInterface.XECKEY_computeECDHSecret(
-                genCtx, pubId, privId);
+                genCtx, pubId, privId, secrectBufferSize);
         //OCKDebug.Msg (debPrefix, methodName,  "pubId :" + pubId + " privId :" + privId + " sharedSecretBytes :", sharedSecretBytes);
         return sharedSecretBytes;
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKAdapter.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKAdapter.java
@@ -1112,9 +1112,9 @@ public abstract class NativeOCKAdapter implements NativeInterface {
     }
 
     @Override
-    public byte[] XECKEY_computeECDHSecret(long genCtx, long pubEcKeyId, long privEcKeyId)
+    public byte[] XECKEY_computeECDHSecret(long genCtx, long pubEcKeyId, long privEcKeyId, int secrectBufferSize)
             throws OCKException {
-        return NativeOCKImplementation.XECKEY_computeECDHSecret(ockContext.getId(), genCtx, pubEcKeyId, privEcKeyId);
+        return NativeOCKImplementation.XECKEY_computeECDHSecret(ockContext.getId(), genCtx, pubEcKeyId, privEcKeyId, secrectBufferSize);
     }
 
     @Override

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKImplementation.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKImplementation.java
@@ -724,7 +724,7 @@ final class NativeOCKImplementation {
             long privEcKeyId) throws OCKException;
 
     static public native byte[] XECKEY_computeECDHSecret(long ockContextId, long genCtx,
-            long pubEcKeyId, long privEcKeyId) throws OCKException;
+            long pubEcKeyId, long privEcKeyId, int secrectBufferSize) throws OCKException;
 
 
     static public native byte[] ECKEY_signDatawithECDSA(long ockContextId, byte[] digestBytes,

--- a/src/main/native/ock/ECKey.c
+++ b/src/main/native/ock/ECKey.c
@@ -2227,7 +2227,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_ECKEY_1computeECDH
 JNIEXPORT jbyteArray JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_XECKEY_1computeECDHSecret(
     JNIEnv *env, jclass thisObj, jlong ockContextId, jlong genCtx,
-    jlong pubXecKeyId, jlong privXecKeyId) {
+    jlong pubXecKeyId, jlong privXecKeyId, jint secretBufferSize) {
     static const char *functionName =
         "NativeInterface_XECKEY_1computeECDHSecret";
 
@@ -2266,21 +2266,29 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_XECKEY_1computeECD
         goto cleanup;
     }
 
-    /*
-     * Always query the required secret size before deriving the secret.
-     * This avoids deriving into a buffer with an incorrect size.
-     */
-    rc = ICC_EVP_PKEY_derive(ockCtx, gen_ctx, NULL, &required_len); /* Get secret key size */
-    if (ICC_OSSL_SUCCESS != rc) {
-        throwOCKException(env, 0,
-                "ICC_EVP_PKEY_derive failed to get secret size");
-        goto cleanup;
+    if (secretBufferSize > 0) {
+        /*
+         * On z/OS, querying the required secret size may not work properly.
+         * In that case, use the caller-provided secretBufferSize as the
+         * expected derived secret size.
+         */
+        required_len = (size_t) secretBufferSize;
+    } else {
+        /*
+         * Query the required secret size before deriving the secret.
+         * This avoids deriving into a buffer with an incorrect size.
+         */
+        rc = ICC_EVP_PKEY_derive(ockCtx, gen_ctx, NULL, &required_len); /* Get secret key size */
+        if (ICC_OSSL_SUCCESS != rc) {
+            throwOCKException(env, 0,
+                    "ICC_EVP_PKEY_derive failed to get secret size");
+            goto cleanup;
+        }
+        if (required_len == 0) {
+            throwOCKException(env, 0, "Derived secret size is zero");
+            goto cleanup;
+        }
     }
-    if (required_len == 0) {
-        throwOCKException(env, 0, "Derived secret size is zero");
-        goto cleanup;
-    }
-
     secret_key_len = required_len;
 
     secretBytes = (*env)->NewByteArray(env, secret_key_len); /* Create Java secret bytes array */


### PR DESCRIPTION
Set the expected XEC secret buffer size explicitly on z/OS before calling the native ECDH secret computation.

On other platforms, the native layer can query the required secret size by calling ICC_EVP_PKEY_derive. However, this size query does not work on z/OS.

To handle this platform difference, determine the curve name from the public key parameters on z/OS and pass the expected secret buffer size to the native layer.

Other platforms continue to use the ICC_EVP_PKEY_derive size query.