### PR TITLE
Use ThreadLocal caching for ExtendedRandom PRNG contexts

### DIFF
--- a/JenkinsfilePerformance
+++ b/JenkinsfilePerformance
@@ -385,6 +385,7 @@ pipeline {
                                             'ibm.jceplus.jmh.PBEBenchmark', \
                                             'ibm.jceplus.jmh.PBKDF2Benchmark', \
                                             'ibm.jceplus.jmh.RandomBenchmark', \
+                                            'ibm.jceplus.jmh.RandomNewInstanceBenchmark', \
                                             'ibm.jceplus.jmh.RSACipherBenchmark', \
                                             'ibm.jceplus.jmh.RSAKeyGeneratorBenchmark', \
                                             'ibm.jceplus.jmh.RSASignatureBenchmark', \

--- a/JenkinsfilePerformance
+++ b/JenkinsfilePerformance
@@ -386,6 +386,7 @@ pipeline {
                                             'ibm.jceplus.jmh.PBKDF2Benchmark', \
                                             'ibm.jceplus.jmh.PBMAC1Benchmark', \
                                             'ibm.jceplus.jmh.RandomBenchmark', \
+                                            'ibm.jceplus.jmh.RandomNewInstanceBenchmark', \
                                             'ibm.jceplus.jmh.RSACipherBenchmark', \
                                             'ibm.jceplus.jmh.RSAKeyGeneratorBenchmark', \
                                             'ibm.jceplus.jmh.RSASignatureBenchmark', \

--- a/src/main/java/com/ibm/crypto/plus/provider/base/ExtendedRandom.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/ExtendedRandom.java
@@ -16,7 +16,13 @@ public final class ExtendedRandom {
 
     private OpenJCEPlusProvider provider;
     private NativeInterface nativeInterface;
-    final long ockPRNGContextId;
+    private final String algName;
+
+    private long ockPRNGContextId;
+    private boolean usingThreadLocalContext = true;
+
+    private static final ThreadLocal<PRNGContextPointer> prngContextBufferSha256 = new ThreadLocal<PRNGContextPointer>();
+    private static final ThreadLocal<PRNGContextPointer> prngContextBufferSha512 = new ThreadLocal<PRNGContextPointer>();
 
     public static ExtendedRandom getInstance(String algName, OpenJCEPlusProvider provider)
             throws NativeException {
@@ -32,11 +38,35 @@ public final class ExtendedRandom {
     }
 
     private ExtendedRandom(String algName, OpenJCEPlusProvider provider) throws NativeException {
+        this.algName = algName;
         this.provider = provider;
         this.nativeInterface = provider.isFIPS() ? NativeOCKAdapterFIPS.getInstance() : NativeOCKAdapterNonFIPS.getInstance();
-        this.ockPRNGContextId = this.nativeInterface.EXTRAND_create(algName);
+        this.ockPRNGContextId = getPRNGContext(algName);
+    }
 
-        this.provider.registerCleanable(this, cleanOCKResources(ockPRNGContextId, nativeInterface));
+    private long getPRNGContext(String algName) throws NativeException {
+        PRNGContextPointer prngCtx = null;
+        ThreadLocal<PRNGContextPointer> prngCtxBuffer = null;
+
+        switch (algName) {
+            case "SHA256":
+                prngCtxBuffer = prngContextBufferSha256;
+                break;
+            case "SHA512":
+                prngCtxBuffer = prngContextBufferSha512;
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported HASHDRBG algorithm: " + algName);
+        }
+
+        prngCtx = prngCtxBuffer.get();
+        if (prngCtx == null) {
+            prngCtx = new PRNGContextPointer(algName, this.nativeInterface, this.provider);
+            prngCtxBuffer.set(prngCtx);
+        }
+
+        return prngCtx.getCtx();
     }
 
     public synchronized void nextBytes(byte[] bytes) throws NativeException {
@@ -55,11 +85,24 @@ public final class ExtendedRandom {
         }
 
         if (seed.length > 0) {
+            createInstanceContextForReSeed();
             this.nativeInterface.EXTRAND_setSeed(ockPRNGContextId, seed);
         }
     }
 
-    private Runnable cleanOCKResources(long ockPRNGContextId, NativeInterface nativeInterface) {
+    private void createInstanceContextForReSeed() throws NativeException {
+        if (!usingThreadLocalContext) {
+            return;
+        }
+
+        long instanceCtx = this.nativeInterface.EXTRAND_create(algName);
+        this.ockPRNGContextId = instanceCtx;
+        this.usingThreadLocalContext = false;
+
+        this.provider.registerCleanable(this, cleanOCKResources(instanceCtx, nativeInterface));
+    }
+
+    private static Runnable cleanOCKResources(long ockPRNGContextId, NativeInterface nativeInterface) {
         return () -> {
             try {
                 if (ockPRNGContextId != 0) {
@@ -67,10 +110,23 @@ public final class ExtendedRandom {
                 }
             } catch (Exception e) {
                 if (OpenJCEPlusProvider.getDebug() != null) {
-                    OpenJCEPlusProvider.getDebug().println("An error occurred while cleaning : " + e.getMessage());
+                    OpenJCEPlusProvider.getDebug().println("An error occurred while cleaning: " + e.getMessage());
                     e.printStackTrace();
                 }
             }
         };
+    }
+
+    private static final class PRNGContextPointer {
+        final long prngCtx;
+
+        PRNGContextPointer(String algName, NativeInterface nativeInterface, OpenJCEPlusProvider provider) throws NativeException {
+            this.prngCtx = nativeInterface.EXTRAND_create(algName);
+            provider.registerCleanable(this, ExtendedRandom.cleanOCKResources(this.prngCtx, nativeInterface));
+        }
+
+        long getCtx() {
+            return this.prngCtx;
+        }
     }
 }

--- a/src/main/java/com/ibm/crypto/plus/provider/base/ExtendedRandom.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/ExtendedRandom.java
@@ -12,6 +12,10 @@ import com.ibm.crypto.plus.provider.OpenJCEPlusProvider;
 
 public final class ExtendedRandom {
 
+    private static final boolean IS_ZOS = System.getProperty("os.name")
+                                                .toLowerCase()
+                                                .contains("z/os");
+
     private OpenJCEPlusProvider provider;
     private NativeInterface nativeInterface;
     private final String algName;
@@ -19,8 +23,10 @@ public final class ExtendedRandom {
     private long ockPRNGContextId;
     private boolean usingThreadLocalContext = true;
 
-    private static final ThreadLocal<PRNGContextPointer> prngContextBufferSha256 = new ThreadLocal<PRNGContextPointer>();
-    private static final ThreadLocal<PRNGContextPointer> prngContextBufferSha512 = new ThreadLocal<PRNGContextPointer>();
+    private static final ThreadLocal<PRNGContextPointer> prngContextBufferSha256 =
+        IS_ZOS ? null : new ThreadLocal<PRNGContextPointer>();
+    private static final ThreadLocal<PRNGContextPointer> prngContextBufferSha512 =
+        IS_ZOS ? null : new ThreadLocal<PRNGContextPointer>();
 
     public static ExtendedRandom getInstance(String algName, OpenJCEPlusProvider provider)
             throws NativeException {
@@ -43,6 +49,13 @@ public final class ExtendedRandom {
     }
 
     private long getPRNGContext(String algName) throws NativeException {
+        // On z/OS, create a new instance context without caching.
+        if (IS_ZOS) {
+            return createInstanceContext();
+        }
+
+        // On non-z/OS platforms, use the cached context if available,
+        // otherwise create and cache it.
         PRNGContextPointer prngCtx = null;
         ThreadLocal<PRNGContextPointer> prngCtxBuffer = null;
 
@@ -83,21 +96,19 @@ public final class ExtendedRandom {
         }
 
         if (seed.length > 0) {
-            createInstanceContextForReSeed();
+            // Switch from cached context to instance context for re-seeding
+            if (usingThreadLocalContext) {
+                this.ockPRNGContextId = createInstanceContext();
+            }
             this.nativeInterface.EXTRAND_setSeed(ockPRNGContextId, seed);
         }
     }
 
-    private void createInstanceContextForReSeed() throws NativeException {
-        if (!usingThreadLocalContext) {
-            return;
-        }
-
+    private long createInstanceContext() throws NativeException {
         long instanceCtx = this.nativeInterface.EXTRAND_create(algName);
-        this.ockPRNGContextId = instanceCtx;
         this.usingThreadLocalContext = false;
-
         this.provider.registerCleanable(this, cleanOCKResources(instanceCtx, nativeInterface));
+        return instanceCtx;
     }
 
     private static Runnable cleanOCKResources(long ockPRNGContextId, NativeInterface nativeInterface) {

--- a/src/main/java/com/ibm/crypto/plus/provider/base/ExtendedRandom.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/ExtendedRandom.java
@@ -14,7 +14,13 @@ public final class ExtendedRandom {
 
     private OpenJCEPlusProvider provider;
     private NativeInterface nativeInterface;
-    final long ockPRNGContextId;
+    private final String algName;
+
+    private long ockPRNGContextId;
+    private boolean usingThreadLocalContext = true;
+
+    private static final ThreadLocal<PRNGContextPointer> prngContextBufferSha256 = new ThreadLocal<PRNGContextPointer>();
+    private static final ThreadLocal<PRNGContextPointer> prngContextBufferSha512 = new ThreadLocal<PRNGContextPointer>();
 
     public static ExtendedRandom getInstance(String algName, OpenJCEPlusProvider provider)
             throws NativeException {
@@ -30,11 +36,35 @@ public final class ExtendedRandom {
     }
 
     private ExtendedRandom(String algName, OpenJCEPlusProvider provider) throws NativeException {
+        this.algName = algName;
         this.provider = provider;
         this.nativeInterface = NativeCryptoSelector.selectBackend(provider, "SecureRandom", algName + "DRBG");
-        this.ockPRNGContextId = this.nativeInterface.EXTRAND_create(algName);
+        this.ockPRNGContextId = getPRNGContext(algName);
+    }
 
-        this.provider.registerCleanable(this, cleanOCKResources(ockPRNGContextId, nativeInterface));
+    private long getPRNGContext(String algName) throws NativeException {
+        PRNGContextPointer prngCtx = null;
+        ThreadLocal<PRNGContextPointer> prngCtxBuffer = null;
+
+        switch (algName) {
+            case "SHA256":
+                prngCtxBuffer = prngContextBufferSha256;
+                break;
+            case "SHA512":
+                prngCtxBuffer = prngContextBufferSha512;
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported HASHDRBG algorithm: " + algName);
+        }
+
+        prngCtx = prngCtxBuffer.get();
+        if (prngCtx == null) {
+            prngCtx = new PRNGContextPointer(algName, this.nativeInterface, this.provider);
+            prngCtxBuffer.set(prngCtx);
+        }
+
+        return prngCtx.getCtx();
     }
 
     public synchronized void nextBytes(byte[] bytes) throws NativeException {
@@ -53,11 +83,24 @@ public final class ExtendedRandom {
         }
 
         if (seed.length > 0) {
+            createInstanceContextForReSeed();
             this.nativeInterface.EXTRAND_setSeed(ockPRNGContextId, seed);
         }
     }
 
-    private Runnable cleanOCKResources(long ockPRNGContextId, NativeInterface nativeInterface) {
+    private void createInstanceContextForReSeed() throws NativeException {
+        if (!usingThreadLocalContext) {
+            return;
+        }
+
+        long instanceCtx = this.nativeInterface.EXTRAND_create(algName);
+        this.ockPRNGContextId = instanceCtx;
+        this.usingThreadLocalContext = false;
+
+        this.provider.registerCleanable(this, cleanOCKResources(instanceCtx, nativeInterface));
+    }
+
+    private static Runnable cleanOCKResources(long ockPRNGContextId, NativeInterface nativeInterface) {
         return () -> {
             try {
                 if (ockPRNGContextId != 0) {
@@ -65,10 +108,23 @@ public final class ExtendedRandom {
                 }
             } catch (Exception e) {
                 if (OpenJCEPlusProvider.getDebug() != null) {
-                    OpenJCEPlusProvider.getDebug().println("An error occurred while cleaning : " + e.getMessage());
+                    OpenJCEPlusProvider.getDebug().println("An error occurred while cleaning: " + e.getMessage());
                     e.printStackTrace();
                 }
             }
         };
+    }
+
+    private static final class PRNGContextPointer {
+        final long prngCtx;
+
+        PRNGContextPointer(String algName, NativeInterface nativeInterface, OpenJCEPlusProvider provider) throws NativeException {
+            this.prngCtx = nativeInterface.EXTRAND_create(algName);
+            provider.registerCleanable(this, ExtendedRandom.cleanOCKResources(this.prngCtx, nativeInterface));
+        }
+
+        long getCtx() {
+            return this.prngCtx;
+        }
     }
 }

--- a/src/test/java/ibm/jceplus/jmh/RandomNewInstanceBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/RandomNewInstanceBenchmark.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright IBM Corp. 2026, 2026
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class RandomNewInstanceBenchmark extends JMHBase {
+
+    @Param({"16", "2048", "32768"})
+    private int payloadSize;
+
+    private byte[] payload;
+
+    private String algorithm;
+    private String provider;
+
+    @Param({"SHA256DRBG|OpenJCEPlus", "SHA512DRBG|OpenJCEPlus", "SHA1PRNG|SUN", "DRBG|SUN"})
+    private String randomToTest;
+
+    @Setup
+    public void setup() throws Exception {
+        String[] algAndProvider = randomToTest.split("\\|");
+        algorithm = algAndProvider[0];
+        provider = algAndProvider[1];
+        super.setup(provider);
+        payload = new byte[payloadSize];
+    }
+
+    @Benchmark
+    public byte[] runSecureRandom() throws Exception {
+        SecureRandom random = SecureRandom.getInstance(algorithm, provider);
+        random.nextBytes(payload);
+        return payload;
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = RandomNewInstanceBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
The first two commits have already been reviewed. However, due to ICC_RNG_Generate() failures in the GitHub Actions build, I reverted the first two commits and added a third commit to fix the ICC_RNG_Generate() failures.

This PR includes the following changes:

Add ThreadLocal caching for native PRNG contexts used by ExtendedRandom. Each thread creates and reuses a PRNG context for supported DRBG algorithms, avoiding repeated EXTRAND_create calls when ExtendedRandom instances are created frequently.

On z/OS, ThreadLocal caching is disabled because it can cause native TCB context issues. z/OS now uses instance-specific PRNG contexts, while other platforms continue using ThreadLocal caching for performance.

Also fix ThreadLocal PRNG context ownership by resolving the current thread’s PRNGContextPointer in nextBytes() instead of storing ThreadLocal-owned native context IDs in ockPRNGContextId, which is now used only for instance-owned contexts.

This is a back port PR from PR: https://github.com/IBM/OpenJCEPlus/pull/1549