### PR TITLE
Correct JNI signatures for native methods

### DIFF
--- a/src/main/native/ock/ECKey.c
+++ b/src/main/native/ock/ECKey.c
@@ -457,7 +457,7 @@ char *getFFDHOption(int option) {
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    XECKEY_generate
- * Signature: (JLjava/lang/String;)J
+ * Signature: (JIJ)J
  */
 JNIEXPORT jlong JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_XECKEY_1generate(
@@ -1152,7 +1152,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_ECKEY_1createPriva
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    XECKEY_createPrivateKey
- * Signature: (J[B)J
+ * Signature: (J[BJ)J
  */
 JNIEXPORT jlong JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_XECKEY_1createPrivateKey(
@@ -1242,7 +1242,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_XECKEY_1createPriv
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    ECKEY_createPublicKey
- * Signature: (J[B)J
+ * Signature: (J[B[B)J
  */
 JNIEXPORT jlong JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_ECKEY_1createPublicKey(
@@ -2222,7 +2222,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_ECKEY_1computeECDH
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    XECKEY_computeECDHSecret
- * Signature: (JJJJ)[B
+ * Signature: (JJJJI)[B
  */
 JNIEXPORT jbyteArray JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_XECKEY_1computeECDHSecret(

--- a/src/main/native/ock/Poly1305Cipher.c
+++ b/src/main/native/ock/Poly1305Cipher.c
@@ -110,7 +110,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_POLY1305CIPHER_1cr
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    POLY1305CIPHER_init
- * Signature: (JJZ)V
+ * Signature: (JJI[B[B)V
  */
 JNIEXPORT void JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_POLY1305CIPHER_1init(
@@ -213,7 +213,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_POLY1305CIPHER_1cl
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    POLY1305CIPHER_setPadding
- * Signature: (JJZ)V
+ * Signature: (JJI)V
  */
 JNIEXPORT void JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_POLY1305CIPHER_1setPadding(
@@ -395,7 +395,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_POLY1305CIPHER_1ge
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    POLY1305CIPHER_encryptUpdate
- * Signature: (JJI[B[B)I
+ * Signature: (JJ[BII[BI)I
  */
 JNIEXPORT jint JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_POLY1305CIPHER_1encryptUpdate(
@@ -500,7 +500,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_POLY1305CIPHER_1en
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    POLY1305CIPHER_encryptFinal
- * Signature: (JJI[B[B)I
+ * Signature: (JJ[BII[BI[B)I
  */
 JNIEXPORT jint JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_POLY1305CIPHER_1encryptFinal(
@@ -645,7 +645,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_POLY1305CIPHER_1en
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    POLY1305CIPHER_decryptUpdate
- * Signature: (JJI[B[B)I
+ * Signature: (JJ[BII[BI)I
  */
 JNIEXPORT jint JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_POLY1305CIPHER_1decryptUpdate(
@@ -746,7 +746,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_POLY1305CIPHER_1de
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    POLY1305CIPHER_decryptFinal
- * Signature: (JJI[B[B)I
+ * Signature: (JJ[BII[BI[B)I
  */
 JNIEXPORT jint JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_POLY1305CIPHER_1decryptFinal(

--- a/src/main/native/ock/RSA.c
+++ b/src/main/native/ock/RSA.c
@@ -25,7 +25,7 @@ static int setPadding(ICC_CTX *icc_ctx, ICC_EVP_PKEY_CTX *ctx, int rsaPaddingId,
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    RSACIPHER_public_encrypt
- * Signature: (JJI[BII[BI)I
+ * Signature: (JJIII[BII[BI)I
  */
 JNIEXPORT jint JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_RSACIPHER_1public_1encrypt(
@@ -171,7 +171,7 @@ cleanup:
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    RSACIPHER_private_encrypt
- * Signature: (JJI[BII[BI)I
+ * Signature: (JJI[BII[BIZ)I
  */
 JNIEXPORT jint JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_RSACIPHER_1private_1encrypt(
@@ -399,7 +399,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_RSACIPHER_1public_
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    RSACIPHER_private_decrypt
- * Signature: (JJI[BII[BI)I
+ * Signature: (JJIII[BII[BIZ)I
  */
 JNIEXPORT jint JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_RSACIPHER_1private_1decrypt(

--- a/src/main/native/ock/RsaPss.c
+++ b/src/main/native/ock/RsaPss.c
@@ -341,7 +341,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_RSAPSS_1signFinal(
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    RSAPSS_verifyFinal
- * Signature: (JJJ)Z
+ * Signature: (JJ[BI)Z
  */
 JNIEXPORT jboolean JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_RSAPSS_1verifyFinal(

--- a/src/main/native/ock/Signature.c
+++ b/src/main/native/ock/Signature.c
@@ -22,7 +22,7 @@
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    SIGNATURE_sign
- * Signature: (JJJ)[B
+ * Signature: (JJJZ)[B
  */
 JNIEXPORT jbyteArray JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_SIGNATURE_1sign(
@@ -176,7 +176,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_SIGNATURE_1sign(
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    SIGNATURE_verify
- * Signature: (JJJ)Z
+ * Signature: (JJJ[B)Z
  */
 JNIEXPORT jboolean JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_SIGNATURE_1verify(

--- a/src/main/native/ock/SignatureRSASSL.c
+++ b/src/main/native/ock/SignatureRSASSL.c
@@ -203,7 +203,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_RSASSL_1SIGNATURE_
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    RSASSL_SIGNATURE_verify
- * Signature: (J[BJ[B)Z
+ * Signature: (J[BJ[BZ)Z
  */
 JNIEXPORT jboolean JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_RSASSL_1SIGNATURE_1verify(

--- a/src/main/native/ock/SymmetricCipher.c
+++ b/src/main/native/ock/SymmetricCipher.c
@@ -153,7 +153,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_CIPHER_1create(
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    CIPHER_init
- * Signature: (JJZ)V
+ * Signature: (JJII[B[B)V
  */
 JNIEXPORT void JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_CIPHER_1init(
@@ -263,7 +263,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_CIPHER_1init(
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    CIPHER_setPadding
- * Signature: (JJZ)V
+ * Signature: (JJI)V
  */
 JNIEXPORT void JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_CIPHER_1setPadding(
@@ -550,7 +550,7 @@ JNIEXPORT int CIPHER_encryptUpdate_internal(
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    CIPHER_encryptUpdate
- * Signature: (JJI[B[B)I
+ * Signature: (JJ[BII[BIZ)I
  */
 JNIEXPORT jint JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_CIPHER_1encryptUpdate(
@@ -689,7 +689,7 @@ JNIEXPORT int CIPHER_encryptFinal_internal(
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    CIPHER_encryptFinal
- * Signature: (JJI[B[B)I
+ * Signature: (JJ[BII[BIZ)I
  */
 JNIEXPORT jint JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_CIPHER_1encryptFinal(
@@ -796,7 +796,7 @@ JNIEXPORT int CIPHER_decryptUpdate_internal(
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    CIPHER_decryptUpdate
- * Signature: (JJI[B[B)I
+ * Signature: (JJ[BII[BIZ)I
  */
 JNIEXPORT jint JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_CIPHER_1decryptUpdate(
@@ -935,7 +935,7 @@ JNIEXPORT int CIPHER_decryptFinal_internal(
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    CIPHER_decryptFinal
- * Signature: (JJI[B[B)I
+ * Signature: (JJ[BII[BIZ)I
  */
 JNIEXPORT jint JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_CIPHER_1decryptFinal(


### PR DESCRIPTION
Some native code had incorrect or outdated signature comments that did not match the corresponding Java native method declarations. This update aligns the JNI signature comments with the Java and makes the native code easier to review, debug, and maintain.

No functional native logic is changed. This is a cleanup update to keep the JNI method signatures accurate and consistent.

This is a back-ported PR from PR: https://github.com/IBM/OpenJCEPlus/pull/1505