### PR TITLE
Improve buffer handling during error handling

### DIFF
--- a/src/main/native/ock/CCM.c
+++ b/src/main/native/ock/CCM.c
@@ -646,18 +646,3 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_do_1CCM_1encrypt(
 
     return (jint)ret;
 }
-
-int OpenSSLError(ICC_CTX* ICC_ctx, const int line) {
-    char buf1[8192];
-
-    unsigned long retcode = 0;
-    retcode               = ICC_ERR_get_error(ICC_ctx);
-
-    /* While because we want to drain the swamp */
-    while (0 != retcode && ((unsigned long)-2L) != retcode) {
-        ICC_ERR_error_string(ICC_ctx, retcode, (char*)buf1);
-        printf("OpenSSL error line %d [%s]\n", line, buf1);
-        retcode = ICC_ERR_get_error(ICC_ctx);
-    }
-    return retcode;
-}

--- a/src/main/native/ock/RSA.c
+++ b/src/main/native/ock/RSA.c
@@ -424,8 +424,8 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_RSACIPHER_1private
 #ifdef DEBUG_RSA_DETAIL
         gslogMessage(
             "DETAIL_RSACIPHER rsaKeyId %lx rsaPaddingId %x mdId %x plaintextOff %d "
-            "plaintextLen %d ciphertextOff %d",
-            (long)rsaKeyId, rsaPaddingId, mdId, (int)plaintextOff, (int)plaintextLen,
+            "ciphertextLen %d ciphertextOff %d",
+            (long)rsaKeyId, rsaPaddingId, mdId, (int)plaintextOff, (int)ciphertextLen,
             (int)ciphertextOff);
 #endif
     }

--- a/src/main/native/ock/RSAKey.c
+++ b/src/main/native/ock/RSAKey.c
@@ -469,7 +469,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_RSAKEY_1getPrivate
 #ifdef DEBUG_RSA_DATA
     if (debug) {
         gslogMessagePrefix("DATA_RSA private KeyBytes : ");
-        gslogMessageHex((char *)pBytes, 0, (int)size, 0, 0,
+        gslogMessageHex((char *)keyBytesNative, 0, (int)size, 0, 0,
                         NULL);
     }
 #endif
@@ -580,7 +580,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_RSAKEY_1getPublicK
 #ifdef DEBUG_RSA_DATA
     if (debug) {
         gslogMessagePrefix("DATA_RSA KeyBytes : ");
-        gslogMessageHex((char *)pBytes, 0, (int)size, 0, 0,
+        gslogMessageHex((char *)keyBytesNative, 0, (int)size, 0, 0,
                         NULL);
     }
 #endif

--- a/src/main/native/ock/Utils.c
+++ b/src/main/native/ock/Utils.c
@@ -50,7 +50,7 @@ int gslogError(const char *formatString, ...) {
     static char printBuffer[4096];
 
     va_start(formatArgs, formatString);
-    charsPrinted = vsprintf(printBuffer, formatString, formatArgs);
+    charsPrinted = vsnprintf(printBuffer, sizeof(printBuffer), formatString, formatArgs);
 
     fprintf(stderr, "[ERROR] %s\n", printBuffer);
 
@@ -68,7 +68,7 @@ int gslogMessage(const char *formatString, ...) {
     static char printBuffer[4096];
 
     va_start(formatArgs, formatString);
-    charsPrinted = vsprintf(printBuffer, formatString, formatArgs);
+    charsPrinted = vsnprintf(printBuffer, sizeof(printBuffer), formatString, formatArgs);
 
     fprintf(stderr, "[DEBUG] %s\n", printBuffer);
 
@@ -86,7 +86,7 @@ int gslogMessagePrefix(const char *formatString, ...) {
     static char printBuffer[4096];
 
     va_start(formatArgs, formatString);
-    charsPrinted = vsprintf(printBuffer, formatString, formatArgs);
+    charsPrinted = vsnprintf(printBuffer, sizeof(printBuffer), formatString, formatArgs);
 
     fprintf(stderr, "[DEBUG] %s", printBuffer);
 
@@ -134,12 +134,11 @@ int gslogFunctionExit(const char *functionName) {
 void ockCheckStatus(ICC_CTX *ctx) {
     if (debug) {
         unsigned long errCode;
+        char errBuffer[8192];
 
-        while ((errCode = ICC_ERR_get_error(ctx)) == 1) {
-            char *err;
-            // gslogMessage("Generating error message");
-            err = ICC_ERR_error_string(ctx, errCode, NULL);
-            gslogMessage("%s", err);
+        while ((errCode = ICC_ERR_get_error(ctx)) != 0) {
+            ICC_ERR_error_string_n(ctx, errCode, errBuffer, sizeof(errBuffer));
+            gslogMessage("%s", errBuffer);
         }
     }
 }


### PR DESCRIPTION
- Replace unsafe vsprintf() with safer vsnprintf() in Utils.c to prevent possible buffer overflows in gslogError(), gslogMessage(), and gslogMessagePrefix() functions
- Fix incorrect variable references in RSA debug logging which prevents compiling debug code. This results in syntax errors:
  - Use ciphertextLen instead of plaintextLen in RSA.c
  - Use keyBytesNative instead of pBytes in RSAKey.c
- Improve error handling in ockCheckStatus() by using ICC_ERR_error_string_n() with bounded fixed size buffer. Loop printing exception messages changed to print any error code not just the value `1`.
- Remove unused OpenSSLError() function from CCM.c

These changes enhance security by preventing the potential of a buffer overflow and fix debug logging to display correct variable values.

Fixes https://github.com/IBM/OpenJCEPlus/issues/1345

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1484

Signed-off-by: Jason Katonica <katonica@us.ibm.com>