### PR TITLE
Add OpenJCEPlusFIPS provider to JMH benchmarks

### DIFF
--- a/JenkinsfilePerformance
+++ b/JenkinsfilePerformance
@@ -395,7 +395,7 @@ pipeline {
             Specify the performance benchmark you would like to run.')
         booleanParam(name: 'OpenJCEPlus', defaultValue: true, description: '\
             Run benchmarks with OpenJCEPlus provider')
-        booleanParam(name: 'OpenJCEPlusFIPS', defaultValue: true, description: '\
+        booleanParam(name: 'OpenJCEPlusFIPS', defaultValue: false, description: '\
             Run benchmarks with OpenJCEPlusFIPS provider')
         booleanParam(name: 'Sun', defaultValue: true, description: '\
             Run benchmarks with all Sun providers')

--- a/src/test/java/ibm/jceplus/jmh/AESCipherBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/AESCipherBenchmark.java
@@ -42,7 +42,7 @@ public class AESCipherBenchmark extends SymmetricCipherBase {
     @Param({"1024", "32768"})
     private int payloadSize;
 
-    @Param({"OpenJCEPlus", "SunJCE"})
+    @Param({"OpenJCEPlus", "OpenJCEPlusFIPS", "SunJCE"})
     private String provider;
 
     @Setup

--- a/src/test/java/ibm/jceplus/jmh/AESKeyGeneratorBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/AESKeyGeneratorBenchmark.java
@@ -32,7 +32,7 @@ import org.openjdk.jmh.runner.options.Options;
 @Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
 public class AESKeyGeneratorBenchmark extends JMHBase {
 
-    @Param({"OpenJCEPlus", "SunJCE"})
+    @Param({"OpenJCEPlus", "OpenJCEPlusFIPS", "SunJCE"})
     private String provider;
 
     private KeyGenerator aesKeyGenerator128 = null;

--- a/src/test/java/ibm/jceplus/jmh/AESWrapBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/AESWrapBenchmark.java
@@ -38,7 +38,7 @@ public class AESWrapBenchmark extends SymmetricCipherBase {
     @Param({"128", "192", "256"})
     private int keySize;
 
-    @Param({"OpenJCEPlus", "SunJCE"})
+    @Param({"OpenJCEPlus", "OpenJCEPlusFIPS", "SunJCE"})
     private String provider;
 
     private byte[] wrappedKey;

--- a/src/test/java/ibm/jceplus/jmh/DHKeyExchangeBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/DHKeyExchangeBenchmark.java
@@ -33,10 +33,10 @@ import org.openjdk.jmh.runner.options.Options;
 @Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
 public class DHKeyExchangeBenchmark extends JMHBase {
 
-    @Param({"OpenJCEPlus", "SunJCE"})
+    @Param({"OpenJCEPlus", "OpenJCEPlusFIPS", "SunJCE"})
     private String provider;
 
-    @Param({"1024", "4096"})
+    @Param({"2048", "4096"})
     private int keySize;
 
     private KeyPairGenerator dhKeyPairGenerator;

--- a/src/test/java/ibm/jceplus/jmh/DHKeyGeneratorBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/DHKeyGeneratorBenchmark.java
@@ -32,30 +32,32 @@ import org.openjdk.jmh.runner.options.Options;
 @Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
 public class DHKeyGeneratorBenchmark extends JMHBase {
 
-    @Param({"OpenJCEPlus", "SunJCE"})
+    @Param({"OpenJCEPlus", "OpenJCEPlusFIPS", "SunJCE"})
     private String provider;
 
-    private KeyPairGenerator dhKeyPairGenerator1024 = null;
-    private KeyPairGenerator dhKeyPairGenerator2048 = null;
+    @Param({"1024", "2048"})
+    private int keySize;
+
+    private KeyPairGenerator dhKeyPairGenerator = null;
 
     @Setup
     public void setup() throws Exception {
         super.setup(provider);
 
-        dhKeyPairGenerator1024 = KeyPairGenerator.getInstance("DH", provider);
-        dhKeyPairGenerator1024.initialize(1024);
-        dhKeyPairGenerator2048 = KeyPairGenerator.getInstance("DH", provider);
-        dhKeyPairGenerator2048.initialize(2048);
+        // Skip 1024-bit DH key generation for FIPS provider as it's not FIPS-approved
+        if (provider.equalsIgnoreCase("OpenJCEPlusFIPS") && keySize == 1024) {
+            throw new RuntimeException(
+                "Skipping 1024-bit DH key generation: Not FIPS-approved for " + provider
+            );
+        }
+
+        dhKeyPairGenerator = KeyPairGenerator.getInstance("DH", provider);
+        dhKeyPairGenerator.initialize(keySize);
     }
 
     @Benchmark
-    public KeyPair dh1024KeyGeneration() throws Exception {
-        return dhKeyPairGenerator1024.generateKeyPair();
-    }
-
-    @Benchmark
-    public KeyPair dh2048KeyGeneration() throws Exception {
-        return dhKeyPairGenerator2048.generateKeyPair();
+    public KeyPair dhKeyGeneration() throws Exception {
+        return dhKeyPairGenerator.generateKeyPair();
     }
 
     public static void main(String[] args) throws RunnerException {

--- a/src/test/java/ibm/jceplus/jmh/ECDHKeyExchangeBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/ECDHKeyExchangeBenchmark.java
@@ -34,7 +34,7 @@ import org.openjdk.jmh.runner.options.Options;
 @Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
 public class ECDHKeyExchangeBenchmark extends JMHBase {
 
-    @Param({"OpenJCEPlus", "SunEC"})
+    @Param({"OpenJCEPlus", "OpenJCEPlusFIPS", "SunEC"})
     private String provider;
 
     @Param({"secp256r1", "secp384r1", "secp521r1"})

--- a/src/test/java/ibm/jceplus/jmh/ECKeyGeneratorBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/ECKeyGeneratorBenchmark.java
@@ -33,7 +33,7 @@ import org.openjdk.jmh.runner.options.Options;
 @Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
 public class ECKeyGeneratorBenchmark extends JMHBase {
 
-    @Param({"OpenJCEPlus", "SunEC"})
+    @Param({"OpenJCEPlus", "OpenJCEPlusFIPS", "SunEC"})
     private String provider;
 
     private KeyPairGenerator ecKeyPairGeneratorP256 = null;

--- a/src/test/java/ibm/jceplus/jmh/ECSignatureBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/ECSignatureBenchmark.java
@@ -37,7 +37,7 @@ public class ECSignatureBenchmark extends JMHBase {
     @Param({"2048", "32768"})
     private int payloadSize;
 
-    @Param({"OpenJCEPlus", "SunEC"})
+    @Param({"OpenJCEPlus", "OpenJCEPlusFIPS", "SunEC"})
     private String provider;
 
     /**
@@ -46,34 +46,20 @@ public class ECSignatureBenchmark extends JMHBase {
     @Param({"256", "521"})
     private int keySize;
 
+    /**
+     * Signature algorithms to benchmark.
+     * Non-FIPS compliant algorithms (SHA1withECDSA, SHA224withECDSA, SHA3-224withECDSA)
+     * will be skipped when provider is OpenJCEPlusFIPS.
+     */
+    @Param({"SHA1withECDSA", "SHA224withECDSA", "SHA256withECDSA", "SHA512withECDSA",
+            "SHA3-224withECDSA", "SHA3-256withECDSA", "SHA3-384withECDSA", "SHA3-512withECDSA"})
+    private String algorithm;
+
     private KeyPairGenerator ecKeyPairGenerator;
-    private Signature ecSha1SignatureInstance;
-    private Signature ecSha224SignatureInstance;
-    private Signature ecSha256SignatureInstance;
-    private Signature ecSha512SignatureInstance;
-    private Signature ecSha3_224SignatureInstance;
-    private Signature ecSha3_256SignatureInstance;
-    private Signature ecSha3_384SignatureInstance;
-    private Signature ecSha3_512SignatureInstance;
-
-    private Signature ecSha1VerifierInstance;
-    private Signature ecSha224VerifierInstance;
-    private Signature ecSha256VerifierInstance;
-    private Signature ecSha512VerifierInstance;
-    private Signature ecSha3_224VerifierInstance;
-    private Signature ecSha3_256VerifierInstance;
-    private Signature ecSha3_384VerifierInstance;
-    private Signature ecSha3_512VerifierInstance;
-
+    private Signature signatureInstance;
+    private Signature verifierInstance;
     private KeyPair ecKeyPair;
-    private byte[] ecSha1Signature;
-    private byte[] ecSha224Signature;
-    private byte[] ecSha256Signature;
-    private byte[] ecSha512Signature;
-    private byte[] ecSha3_224Signature;
-    private byte[] ecSha3_256Signature;
-    private byte[] ecSha3_384Signature;
-    private byte[] ecSha3_512Signature;
+    private byte[] signature;
     private byte[] payload;
     private SecureRandom random = new SecureRandom();
 
@@ -81,170 +67,46 @@ public class ECSignatureBenchmark extends JMHBase {
     public void setup() throws Exception {
         super.setup(provider);
 
+        // Skip non-FIPS compliant algorithms when using OpenJCEPlusFIPS provider
+        if (provider.equalsIgnoreCase("OpenJCEPlusFIPS") &&
+            (algorithm.equals("SHA1withECDSA") || 
+             algorithm.equals("SHA224withECDSA") ||
+             algorithm.equals("SHA3-224withECDSA") ||
+             algorithm.equals("SHA3-2564withECDSA") ||
+             algorithm.equals("SHA3-384withECDSA") ||
+             algorithm.equals("SHA3-512withECDSA"))) {
+            throw new RunnerException("Skipping " + algorithm + " for FIPS provider");
+        }
+
         ecKeyPairGenerator = KeyPairGenerator.getInstance("EC", provider);
         ecKeyPairGenerator.initialize(keySize);
 
-        ecSha1SignatureInstance = Signature.getInstance("SHA1withECDSA", provider);
-        ecSha224SignatureInstance = Signature.getInstance("SHA224withECDSA", provider);
-        ecSha256SignatureInstance = Signature.getInstance("SHA256withECDSA", provider);
-        ecSha512SignatureInstance = Signature.getInstance("SHA512withECDSA", provider);
-        ecSha3_224SignatureInstance = Signature.getInstance("SHA3-224withECDSA", provider);
-        ecSha3_256SignatureInstance = Signature.getInstance("SHA3-256withECDSA", provider);
-        ecSha3_384SignatureInstance = Signature.getInstance("SHA3-384withECDSA", provider);
-        ecSha3_512SignatureInstance = Signature.getInstance("SHA3-512withECDSA", provider);
-
-        ecSha1VerifierInstance = Signature.getInstance("SHA1withECDSA", provider);
-        ecSha224VerifierInstance = Signature.getInstance("SHA224withECDSA", provider);
-        ecSha256VerifierInstance = Signature.getInstance("SHA256withECDSA", provider);
-        ecSha512VerifierInstance = Signature.getInstance("SHA512withECDSA", provider);
-        ecSha3_224VerifierInstance = Signature.getInstance("SHA3-224withECDSA", provider);
-        ecSha3_256VerifierInstance = Signature.getInstance("SHA3-256withECDSA", provider);
-        ecSha3_384VerifierInstance = Signature.getInstance("SHA3-384withECDSA", provider);
-        ecSha3_512VerifierInstance = Signature.getInstance("SHA3-512withECDSA", provider);
+        signatureInstance = Signature.getInstance(algorithm, provider);
+        verifierInstance = Signature.getInstance(algorithm, provider);
 
         ecKeyPair = ecKeyPairGenerator.generateKeyPair();
 
-        ecSha1SignatureInstance.initSign(ecKeyPair.getPrivate());
-        ecSha224SignatureInstance.initSign(ecKeyPair.getPrivate());
-        ecSha256SignatureInstance.initSign(ecKeyPair.getPrivate());
-        ecSha512SignatureInstance.initSign(ecKeyPair.getPrivate());
-        ecSha3_224SignatureInstance.initSign(ecKeyPair.getPrivate());
-        ecSha3_256SignatureInstance.initSign(ecKeyPair.getPrivate());
-        ecSha3_384SignatureInstance.initSign(ecKeyPair.getPrivate());
-        ecSha3_512SignatureInstance.initSign(ecKeyPair.getPrivate());
+        signatureInstance.initSign(ecKeyPair.getPrivate());
 
         payload = new byte[payloadSize];
         random.nextBytes(payload);
 
-        ecSha1SignatureInstance.update(payload);
-        ecSha224SignatureInstance.update(payload);
-        ecSha256SignatureInstance.update(payload);
-        ecSha512SignatureInstance.update(payload);
-        ecSha3_224SignatureInstance.update(payload);
-        ecSha3_256SignatureInstance.update(payload);
-        ecSha3_384SignatureInstance.update(payload);
-        ecSha3_512SignatureInstance.update(payload);
-
-        ecSha1Signature = ecSha1SignatureInstance.sign();
-        ecSha224Signature = ecSha224SignatureInstance.sign();
-        ecSha256Signature = ecSha256SignatureInstance.sign();
-        ecSha512Signature = ecSha512SignatureInstance.sign();
-        ecSha3_224Signature = ecSha3_224SignatureInstance.sign();
-        ecSha3_256Signature = ecSha3_256SignatureInstance.sign();
-        ecSha3_384Signature = ecSha3_384SignatureInstance.sign();
-        ecSha3_512Signature = ecSha3_512SignatureInstance.sign();
+        signatureInstance.update(payload);
+        signature = signatureInstance.sign();
     }
 
     @Benchmark
-    public byte[] ecSha1Sign() throws Exception {
-        ecSha1SignatureInstance.initSign(ecKeyPair.getPrivate());
-        ecSha1SignatureInstance.update(payload);
-        return ecSha1SignatureInstance.sign();
+    public byte[] sign() throws Exception {
+        signatureInstance.initSign(ecKeyPair.getPrivate());
+        signatureInstance.update(payload);
+        return signatureInstance.sign();
     }
 
     @Benchmark
-    public byte[] ecSha224Sign() throws Exception {
-        ecSha224SignatureInstance.initSign(ecKeyPair.getPrivate());
-        ecSha224SignatureInstance.update(payload);
-        return ecSha224SignatureInstance.sign();
-    }
-
-    @Benchmark
-    public byte[] ecSha256Sign() throws Exception {
-        ecSha256SignatureInstance.initSign(ecKeyPair.getPrivate());
-        ecSha256SignatureInstance.update(payload);
-        return ecSha256SignatureInstance.sign();
-    }
-
-    @Benchmark
-    public byte[] ecSha512Sign() throws Exception {
-        ecSha512SignatureInstance.initSign(ecKeyPair.getPrivate());
-        ecSha512SignatureInstance.update(payload);
-        return ecSha512SignatureInstance.sign();
-    }
-
-    @Benchmark
-    public byte[] ecSha3_224Sign() throws Exception {
-        ecSha3_224SignatureInstance.initSign(ecKeyPair.getPrivate());
-        ecSha3_224SignatureInstance.update(payload);
-        return ecSha3_224SignatureInstance.sign();
-    }
-
-    @Benchmark
-    public byte[] ecSha3_256Sign() throws Exception {
-        ecSha3_256SignatureInstance.initSign(ecKeyPair.getPrivate());
-        ecSha3_256SignatureInstance.update(payload);
-        return ecSha3_256SignatureInstance.sign();
-    }
-
-    @Benchmark
-    public byte[] ecSha3_384Sign() throws Exception {
-        ecSha3_384SignatureInstance.initSign(ecKeyPair.getPrivate());
-        ecSha3_384SignatureInstance.update(payload);
-        return ecSha3_384SignatureInstance.sign();
-    }
-
-    @Benchmark
-    public byte[] ecSha3_512Sign() throws Exception {
-        ecSha3_512SignatureInstance.initSign(ecKeyPair.getPrivate());
-        ecSha3_512SignatureInstance.update(payload);
-        return ecSha3_512SignatureInstance.sign();
-    }
-
-    @Benchmark
-    public boolean ecSha1Verify() throws Exception {
-        ecSha1VerifierInstance.initVerify(ecKeyPair.getPublic());
-        ecSha1VerifierInstance.update(payload);
-        return ecSha1VerifierInstance.verify(ecSha1Signature);
-    }
-
-    @Benchmark
-    public boolean ecSha224Verify() throws Exception {
-        ecSha224VerifierInstance.initVerify(ecKeyPair.getPublic());
-        ecSha224VerifierInstance.update(payload);
-        return ecSha224VerifierInstance.verify(ecSha224Signature);
-    }
-
-    @Benchmark
-    public boolean ecSha256Verify() throws Exception {
-        ecSha256VerifierInstance.initVerify(ecKeyPair.getPublic());
-        ecSha256VerifierInstance.update(payload);
-        return ecSha256VerifierInstance.verify(ecSha256Signature);
-    }
-
-    @Benchmark
-    public boolean ecSha512Verify() throws Exception {
-        ecSha512VerifierInstance.initVerify(ecKeyPair.getPublic());
-        ecSha512VerifierInstance.update(payload);
-        return ecSha512VerifierInstance.verify(ecSha512Signature);
-    }
-
-    @Benchmark
-    public boolean ecSha3_224Verify() throws Exception {
-        ecSha3_224VerifierInstance.initVerify(ecKeyPair.getPublic());
-        ecSha3_224VerifierInstance.update(payload);
-        return ecSha3_224VerifierInstance.verify(ecSha3_224Signature);
-    }
-
-    @Benchmark
-    public boolean ecSha3_256Verify() throws Exception {
-        ecSha3_256VerifierInstance.initVerify(ecKeyPair.getPublic());
-        ecSha3_256VerifierInstance.update(payload);
-        return ecSha3_256VerifierInstance.verify(ecSha3_256Signature);
-    }
-
-    @Benchmark
-    public boolean ecSha3_384Verify() throws Exception {
-        ecSha3_384VerifierInstance.initVerify(ecKeyPair.getPublic());
-        ecSha3_384VerifierInstance.update(payload);
-        return ecSha3_384VerifierInstance.verify(ecSha3_384Signature);
-    }
-
-    @Benchmark
-    public boolean ecSha3_512Verify() throws Exception {
-        ecSha3_512VerifierInstance.initVerify(ecKeyPair.getPublic());
-        ecSha3_512VerifierInstance.update(payload);
-        return ecSha3_512VerifierInstance.verify(ecSha3_512Signature);
+    public boolean verify() throws Exception {
+        verifierInstance.initVerify(ecKeyPair.getPublic());
+        verifierInstance.update(payload);
+        return verifierInstance.verify(signature);
     }
 
     public static void main(String[] args) throws RunnerException {

--- a/src/test/java/ibm/jceplus/jmh/HMACKeyGeneratorBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/HMACKeyGeneratorBenchmark.java
@@ -32,42 +32,33 @@ import org.openjdk.jmh.runner.options.Options;
 @Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
 public class HMACKeyGeneratorBenchmark extends JMHBase {
 
-    @Param({"OpenJCEPlus", "SunJCE"})
+    @Param({"OpenJCEPlus", "OpenJCEPlusFIPS", "SunJCE"})
     private String provider;
 
-    private KeyGenerator hmacSha1KeyGenerator = null;
-    private KeyGenerator hmacSha256KeyGenerator = null;
-    private KeyGenerator hmacSha384KeyGenerator = null;
-    private KeyGenerator hmacSha512KeyGenerator = null;
+    /**
+     * HMAC algorithms for key generation.
+     * Non-FIPS compliant algorithm (HmacSHA1) will be skipped when provider is OpenJCEPlusFIPS.
+     */
+    @Param({"HmacSHA1", "HmacSHA256", "HmacSHA384", "HmacSHA512"})
+    private String algorithm;
+
+    private KeyGenerator keyGenerator;
 
     @Setup
     public void setup() throws Exception {
         super.setup(provider);
 
-        hmacSha1KeyGenerator = KeyGenerator.getInstance("HmacSHA1", provider);
-        hmacSha256KeyGenerator = KeyGenerator.getInstance("HmacSHA256", provider);
-        hmacSha384KeyGenerator = KeyGenerator.getInstance("HmacSHA384", provider);
-        hmacSha512KeyGenerator = KeyGenerator.getInstance("HmacSHA512", provider);
+        // Skip non-FIPS compliant algorithms when using OpenJCEPlusFIPS provider
+        if (provider.equalsIgnoreCase("OpenJCEPlusFIPS") && algorithm.equals("HmacSHA1")) {
+            throw new RunnerException("Skipping HmacSHA1 for FIPS provider");
+        }
+
+        keyGenerator = KeyGenerator.getInstance(algorithm, provider);
     }
 
     @Benchmark
-    public SecretKey hmacSha1KeyGeneration() throws Exception {
-        return hmacSha1KeyGenerator.generateKey();
-    }
-
-    @Benchmark
-    public SecretKey hmacSha256KeyGeneration() throws Exception {
-        return hmacSha256KeyGenerator.generateKey();
-    }
-
-    @Benchmark
-    public SecretKey hmacSha384KeyGeneration() throws Exception {
-        return hmacSha384KeyGenerator.generateKey();
-    }
-
-    @Benchmark
-    public SecretKey hmacSha512KeyGeneration() throws Exception {
-        return hmacSha512KeyGenerator.generateKey();
+    public SecretKey keyGeneration() {
+        return keyGenerator.generateKey();
     }
 
     public static void main(String[] args) throws RunnerException {

--- a/src/test/java/ibm/jceplus/jmh/HmacBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/HmacBenchmark.java
@@ -42,7 +42,7 @@ public class HmacBenchmark extends JMHBase {
     @Param({"16", "2048", "32768"})
     private int payloadSize;
 
-    @Param({"OpenJCEPlus", "SunJCE"})
+    @Param({"OpenJCEPlus", "OpenJCEPlusFIPS", "SunJCE"})
     private String provider;
 
     private Mac mac;
@@ -53,6 +53,12 @@ public class HmacBenchmark extends JMHBase {
     @Setup(Level.Trial)
     public void setup() throws Exception {
         super.setup(provider);
+
+        // Skip non-FIPS compliant algorithms when using OpenJCEPlusFIPS provider
+        if (provider.equalsIgnoreCase("OpenJCEPlusFIPS")
+                && transformation.equalsIgnoreCase("HMACSHA1")) {
+            throw new RunnerException("Skipping HMACSHA1 for FIPS provider");
+        }
 
         KeyGenerator kg = KeyGenerator.getInstance("AES");
         kg.init(256);

--- a/src/test/java/ibm/jceplus/jmh/JMHBase.java
+++ b/src/test/java/ibm/jceplus/jmh/JMHBase.java
@@ -80,7 +80,7 @@ abstract public class JMHBase {
         if (!(isPpc64le && isLinux)) {
             optionsBuilder.addProfiler(CompilerProfiler.class);
         }
-        List<String> jvmArgs = new ArrayList<>(Arrays.asList("-Xms1G", "-Xmx1G", "--patch-module",
+        List<String> jvmArgs = new ArrayList<>(Arrays.asList("-Xms2G", "-Xmx2G", "--patch-module",
                 "openjceplus=" + projectHomeDir + "/target/classes",
                 "--add-exports=java.base/sun.security.util=ALL-UNNAMED",
                 "--add-exports=java.base/sun.security.pkcs=ALL-UNNAMED",

--- a/src/test/java/ibm/jceplus/jmh/MessageDigestBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/MessageDigestBenchmark.java
@@ -35,7 +35,7 @@ public class MessageDigestBenchmark extends JMHBase {
     @Param({"16", "2048", "32768"})
     private int payloadSize;
 
-    @Param({"OpenJCEPlus", "SUN"})
+    @Param({"OpenJCEPlus", "OpenJCEPlusFIPS", "SUN"})
     private String provider;
 
     private MessageDigest messageDigestSHA512;

--- a/src/test/java/ibm/jceplus/jmh/MessageDigestInstanceBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/MessageDigestInstanceBenchmark.java
@@ -35,7 +35,7 @@ public class MessageDigestInstanceBenchmark extends JMHBase {
     @Param({"1"})
     private int payloadSize;
 
-    @Param({"OpenJCEPlus", "SUN"})
+    @Param({"OpenJCEPlus", "OpenJCEPlusFIPS", "SUN"})
     private String provider;
 
     private MessageDigest messageDigestSHA512;

--- a/src/test/java/ibm/jceplus/jmh/PBKDF2Benchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/PBKDF2Benchmark.java
@@ -33,88 +33,51 @@ import org.openjdk.jmh.runner.options.Options;
 @Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
 public class PBKDF2Benchmark extends JMHBase {
-    private SecretKeyFactory pbkdf2Sha1Factory;
-    private SecretKeyFactory pbkdf2Sha256Factory;
-    private SecretKeyFactory pbkdf2Sha512Factory;
-    private SecretKeyFactory pbkdf2Sha512_224Factory;
-    private SecretKeyFactory pbkdf2Sha512_256Factory;
+
+    @Param({"OpenJCEPlus", "OpenJCEPlusFIPS", "SunJCE"})
+    private String provider;
+
+    /**
+     * PBKDF2 algorithms to benchmark.
+     * Non-FIPS compliant algorithms (PBKDF2WithHmacSHA1, PBKDF2WithHmacSHA512/224, PBKDF2WithHmacSHA512/256)
+     * will be skipped when provider is OpenJCEPlusFIPS.
+     */
+    @Param({"PBKDF2WithHmacSHA1", "PBKDF2WithHmacSHA256", "PBKDF2WithHmacSHA512",
+            "PBKDF2WithHmacSHA512/224", "PBKDF2WithHmacSHA512/256"})
+    private String algorithm;
+
+    /**
+     * Iteration counts for PBKDF2.
+     */
+    @Param({"1000", "300000"})
+    private int iterations;
+
+    private SecretKeyFactory factory;
     private char[] password;
     private byte[] salt = new byte[16];
     private SecureRandom random = new SecureRandom();
-
-    @Param({"OpenJCEPlus", "SunJCE"})
-    private String provider;
 
     @Setup
     public void setup() throws Exception {
         super.setup(provider);
 
-        pbkdf2Sha1Factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1", provider);
-        pbkdf2Sha256Factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256", provider);
-        pbkdf2Sha512Factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA512", provider);
-        pbkdf2Sha512_224Factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA512/224", provider);
-        pbkdf2Sha512_256Factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA512/256", provider);
+        // Skip non-FIPS compliant algorithms when using OpenJCEPlusFIPS provider
+        if (provider.equalsIgnoreCase("OpenJCEPlusFIPS") &&
+            (algorithm.equals("PBKDF2WithHmacSHA1") ||
+             algorithm.equals("PBKDF2WithHmacSHA512/224") ||
+             algorithm.equals("PBKDF2WithHmacSHA512/256"))) {
+            throw new RunnerException("Skipping " + algorithm + " for FIPS provider");
+        }
+
+        factory = SecretKeyFactory.getInstance(algorithm, provider);
+
         password = "lazydogjumpedoverthemoon".toCharArray();
         random.nextBytes(salt);
     }
 
     @Benchmark
-    public byte[] pbkdf2Sha11000Iter() throws InvalidKeySpecException {
-        return pbkdf2Sha1Factory.generateSecret(new PBEKeySpec(password, salt, 1000, 256))
-                .getEncoded();
-    }
-
-    @Benchmark
-    public byte[] pbkdf2Sha1300000Iter() throws InvalidKeySpecException {
-        return pbkdf2Sha1Factory.generateSecret(new PBEKeySpec(password, salt, 300000, 256))
-                .getEncoded();
-    }
-
-    @Benchmark
-    public byte[] pbkdf2Sha2561000Iter() throws InvalidKeySpecException {
-        return pbkdf2Sha256Factory.generateSecret(new PBEKeySpec(password, salt, 1000, 256))
-                .getEncoded();
-    }
-
-    @Benchmark
-    public byte[] pbkdf2Sha256300000Iter() throws InvalidKeySpecException {
-        return pbkdf2Sha256Factory.generateSecret(new PBEKeySpec(password, salt, 300000, 256))
-                .getEncoded();
-    }
-
-    @Benchmark
-    public byte[] pbkdf2Sha5121000Iter() throws InvalidKeySpecException {
-        return pbkdf2Sha512Factory.generateSecret(new PBEKeySpec(password, salt, 1000, 256))
-                .getEncoded();
-    }
-
-    @Benchmark
-    public byte[] pbkdf2Sha512300000Iter() throws InvalidKeySpecException {
-        return pbkdf2Sha512Factory.generateSecret(new PBEKeySpec(password, salt, 300000, 256))
-                .getEncoded();
-    }
-
-    @Benchmark
-    public byte[] pbkdf2Sha512_2241000Iter() throws InvalidKeySpecException {
-        return pbkdf2Sha512_224Factory.generateSecret(new PBEKeySpec(password, salt, 1000, 256))
-                .getEncoded();
-    }
-
-    @Benchmark
-    public byte[] pbkdf2Sha512_224300000Iter() throws InvalidKeySpecException {
-        return pbkdf2Sha512_224Factory.generateSecret(new PBEKeySpec(password, salt, 300000, 256))
-                .getEncoded();
-    }
-
-    @Benchmark
-    public byte[] pbkdf2Sha512_2561000Iter() throws InvalidKeySpecException {
-        return pbkdf2Sha512_256Factory.generateSecret(new PBEKeySpec(password, salt, 1000, 256))
-                .getEncoded();
-    }
-
-    @Benchmark
-    public byte[] pbkdf2Sha512_256300000Iter() throws InvalidKeySpecException {
-        return pbkdf2Sha512_256Factory.generateSecret(new PBEKeySpec(password, salt, 300000, 256))
+    public byte[] pbkdf2() throws InvalidKeySpecException {
+        return factory.generateSecret(new PBEKeySpec(password, salt, iterations, 256))
                 .getEncoded();
     }
 

--- a/src/test/java/ibm/jceplus/jmh/RSACipherBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/RSACipherBenchmark.java
@@ -8,11 +8,11 @@
 
 package ibm.jceplus.jmh;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
+import java.security.spec.MGF1ParameterSpec;
 import java.util.concurrent.TimeUnit;
 import javax.crypto.Cipher;
+import javax.crypto.spec.OAEPParameterSpec;
+import javax.crypto.spec.PSource;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
@@ -34,111 +34,118 @@ import org.openjdk.jmh.runner.options.Options;
 @Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
 public class RSACipherBenchmark extends AsymmetricCipherBase {
 
-    private Map<String, Cipher> encryptCiphers = new HashMap<>();
-    private Map<String, Cipher> decryptCiphers = new HashMap<>();
-
-    private Map<String, byte[]> plaintexts = new HashMap<>();
-    private Map<String, byte[]> ciphertexts = new HashMap<>();
-
     @Param({"2048"})
     private int keySize;
 
-    @Param({"OpenJCEPlus", "SunJCE"})
+    @Param({"OpenJCEPlus", "OpenJCEPlusFIPS", "SunJCE"})
     private String provider;
+
+    /**
+     * RSA padding modes to benchmark.
+     * Non-FIPS compliant paddings (NoPadding, PKCS1Padding, OAEPPadding with SHA-1) will be skipped when provider is OpenJCEPlusFIPS.
+     */
+    @Param({"NoPadding", "PKCS1Padding", "OAEPPadding", "OAEPWithSHA-256AndMGF1Padding",
+            "OAEPWithSHA-512AndMGF1Padding", "OAEPWithSHA-512/224AndMGF1Padding"})
+    private String padding;
+
+    private Cipher encryptCipher;
+    private Cipher decryptCipher;
+    private byte[] plaintext;
+    private byte[] ciphertext;
+    private OAEPParameterSpec oaepSpec;
 
     @Setup
     public void setup() throws Exception {
         super.setup(keySize, "RSA", provider);
 
-        Map<String, Integer> paddings = new HashMap<>();
-        paddings.put("NoPadding", 1);
-        paddings.put("PKCS1Padding", 11);
-        paddings.put("OAEPPadding", (2 * 20 + 2)); // SHA-1 size is 20 bytes
-        paddings.put("OAEPWithSHA-256AndMGF1Padding", (2 * 32 + 2)); // SHA-256 size is 32 bytes
-        paddings.put("OAEPWithSHA-512AndMGF1Padding", (2 * 64 + 2)); // SHA-512 size is 64 bytes
-        paddings.put("OAEPWithSHA-512/224AndMGF1Padding", (2 * 28 + 2)); // SHA-512/224 size is 28 bytes
-
-        for (String padding : paddings.keySet()) {
-            encryptCiphers.put(padding, Cipher.getInstance("RSA/ECB/" + padding, provider));
-            decryptCiphers.put(padding, Cipher.getInstance("RSA/ECB/" + padding, provider));
+        boolean isFIPS = provider.equalsIgnoreCase("OpenJCEPlusFIPS");
+        
+        // Skip non-FIPS compliant paddings when using OpenJCEPlusFIPS provider
+        if (isFIPS && (padding.equals("NoPadding") || padding.equals("PKCS1Padding") || padding.equals("OAEPPadding"))) {
+            throw new RunnerException("Skipping " + padding + " for FIPS provider (not FIPS compliant)");
         }
 
-        for (Entry<String, Integer> entry : paddings.entrySet()) {
-            int payloadSize = (keySize / 8) - entry.getValue();
-            byte[] plaintext = new byte[payloadSize];
-            random.nextBytes(plaintext);
-            plaintexts.put(entry.getKey(), plaintext);
+        // Determine hash algorithm and MGF1 spec for OAEP padding
+        String hashAlg = null;
+        String mgf1Alg = null;
+        int paddingOverhead;
+        switch (padding) {
+            case "NoPadding":
+                paddingOverhead = 1;
+                break;
+            case "PKCS1Padding":
+                paddingOverhead = 11;
+                break;
+            case "OAEPPadding":
+                // Default OAEP uses SHA-1, which is not FIPS compliant
+                hashAlg = "SHA-1";
+                mgf1Alg = "SHA-1";
+                paddingOverhead = (2 * 20 + 2); // SHA-1 size is 20 bytes
+                break;
+            case "OAEPWithSHA-256AndMGF1Padding":
+                hashAlg = "SHA-256";
+                mgf1Alg = "SHA-256";
+                paddingOverhead = (2 * 32 + 2); // SHA-256 size is 32 bytes
+                break;
+            case "OAEPWithSHA-512AndMGF1Padding":
+                hashAlg = "SHA-512";
+                mgf1Alg = "SHA-512";
+                paddingOverhead = (2 * 64 + 2); // SHA-512 size is 64 bytes
+                break;
+            case "OAEPWithSHA-512/224AndMGF1Padding":
+                hashAlg = "SHA-512/224";
+                mgf1Alg = "SHA-512/224";
+                paddingOverhead = (2 * 28 + 2); // SHA-512/224 size is 28 bytes
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown padding: " + padding);
+        }
 
-            Cipher ec = encryptCiphers.get(entry.getKey());
-            ec.init(Cipher.ENCRYPT_MODE, publicKey);
+        // Create OAEPParameterSpec for OAEP paddings
+        if (hashAlg != null) {
+            oaepSpec = new OAEPParameterSpec(
+                hashAlg,
+                "MGF1",
+                new MGF1ParameterSpec(mgf1Alg),
+                PSource.PSpecified.DEFAULT
+            );
+        }
 
-            if (plaintext.length > 0) {
-                ciphertexts.put(entry.getKey(), ec.doFinal(plaintext));
-            }
+        encryptCipher = Cipher.getInstance("RSA/ECB/" + padding, provider);
+        decryptCipher = Cipher.getInstance("RSA/ECB/" + padding, provider);
 
-            Cipher dc = decryptCiphers.get(entry.getKey());
-            dc.init(Cipher.DECRYPT_MODE, privateKey);
+        int payloadSize = (keySize / 8) - paddingOverhead;
+        plaintext = new byte[payloadSize];
+        random.nextBytes(plaintext);
+
+        // Initialize ciphers with appropriate parameters
+        if (oaepSpec != null) {
+            // For OAEP padding, use explicit parameters (required for FIPS)
+            encryptCipher.init(Cipher.ENCRYPT_MODE, publicKey, oaepSpec);
+        } else {
+            // For non-OAEP padding, no parameters needed
+            encryptCipher.init(Cipher.ENCRYPT_MODE, publicKey);
+        }
+        
+        if (plaintext.length > 0) {
+            ciphertext = encryptCipher.doFinal(plaintext);
+        }
+
+        if (oaepSpec != null) {
+            decryptCipher.init(Cipher.DECRYPT_MODE, privateKey, oaepSpec);
+        } else {
+            decryptCipher.init(Cipher.DECRYPT_MODE, privateKey);
         }
     }
 
     @Benchmark
-    public byte[] benchmarkEncryption_NoPadding() throws Exception {
-        return encryptCiphers.get("NoPadding").doFinal(plaintexts.get("NoPadding"));
+    public byte[] encrypt() throws Exception {
+        return encryptCipher.doFinal(plaintext);
     }
 
     @Benchmark
-    public byte[] benchmarkDecryption_NoPadding() throws Exception {
-        return decryptCiphers.get("NoPadding").doFinal(ciphertexts.get("NoPadding"));
-    }
-
-    @Benchmark
-    public byte[] benchmarkEncryption_PKCS1Padding() throws Exception {
-        return encryptCiphers.get("PKCS1Padding").doFinal(plaintexts.get("PKCS1Padding"));
-    }
-
-    @Benchmark
-    public byte[] benchmarkDecryption_PKCS1Padding() throws Exception {
-        return decryptCiphers.get("PKCS1Padding").doFinal(ciphertexts.get("PKCS1Padding"));
-    }
-
-    @Benchmark
-    public byte[] benchmarkEncryption_OAEPPadding() throws Exception {
-        return encryptCiphers.get("OAEPPadding").doFinal(plaintexts.get("OAEPPadding"));
-    }
-
-    @Benchmark
-    public byte[] benchmarkDecryption_OAEPPadding() throws Exception {
-        return decryptCiphers.get("OAEPPadding").doFinal(ciphertexts.get("OAEPPadding"));
-    }
-
-    @Benchmark
-    public byte[] benchmarkEncryption_OAEPWithSHA256AndMGF1Padding() throws Exception {
-        return encryptCiphers.get("OAEPWithSHA-256AndMGF1Padding").doFinal(plaintexts.get("OAEPWithSHA-256AndMGF1Padding"));
-    }
-
-    @Benchmark
-    public byte[] benchmarkDecryption_OAEPWithSHA256AndMGF1Padding() throws Exception {
-        return decryptCiphers.get("OAEPWithSHA-256AndMGF1Padding").doFinal(ciphertexts.get("OAEPWithSHA-256AndMGF1Padding"));
-    }
-
-    @Benchmark
-    public byte[] benchmarkEncryption_OAEPWithSHA512AndMGF1Padding() throws Exception {
-        return encryptCiphers.get("OAEPWithSHA-512AndMGF1Padding").doFinal(plaintexts.get("OAEPWithSHA-512AndMGF1Padding"));
-    }
-
-    @Benchmark
-    public byte[] benchmarkDecryption_OAEPWithSHA512AndMGF1Padding() throws Exception {
-        return decryptCiphers.get("OAEPWithSHA-512AndMGF1Padding").doFinal(ciphertexts.get("OAEPWithSHA-512AndMGF1Padding"));
-    }
-
-    @Benchmark
-    public byte[] benchmarkEncryption_OAEPWithSHA512_224AndMGF1Padding() throws Exception {
-        return encryptCiphers.get("OAEPWithSHA-512/224AndMGF1Padding").doFinal(plaintexts.get("OAEPWithSHA-512/224AndMGF1Padding"));
-    }
-
-    @Benchmark
-    public byte[] benchmarkDecryption_OAEPWithSHA512_224AndMGF1Padding() throws Exception {
-        return decryptCiphers.get("OAEPWithSHA-512/224AndMGF1Padding").doFinal(ciphertexts.get("OAEPWithSHA-512/224AndMGF1Padding"));
+    public byte[] decrypt() throws Exception {
+        return decryptCipher.doFinal(ciphertext);
     }
 
     public static void main(String[] args) throws RunnerException {

--- a/src/test/java/ibm/jceplus/jmh/RSAKeyGeneratorBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/RSAKeyGeneratorBenchmark.java
@@ -32,38 +32,32 @@ import org.openjdk.jmh.runner.options.Options;
 @Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
 public class RSAKeyGeneratorBenchmark extends JMHBase {
 
-    @Param({"OpenJCEPlus", "SunRsaSign"})
+    @Param({"OpenJCEPlus", "OpenJCEPlusFIPS", "SunRsaSign"})
     private String provider;
 
-    private KeyPairGenerator rsaKeyPairGenerator1024 = null;
-    private KeyPairGenerator rsaKeyPairGenerator2048 = null;
-    private KeyPairGenerator rsaKeyPairGenerator4096 = null;
+    @Param({"1024", "2048", "4096"})
+    private int keySize;
+
+    private KeyPairGenerator rsaKeyPairGenerator = null;
 
     @Setup
     public void setup() throws Exception {
         super.setup(provider);
 
-        rsaKeyPairGenerator1024 = KeyPairGenerator.getInstance("RSA", provider);
-        rsaKeyPairGenerator1024.initialize(1024);
-        rsaKeyPairGenerator2048 = KeyPairGenerator.getInstance("RSA", provider);
-        rsaKeyPairGenerator2048.initialize(2048);
-        rsaKeyPairGenerator4096 = KeyPairGenerator.getInstance("RSA", provider);
-        rsaKeyPairGenerator4096.initialize(4096);
+        // Skip 1024-bit RSA key generation for FIPS provider as it's not FIPS-approved
+        if (provider.equalsIgnoreCase("OpenJCEPlusFIPS") && keySize == 1024) {
+            throw new RuntimeException(
+                "Skipping 1024-bit RSA key generation: Not FIPS-approved for " + provider
+            );
+        }
+
+        rsaKeyPairGenerator = KeyPairGenerator.getInstance("RSA", provider);
+        rsaKeyPairGenerator.initialize(keySize);
     }
 
     @Benchmark
-    public KeyPair rsa1024KeyGeneration() throws Exception {
-        return rsaKeyPairGenerator1024.generateKeyPair();
-    }
-
-    @Benchmark
-    public KeyPair rsa2048KeyGeneration() throws Exception {
-        return rsaKeyPairGenerator2048.generateKeyPair();
-    }
-
-    @Benchmark
-    public KeyPair rsa4096KeyGeneration() throws Exception {
-        return rsaKeyPairGenerator4096.generateKeyPair();
+    public KeyPair rsaKeyGeneration() throws Exception {
+        return rsaKeyPairGenerator.generateKeyPair();
     }
 
     public static void main(String[] args) throws RunnerException {

--- a/src/test/java/ibm/jceplus/jmh/RSASignatureBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/RSASignatureBenchmark.java
@@ -37,7 +37,7 @@ public class RSASignatureBenchmark extends JMHBase {
     @Param({"2048", "32768"})
     private int payloadSize;
 
-    @Param({"OpenJCEPlus", "SunRsaSign"})
+    @Param({"OpenJCEPlus", "OpenJCEPlusFIPS", "SunRsaSign"})
     private String provider;
 
     @Param({"2048", "4096"})

--- a/src/test/java/ibm/jceplus/jmh/RandomBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/RandomBenchmark.java
@@ -38,7 +38,16 @@ public class RandomBenchmark extends JMHBase {
 
     private SecureRandom random;
 
-    @Param({"SHA256DRBG|OpenJCEPlus", "SHA512DRBG|OpenJCEPlus", "SHA1PRNG|SUN", "DRBG|SUN"})
+    @Param({
+        "SHA256DRBG|OpenJCEPlus",
+        "SHA512DRBG|OpenJCEPlus",
+        "HASHDRBG|OpenJCEPlus",
+        "SHA256DRBG|OpenJCEPlusFIPS",
+        "SHA512DRBG|OpenJCEPlusFIPS",
+        "HASHDRBG|OpenJCEPlusFIPS",
+        "SHA1PRNG|SUN",
+        "DRBG|SUN"
+    })
     private String randomToTest;
 
     @Setup


### PR DESCRIPTION
Add OpenJCEPlusFIPS as a benchmark parameter across some JMH performance tests to enable FIPS-compliant provider testing. Update JenkinsfilePerformance to set OpenJCEPlusFIPS default to false to avoid running FIPS benchmarks by default unless the user requests it.

Updated each JMH test run from 1G initial and maximum heap to 2G.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1491

Signed-off-by: Jason Katonica <katonica@us.ibm.com>