### PR TITLE
Use PKCS#8 to translate a private key

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/PQCKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCKeyFactory.java
@@ -145,10 +145,10 @@ class PQCKeyFactory extends KeyFactorySpi {
                     return key;
                 }
                 // Convert key to spec
-                X509EncodedKeySpec x509KeySpec = engineGetKeySpec(key,
-                        X509EncodedKeySpec.class);
+                PKCS8EncodedKeySpec pkcs8KeySpec = engineGetKeySpec(key,
+                        PKCS8EncodedKeySpec.class);
                 // Create key from spec, and return it
-                return engineGeneratePrivate(x509KeySpec);
+                return engineGeneratePrivate(pkcs8KeySpec);
             } else {
                 throw new InvalidKeyException("Wrong algorithm type");
             }


### PR DESCRIPTION
Use PKCS8EncodedKeySpec to translate a PrivateKey

Backported from: https://github.com/IBM/OpenJCEPlus/pull/1523