### PR TITLE
Use ThreadLocal caching for ExtendedRandom PRNG contexts

### DIFF
--- a/JenkinsfilePerformance
+++ b/JenkinsfilePerformance
@@ -388,6 +388,7 @@ pipeline {
                                             'ibm.jceplus.jmh.PBKDF2Benchmark', \
                                             'ibm.jceplus.jmh.PBMAC1Benchmark', \
                                             'ibm.jceplus.jmh.RandomBenchmark', \
+                                            'ibm.jceplus.jmh.RandomNewInstanceBenchmark', \
                                             'ibm.jceplus.jmh.RSACipherBenchmark', \
                                             'ibm.jceplus.jmh.RSAKeyGeneratorBenchmark', \
                                             'ibm.jceplus.jmh.RSASignatureBenchmark', \

--- a/src/main/java/com/ibm/crypto/plus/provider/base/ExtendedRandom.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/ExtendedRandom.java
@@ -20,6 +20,12 @@ public final class ExtendedRandom {
     private NativeInterface nativeInterface;
     private final String algName;
 
+    /*
+     * Used only when this ExtendedRandom instance owns its
+     * own PRNG context, for example on z/OS or after setSeed().
+     *
+     * ThreadLocal contexts are not stored.
+     */
     private long ockPRNGContextId;
     private boolean usingThreadLocalContext = true;
 
@@ -45,20 +51,24 @@ public final class ExtendedRandom {
         this.algName = algName;
         this.provider = provider;
         this.nativeInterface = NativeCryptoSelector.selectBackend(provider, "SecureRandom", algName + "DRBG");
-        this.ockPRNGContextId = getPRNGContext(algName);
 
-    private long getPRNGContext(String algName) throws NativeException {
-        // On z/OS, create a new instance context without caching.
+        /*
+         * On z/OS, create an instance-owned context without ThreadLocal
+         * caching.
+         *
+         * On non-z/OS, do not initialize the ThreadLocal context here.
+         * The ThreadLocal context is resolved in nextBytes().
+         */
         if (IS_ZOS) {
-            return createInstanceContext();
+            this.ockPRNGContextId = createInstanceContext();
         }
+    }
 
-        // On non-z/OS platforms, use the cached context if available,
-        // otherwise create and cache it.
+    private PRNGContextPointer getThreadLocalPRNGContext() throws NativeException {
         PRNGContextPointer prngCtx = null;
         ThreadLocal<PRNGContextPointer> prngCtxBuffer = null;
 
-        switch (algName) {
+        switch (this.algName) {
             case "SHA256":
                 prngCtxBuffer = prngContextBufferSha256;
                 break;
@@ -67,16 +77,16 @@ public final class ExtendedRandom {
                 break;
             default:
                 throw new IllegalArgumentException(
-                        "Unsupported HASHDRBG algorithm: " + algName);
+                        "Unsupported HASHDRBG algorithm: " + this.algName);
         }
 
         prngCtx = prngCtxBuffer.get();
         if (prngCtx == null) {
-            prngCtx = new PRNGContextPointer(algName, this.nativeInterface, this.provider);
+            prngCtx = new PRNGContextPointer(this.algName, this.nativeInterface, this.provider);
             prngCtxBuffer.set(prngCtx);
         }
 
-        return prngCtx.getCtx();
+        return prngCtx;
     }
 
     public synchronized void nextBytes(byte[] bytes) throws NativeException {
@@ -85,7 +95,12 @@ public final class ExtendedRandom {
         }
 
         if (bytes.length > 0) {
-            this.nativeInterface.EXTRAND_nextBytes(ockPRNGContextId, bytes);
+            if (usingThreadLocalContext && !IS_ZOS) {
+                PRNGContextPointer prngCtx = getThreadLocalPRNGContext();
+                this.nativeInterface.EXTRAND_nextBytes(prngCtx.getCtx(), bytes);
+            } else {
+                this.nativeInterface.EXTRAND_nextBytes(ockPRNGContextId, bytes);
+            }
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/base/ExtendedRandom.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/ExtendedRandom.java
@@ -12,6 +12,10 @@ import com.ibm.crypto.plus.provider.OpenJCEPlusProvider;
 
 public final class ExtendedRandom {
 
+    private static final boolean IS_ZOS = System.getProperty("os.name")
+                                                .toLowerCase()
+                                                .contains("z/os");
+
     private OpenJCEPlusProvider provider;
     private NativeInterface nativeInterface;
     private final String algName;
@@ -19,8 +23,10 @@ public final class ExtendedRandom {
     private long ockPRNGContextId;
     private boolean usingThreadLocalContext = true;
 
-    private static final ThreadLocal<PRNGContextPointer> prngContextBufferSha256 = new ThreadLocal<PRNGContextPointer>();
-    private static final ThreadLocal<PRNGContextPointer> prngContextBufferSha512 = new ThreadLocal<PRNGContextPointer>();
+    private static final ThreadLocal<PRNGContextPointer> prngContextBufferSha256 =
+        IS_ZOS ? null : new ThreadLocal<PRNGContextPointer>();
+    private static final ThreadLocal<PRNGContextPointer> prngContextBufferSha512 =
+        IS_ZOS ? null : new ThreadLocal<PRNGContextPointer>();
 
     public static ExtendedRandom getInstance(String algName, OpenJCEPlusProvider provider)
             throws NativeException {
@@ -42,6 +48,13 @@ public final class ExtendedRandom {
         this.ockPRNGContextId = getPRNGContext(algName);
 
     private long getPRNGContext(String algName) throws NativeException {
+        // On z/OS, create a new instance context without caching.
+        if (IS_ZOS) {
+            return createInstanceContext();
+        }
+
+        // On non-z/OS platforms, use the cached context if available,
+        // otherwise create and cache it.
         PRNGContextPointer prngCtx = null;
         ThreadLocal<PRNGContextPointer> prngCtxBuffer = null;
 
@@ -82,21 +95,19 @@ public final class ExtendedRandom {
         }
 
         if (seed.length > 0) {
-            createInstanceContextForReSeed();
+            // Switch from cached context to instance context for re-seeding
+            if (usingThreadLocalContext) {
+                this.ockPRNGContextId = createInstanceContext();
+            }
             this.nativeInterface.EXTRAND_setSeed(ockPRNGContextId, seed);
         }
     }
 
-    private void createInstanceContextForReSeed() throws NativeException {
-        if (!usingThreadLocalContext) {
-            return;
-        }
-
+    private long createInstanceContext() throws NativeException {
         long instanceCtx = this.nativeInterface.EXTRAND_create(algName);
-        this.ockPRNGContextId = instanceCtx;
         this.usingThreadLocalContext = false;
-
         this.provider.registerCleanable(this, cleanOCKResources(instanceCtx, nativeInterface));
+        return instanceCtx;
     }
 
     private static Runnable cleanOCKResources(long ockPRNGContextId, NativeInterface nativeInterface) {

--- a/src/main/java/com/ibm/crypto/plus/provider/base/ExtendedRandom.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/ExtendedRandom.java
@@ -14,7 +14,13 @@ public final class ExtendedRandom {
 
     private OpenJCEPlusProvider provider;
     private NativeInterface nativeInterface;
-    final long ockPRNGContextId;
+    private final String algName;
+
+    private long ockPRNGContextId;
+    private boolean usingThreadLocalContext = true;
+
+    private static final ThreadLocal<PRNGContextPointer> prngContextBufferSha256 = new ThreadLocal<PRNGContextPointer>();
+    private static final ThreadLocal<PRNGContextPointer> prngContextBufferSha512 = new ThreadLocal<PRNGContextPointer>();
 
     public static ExtendedRandom getInstance(String algName, OpenJCEPlusProvider provider)
             throws NativeException {
@@ -30,11 +36,34 @@ public final class ExtendedRandom {
     }
 
     private ExtendedRandom(String algName, OpenJCEPlusProvider provider) throws NativeException {
+        this.algName = algName;
         this.provider = provider;
         this.nativeInterface = NativeCryptoSelector.selectBackend(provider, "SecureRandom", algName + "DRBG");
-        this.ockPRNGContextId = this.nativeInterface.EXTRAND_create(algName);
+        this.ockPRNGContextId = getPRNGContext(algName);
 
-        this.provider.registerCleanable(this, cleanOCKResources(ockPRNGContextId, nativeInterface));
+    private long getPRNGContext(String algName) throws NativeException {
+        PRNGContextPointer prngCtx = null;
+        ThreadLocal<PRNGContextPointer> prngCtxBuffer = null;
+
+        switch (algName) {
+            case "SHA256":
+                prngCtxBuffer = prngContextBufferSha256;
+                break;
+            case "SHA512":
+                prngCtxBuffer = prngContextBufferSha512;
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported HASHDRBG algorithm: " + algName);
+        }
+
+        prngCtx = prngCtxBuffer.get();
+        if (prngCtx == null) {
+            prngCtx = new PRNGContextPointer(algName, this.nativeInterface, this.provider);
+            prngCtxBuffer.set(prngCtx);
+        }
+
+        return prngCtx.getCtx();
     }
 
     public synchronized void nextBytes(byte[] bytes) throws NativeException {
@@ -53,11 +82,24 @@ public final class ExtendedRandom {
         }
 
         if (seed.length > 0) {
+            createInstanceContextForReSeed();
             this.nativeInterface.EXTRAND_setSeed(ockPRNGContextId, seed);
         }
     }
 
-    private Runnable cleanOCKResources(long ockPRNGContextId, NativeInterface nativeInterface) {
+    private void createInstanceContextForReSeed() throws NativeException {
+        if (!usingThreadLocalContext) {
+            return;
+        }
+
+        long instanceCtx = this.nativeInterface.EXTRAND_create(algName);
+        this.ockPRNGContextId = instanceCtx;
+        this.usingThreadLocalContext = false;
+
+        this.provider.registerCleanable(this, cleanOCKResources(instanceCtx, nativeInterface));
+    }
+
+    private static Runnable cleanOCKResources(long ockPRNGContextId, NativeInterface nativeInterface) {
         return () -> {
             try {
                 if (ockPRNGContextId != 0) {
@@ -65,10 +107,23 @@ public final class ExtendedRandom {
                 }
             } catch (Exception e) {
                 if (OpenJCEPlusProvider.getDebug() != null) {
-                    OpenJCEPlusProvider.getDebug().println("An error occurred while cleaning : " + e.getMessage());
+                    OpenJCEPlusProvider.getDebug().println("An error occurred while cleaning: " + e.getMessage());
                     e.printStackTrace();
                 }
             }
         };
+    }
+
+    private static final class PRNGContextPointer {
+        final long prngCtx;
+
+        PRNGContextPointer(String algName, NativeInterface nativeInterface, OpenJCEPlusProvider provider) throws NativeException {
+            this.prngCtx = nativeInterface.EXTRAND_create(algName);
+            provider.registerCleanable(this, ExtendedRandom.cleanOCKResources(this.prngCtx, nativeInterface));
+        }
+
+        long getCtx() {
+            return this.prngCtx;
+        }
     }
 }

--- a/src/main/native/ock/ExtendedRandom.c
+++ b/src/main/native/ock/ExtendedRandom.c
@@ -136,7 +136,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_EXTRAND_1nextBytes
         if ((spState == (SP800_90STATE)ICC_FAILURE) ||
             (spState == SP800_90ERROR) || (spState == SP800_90CRIT)) {
             ockCheckStatus(ockCtx);
-            throwOCKException(env, 0, "ICC_RNG_CTX_Init() failed");
+            throwOCKException(env, 0, "ICC_RNG_Generate() failed");
         }
     }
 
@@ -191,7 +191,7 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_EXTRAND_1setSeed(
         if ((spState == (SP800_90STATE)ICC_FAILURE) ||
             (spState == SP800_90ERROR) || (spState == SP800_90CRIT)) {
             ockCheckStatus(ockCtx);
-            throwOCKException(env, 0, "ICC_RNG_CTX_Init() failed");
+            throwOCKException(env, 0, "ICC_RNG_ReSeed() failed");
         }
     }
 

--- a/src/test/java/ibm/jceplus/jmh/RandomNewInstanceBenchmark.java
+++ b/src/test/java/ibm/jceplus/jmh/RandomNewInstanceBenchmark.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright IBM Corp. 2026, 2026
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.jmh;
+
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = TimeUnit.SECONDS)
+public class RandomNewInstanceBenchmark extends JMHBase {
+
+    @Param({"16", "2048", "32768"})
+    private int payloadSize;
+
+    private byte[] payload;
+
+    private String algorithm;
+    private String provider;
+
+    @Param({"SHA256DRBG|OpenJCEPlus", "SHA512DRBG|OpenJCEPlus", "SHA1PRNG|SUN", "DRBG|SUN"})
+    private String randomToTest;
+
+    @Setup
+    public void setup() throws Exception {
+        String[] algAndProvider = randomToTest.split("\\|");
+        algorithm = algAndProvider[0];
+        provider = algAndProvider[1];
+        super.setup(provider);
+        payload = new byte[payloadSize];
+    }
+
+    @Benchmark
+    public byte[] runSecureRandom() throws Exception {
+        SecureRandom random = SecureRandom.getInstance(algorithm, provider);
+        random.nextBytes(payload);
+        return payload;
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String testSimpleName = RandomNewInstanceBenchmark.class.getSimpleName();
+        Options opt = optionsBuild(testSimpleName, testSimpleName);
+
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
The first two commits have already been reviewed. However, due to ICC_RNG_Generate() failures in the GitHub Actions build, I reverted the first two commits and added a third commit to fix the ICC_RNG_Generate() failures.

This PR includes the following changes:

Add ThreadLocal caching for native PRNG contexts used by ExtendedRandom. Each thread creates and reuses a PRNG context for supported DRBG algorithms, avoiding repeated EXTRAND_create calls when ExtendedRandom instances are created frequently.

On z/OS, ThreadLocal caching is disabled because it can cause native TCB context issues. z/OS now uses instance-specific PRNG contexts, while other platforms continue using ThreadLocal caching for performance.

Also fix ThreadLocal PRNG context ownership by resolving the current thread’s PRNGContextPointer in nextBytes() instead of storing ThreadLocal-owned native context IDs in ockPRNGContextId, which is now used only for instance-owned contexts.
