### PR TITLE
Revert "Disable ThreadLocal caching for ExtendedRandom on z/OS"

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/base/ExtendedRandom.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/ExtendedRandom.java
@@ -14,10 +14,6 @@ import com.ibm.crypto.plus.provider.ock.NativeOCKAdapterNonFIPS;
 
 public final class ExtendedRandom {
 
-    private static final boolean IS_ZOS = System.getProperty("os.name")
-                                                .toLowerCase()
-                                                .contains("z/os");
-
     private OpenJCEPlusProvider provider;
     private NativeInterface nativeInterface;
     private final String algName;
@@ -25,10 +21,8 @@ public final class ExtendedRandom {
     private long ockPRNGContextId;
     private boolean usingThreadLocalContext = true;
 
-    private static final ThreadLocal<PRNGContextPointer> prngContextBufferSha256 =
-        IS_ZOS ? null : new ThreadLocal<PRNGContextPointer>();
-    private static final ThreadLocal<PRNGContextPointer> prngContextBufferSha512 =
-        IS_ZOS ? null : new ThreadLocal<PRNGContextPointer>();
+    private static final ThreadLocal<PRNGContextPointer> prngContextBufferSha256 = new ThreadLocal<PRNGContextPointer>();
+    private static final ThreadLocal<PRNGContextPointer> prngContextBufferSha512 = new ThreadLocal<PRNGContextPointer>();
 
     public static ExtendedRandom getInstance(String algName, OpenJCEPlusProvider provider)
             throws NativeException {
@@ -51,13 +45,6 @@ public final class ExtendedRandom {
     }
 
     private long getPRNGContext(String algName) throws NativeException {
-        // On z/OS, create a new instance context without caching.
-        if (IS_ZOS) {
-            return createInstanceContext();
-        }
-
-        // On non-z/OS platforms, use the cached context if available,
-        // otherwise create and cache it.
         PRNGContextPointer prngCtx = null;
         ThreadLocal<PRNGContextPointer> prngCtxBuffer = null;
 
@@ -98,19 +85,21 @@ public final class ExtendedRandom {
         }
 
         if (seed.length > 0) {
-            // Switch from cached context to instance context for re-seeding
-            if (usingThreadLocalContext) {
-                this.ockPRNGContextId = createInstanceContext();
-            }
+            createInstanceContextForReSeed();
             this.nativeInterface.EXTRAND_setSeed(ockPRNGContextId, seed);
         }
     }
 
-    private long createInstanceContext() throws NativeException {
+    private void createInstanceContextForReSeed() throws NativeException {
+        if (!usingThreadLocalContext) {
+            return;
+        }
+
         long instanceCtx = this.nativeInterface.EXTRAND_create(algName);
+        this.ockPRNGContextId = instanceCtx;
         this.usingThreadLocalContext = false;
+
         this.provider.registerCleanable(this, cleanOCKResources(instanceCtx, nativeInterface));
-        return instanceCtx;
     }
 
     private static Runnable cleanOCKResources(long ockPRNGContextId, NativeInterface nativeInterface) {


### PR DESCRIPTION
This PR reverts "Disable ThreadLocal caching for ExtendedRandom on z/OS" due to an ICC_RNG_Generate() failure in ExtendedRandom when running the GitHub Actions build.

I will raise a new PR once the ICC_RNG_Generate() failure is addressed.