### PR TITLE
Add z/OS to supported platforms list for FIPS

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -64,7 +64,7 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
 
     static {
         supportedPlatforms.put("Arch", List.of("amd64", "ppc64", "s390x"));
-        supportedPlatforms.put("OS", List.of("Linux", "AIX", "Windows"));
+        supportedPlatforms.put("OS", List.of("Linux", "AIX", "Windows", "z/OS"));
 
         osName = System.getProperty("os.name");
         osArch = System.getProperty("os.arch");;

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKAdapterFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKAdapterFIPS.java
@@ -27,7 +27,7 @@ public class NativeOCKAdapterFIPS extends NativeOCKAdapter {
 
     static {
         supportedPlatforms.put("Arch", List.of("amd64", "ppc64", "s390x"));
-        supportedPlatforms.put("OS", List.of("Linux", "AIX", "Windows"));
+        supportedPlatforms.put("OS", List.of("Linux", "AIX", "Windows", "z/OS"));
 
         osName = System.getProperty("os.name");
         osArch = System.getProperty("os.arch");;

--- a/src/test/java/ibm/jceplus/junit/base/BaseUtils.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseUtils.java
@@ -114,7 +114,7 @@ abstract public class BaseUtils {
         String osArch;
 
         supportedPlatforms.put("Arch", List.of("amd64", "ppc64", "s390x"));
-        supportedPlatforms.put("OS", List.of("Linux", "AIX", "Windows"));
+        supportedPlatforms.put("OS", List.of("Linux", "AIX", "Windows", "z/OS"));
 
         osName = System.getProperty("os.name");
         osArch = System.getProperty("os.arch");;


### PR DESCRIPTION
Updated the supported OS list in OpenJCEPlusFIPS, NativeOCKAdapterFIPS, and BaseUtils to include "z/OS" alongside the existing Linux, AIX, and Windows platforms.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1557

Fixes: https://github.com/IBM/OpenJCEPlus/issues/1556

Signed-off-by: Jason Katonica <katonica@us.ibm.com>