### PR TITLE
Support SEED, EXPANDED, BOTH PrivateKey choice for FIPS 203 and 204

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/PQCPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCPrivateKey.java
@@ -46,24 +46,43 @@ final class PQCPrivateKey extends PKCS8Key {
         this.provider = provider;
         byte[] key = null;
         DerValue pkOct = null;
-        
-        //Check to determine if the key bytes already have the Octet tag.
-        if (OctectStringEncoded(keyBytes)) {
-            //Remove encoding OctetString encoding.
-            key = Arrays.copyOfRange(keyBytes, 4, keyBytes.length);
-        } else {
-            key = keyBytes;
-        }
 
-        // Currently the ICC expects the raw keys in an OctetString
+        /*
+         * Java/PKCS#8 layer may contain a PQC private key choice:
+         *
+         *   seed      [0] IMPLICIT OCTET STRING  => 0x80
+         *   expanded  OCTET STRING               => 0x04
+         *   both      SEQUENCE                   => 0x30
+         *
+         * Keep this.privKeyMaterial as the original encoded choice when present,
+         * so getEncoded() preserves the Java-level PKCS#8 encoding.
+         *
+         * ICC still expects the raw key content wrapped in an OCTET STRING.
+         */
         try {
             try {
+                if (OctectStringEncoded(keyBytes)) {
+                    this.privKeyMaterial = Arrays.copyOf(keyBytes, keyBytes.length);
+
+                    // Remove the choice tag and DER length bytes for ICC input.
+                    key = Arrays.copyOfRange(keyBytes, getDerValueOffset(keyBytes), keyBytes.length);
+                } else {
+                    key = keyBytes;
+                }
+
+                // Currently the ICC expects the raw keys in an OctetString.
                 pkOct = new DerValue(DerValue.tag_OctetString, key);
+
                 this.pqcKey = PQCKey.createPrivateKey(
                                 this.name, pkOct.toByteArray(), provider);
-                this.privKeyMaterial = pkOct.toByteArray();
+
+                if (!(OctectStringEncoded(keyBytes))) {
+                    this.privKeyMaterial = pkOct.toByteArray();
+                }
             } finally {
-                pkOct.clear();
+                if (pkOct != null) {
+                    pkOct.clear();
+                }
             }
         } catch (Exception e) {
             throw new InvalidKeyException("Invalid key " + e.getMessage(), e);
@@ -80,7 +99,7 @@ final class PQCPrivateKey extends PKCS8Key {
             this.provider = provider;
             this.pqcKey = pqcKey;
 
-            //Check to determine if the key bytes have the Octet tag.
+            // Check to determine if the key bytes have the PQC private key choice tag.
             if (OctectStringEncoded(pqcKey.getPrivateKeyBytes())) {
                 this.privKeyMaterial = pqcKey.getPrivateKeyBytes();
             } else {
@@ -90,7 +109,9 @@ final class PQCPrivateKey extends PKCS8Key {
 
                     this.privKeyMaterial = pkOct.toByteArray();
                 } finally {
-                    pkOct.clear();
+                    if (pkOct != null) {
+                        pkOct.clear();
+                    }
                 }
             }
 
@@ -102,7 +123,7 @@ final class PQCPrivateKey extends PKCS8Key {
     }
 
     /**
-     * Create a private key from it's DER encoding (PKCS#8).
+     * Create a private key from its DER encoding (PKCS#8).
      *
      * @param encoded   the encoded PKCS#8 key
      */
@@ -112,20 +133,41 @@ final class PQCPrivateKey extends PKCS8Key {
 
         this.name = PQCKnownOIDs.findMatch(this.algid.getName()).stdName();
 
-        //Check to determine if the key bytes have the Octet tag.
-        if (!(OctectStringEncoded(this.privKeyMaterial))) {
-            DerValue pkOct = null;
-            try {
-                pkOct = new DerValue(DerValue.tag_OctetString, this.privKeyMaterial);
+        byte[] key = null;
+        DerValue pkOct = null;
 
-                this.privKeyMaterial = pkOct.toByteArray();
-            } finally {
-                pkOct.clear();
-            }
-        }
+        /*
+         * super(encoded) parses the outer PKCS#8 structure.
+         * this.privKeyMaterial is the content inside the PKCS#8 privateKey
+         * OCTET STRING.
+         *
+         */
         try {
-            this.pqcKey = PQCKey.createPrivateKey(
-                                this.name, this.privKeyMaterial, provider);
+            try {
+                if (OctectStringEncoded(this.privKeyMaterial)) {
+                    // Keep this.privKeyMaterial unchanged for getEncoded().
+                    key = Arrays.copyOfRange(
+                            this.privKeyMaterial,
+                            getDerValueOffset(this.privKeyMaterial),
+                            this.privKeyMaterial.length);
+                } else {
+                    key = this.privKeyMaterial;
+                }
+
+                // Currently the ICC expects the raw keys in an OctetString.
+                pkOct = new DerValue(DerValue.tag_OctetString, key);
+
+                if (!(OctectStringEncoded(this.privKeyMaterial))) {
+                    this.privKeyMaterial = pkOct.toByteArray();
+                }
+
+                this.pqcKey = PQCKey.createPrivateKey(
+                                this.name, pkOct.toByteArray(), provider);
+            } finally {
+                if (pkOct != null) {
+                    pkOct.clear();
+                }
+            }
         } catch (Exception e) {
             throw new InvalidKeyException("Invalid key " + e.getMessage(), e);
         }
@@ -165,10 +207,10 @@ final class PQCPrivateKey extends PKCS8Key {
             tmp.close();
             bytes.close();
         } catch (IOException ex) {
-            //System.out.println("Exception creating encoding - "+ex.getMessage());
+            //System.out.println("Exception creating encoding - " + ex.getMessage());
             return encodedKey;
         }
-        
+
         return encodedKey;
     }
 
@@ -180,7 +222,7 @@ final class PQCPrivateKey extends PKCS8Key {
     protected Object writeReplace() throws java.io.ObjectStreamException {
         checkDestroyed();
         return new JCEPlusKeyRep(JCEPlusKeyRep.Type.PRIVATE, getAlgorithm(), getFormat(), getEncoded(), provider.getName());
-    } 
+    }
 
     /**
      * Destroys this key. A call to any of its other methods after this will
@@ -213,26 +255,102 @@ final class PQCPrivateKey extends PKCS8Key {
         }
     }
 
+    /**
+     * Determines if this key is already encoded as a PQC private key choice.
+     *
+     * Supported choices:
+     *
+     *   seed      [0] IMPLICIT OCTET STRING  => 0x80
+     *   expanded  OCTET STRING               => 0x04
+     *   both      SEQUENCE                   => 0x30
+     */
     private boolean OctectStringEncoded(byte[] key) {
         try {
-            //Check and see if this is an encoded OctetString
-            if (key[0] == 0x04) {
-                //This might be encoded
-                StringBuilder sb = new StringBuilder();
-                for (int i = 2; i < 4; i++) {
-                    sb.append(String.format("%02X", key[i]));
-                }
-                String s = sb.toString();
-                int b =  Integer.parseInt(s, 16);
-                if (b == (key.length - 4)) {
-                    //This is an encoding
-                    return true;
-                }
-            } 
-            return false;
+            if (key == null || key.length < 2) {
+                return false;
+            }
+
+            int tag = key[0] & 0xFF;
+
+            if (tag != 0x80 && tag != 0x04 && tag != 0x30) {
+                return false;
+            }
+
+            return validDerLength(key);
         } catch (Exception e) {
             return false;
         }
     }
 
+    /**
+     * Check that the DER length field matches the actual value length.
+     */
+    private boolean validDerLength(byte[] key) {
+        try {
+            if (key == null || key.length < 2) {
+                return false;
+            }
+
+            int firstLenByte = key[1] & 0xFF;
+
+            if ((firstLenByte & 0x80) == 0) {
+                int contentLength = firstLenByte;
+                return contentLength == (key.length - 2);
+            }
+
+            int numLengthBytes = firstLenByte & 0x7F;
+
+            if (numLengthBytes == 0 || numLengthBytes > 4) {
+                return false;
+            }
+
+            if (key.length < 2 + numLengthBytes) {
+                return false;
+            }
+
+            int contentLength = 0;
+            for (int i = 0; i < numLengthBytes; i++) {
+                contentLength = (contentLength << 8) | (key[2 + i] & 0xFF);
+            }
+
+            int headerLength = 2 + numLengthBytes;
+
+            return contentLength == (key.length - headerLength);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Return the offset where the DER value content starts.
+     *
+     * Examples:
+     *
+     *   80 20 <seed>                    => offset 2
+     *   04 82 0A 00 <2560-byte value>   => offset 4
+     *   30 82 xx xx <sequence-content>  => offset 4
+     */
+    private int getDerValueOffset(byte[] key) {
+        int offset = 0;
+
+        // Skip tag byte.
+        offset++;
+
+        int firstLenByte = key[offset] & 0xFF;
+
+        // Skip first length byte.
+        offset++;
+
+        // seed
+        if ((firstLenByte & 0x80) == 0) {
+            return offset;
+        }
+
+        int numLengthBytes = firstLenByte & 0x7F;
+
+        // Skip the actual length bytes.
+        offset += numLengthBytes;
+
+        return offset;
+    }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeyInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeyInterop.java
@@ -16,6 +16,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.security.spec.EncodedKeySpec;
+import java.security.spec.KeySpec;
 import java.security.spec.NamedParameterSpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -737,6 +739,78 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
         
         assertArrayEquals(encapsulatedPlus.key().getEncoded(), decapKeyInterop.getEncoded(),
                 "Keys do not match for test 2 with " + parameterSet);
+    }
+
+    /**
+     * The PKCS8EncodedKeySpec is obtained from the SunJCE provider,
+     * then used by OpenJCEPlus KeyFactory.generatePrivate().
+     */
+    @ParameterizedTest
+    @CsvSource({"ML-KEM", "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+    public void testMLKEMGetKeySpecPrivateInteropToPlus(String algorithm)
+            throws Exception {
+        // This is not in the FIPS provider yet.
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+
+        // This test is for SunJCE/OpenJCEPlus interop, not BC.
+        assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName()));
+
+        doGetKeySpecPrivateInteropToPlus(
+                algorithm, getInteropProviderName(), getProviderName());
+    }
+
+    /**
+     * JCK-style getKeySpec_private interop test for ML-DSA.
+     *
+     * The PKCS8EncodedKeySpec is obtained from the SUN provider,
+     * then used by OpenJCEPlus KeyFactory.generatePrivate().
+     */
+    @ParameterizedTest
+    @CsvSource({"ML-DSA", "ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
+    public void testMLDSAGetKeySpecPrivateInteropToPlus(String algorithm)
+            throws Exception {
+        // This is not in the FIPS provider yet.
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+
+        // This test is for SunJCE/OpenJCEPlus interop, not BC.
+        assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName2()));
+
+        doGetKeySpecPrivateInteropToPlus(
+                algorithm, getInteropProviderName2(), getProviderName());
+    }
+
+    private void doGetKeySpecPrivateInteropToPlus(String algorithm,
+            String interopProviderName, String openjceplusProviderName) throws Exception {
+        /*
+         * Same intent as JCK:
+         *
+         * KeyFactory keyFactory = KeyFactory.getInstance(getAlgorithm(),providerName);
+         * KeySpec expectedPrivKeySpec = getExpectedPrivKeySpec();
+         * PrivateKey expectedPrivateKey =  keyFactory.generatePrivate(expectedPrivKeySpec);
+         * KeySpec keySpec = keyFactory.getKeySpec(expectedPrivateKey, expectedPrivKeySpec.getClass());
+         * assertEquals(expectedPrivKeySpec.getClass(),keySpec.getClass());
+         * assertKeySpec(expectedPrivKeySpec,keySpec, true);
+         */
+        KeyFactory openjceplusKeyFactory = KeyFactory.getInstance(algorithm, openjceplusProviderName);
+        KeyPairGenerator interopKpg = KeyPairGenerator.getInstance(algorithm, interopProviderName);
+        KeyPair interopKeyPair = interopKpg.generateKeyPair();
+        PrivateKey interopPrivateKey = interopKeyPair.getPrivate();
+        KeySpec interopPrivKeySpec = new PKCS8EncodedKeySpec(interopPrivateKey.getEncoded());
+        PrivateKey openjceplusPrivateKey = openjceplusKeyFactory.generatePrivate(interopPrivKeySpec);
+        KeySpec keySpec = openjceplusKeyFactory.getKeySpec(openjceplusPrivateKey, interopPrivKeySpec.getClass());
+        assertEquals(interopPrivKeySpec.getClass(), keySpec.getClass());
+        assertPrivateKeySpecEquals(interopPrivKeySpec, keySpec);
+    }
+
+    private void assertPrivateKeySpecEquals(KeySpec expected, KeySpec actual) {
+        assertEquals(PKCS8EncodedKeySpec.class, actual.getClass());
+
+        PKCS8EncodedKeySpec expectedSpec = (PKCS8EncodedKeySpec) expected;
+        PKCS8EncodedKeySpec actualSpec = (PKCS8EncodedKeySpec) actual;
+
+        assertArrayEquals(expectedSpec.getEncoded(), actualSpec.getEncoded());
+        assertEquals(expectedSpec.getAlgorithm(), actualSpec.getAlgorithm());
+        assertEquals(expectedSpec.getFormat(), actualSpec.getFormat());
     }
 
 }


### PR DESCRIPTION
Enhance PQCPrivateKey to recognize all supported PQC private key choice encodings instead of only handling DER OCTET STRING values with a fixed 4-byte header.

The previous OctectStringEncoded() logic only checked for tag 0x04 and assumed the length was encoded using two length bytes. This worked for some expanded private keys, but failed for other valid private key choices such as seed and both.

This update extends the detection logic to recognize:

- seed:     [0] IMPLICIT OCTET STRING, tag 0x80
- expanded: OCTET STRING, tag 0x04
- both:     SEQUENCE, tag 0x30

If the input is already encoded as a valid PQC private key choice, it is used directly. If no private key choice tag is present, the original behavior is preserved by wrapping the raw bytes as an OCTET STRING private key choice.

This avoids incorrectly re-wrapping seed or both encodings and prevents valid private key material from being rejected due to fixed-length header assumptions.