### PR TITLE
Fix AESCCMCipher.engineDoFinal to use inputLen

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/AESCCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/AESCCMCipher.java
@@ -223,12 +223,12 @@ public final class AESCCMCipher extends CipherSpi implements AESConstants, CCMCo
 
         // Force the doFinal caller to call getOutputSize( ) and add the length of the doFinal data to it.
         if (encrypting) {
-            if ((output.length - outputOffset) < (input.length + tagLenInBytes)) {
+            if ((output.length - outputOffset) < (inputLen + tagLenInBytes)) {
                 throw new ShortBufferException(
                         "The output buffer is too small to hold the encryption result.");
             }
         } else { // decrypting
-            if ((output.length - outputOffset) < (input.length - tagLenInBytes)) {
+            if ((output.length - outputOffset) < (inputLen - tagLenInBytes)) {
                 throw new ShortBufferException(
                         "The output buffer is too small to hold the decryption result.");
             }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCMInteropBC.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestAESCCMInteropBC.java
@@ -289,6 +289,129 @@ public class BaseTestAESCCMInteropBC extends BaseTestJunit5Interop {
         }
     } // end testAESCCM()
 
+    /**
+     * Tests that engineDoFinal correctly uses inputLen (not input.length) for the output buffer
+     * size check during cross-provider interop with BouncyCastle.
+     *
+     * Exercises two cross-provider scenarios, each with a large input backing array where only a
+     * slice is passed via inputOffset + inputLen, and the output buffer is exactly the right size
+     * for that slice.
+     *
+     * Scenario A: OpenJCEPlus encrypts a slice → BC decrypts → plaintext verified.
+     * Scenario B: BC encrypts → OpenJCEPlus decrypts a slice → plaintext verified.
+     */
+    @Test
+    public void testAESCCMDoFinalWithInputSliceInterop() throws Exception {
+        // Fixed parameters for deterministic, readable test.
+        int ccmTagLengthBits = 128;
+        int tagLenInBytes    = ccmTagLengthBits / 8; // 16
+        byte[] iv = {(byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04,
+                     (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08,
+                     (byte) 0x09, (byte) 0x0a, (byte) 0x0b, (byte) 0x0c,
+                     (byte) 0x0d};
+        byte[] aadBytes = {(byte) 0x09, (byte) 0x10, (byte) 0x11, (byte) 0x12,
+                           (byte) 0x13, (byte) 0x14, (byte) 0x15, (byte) 0x16};
+
+        // Generate a shared 128-bit AES key via OpenJCEPlus.
+        KeyGenerator keyGenerator = KeyGenerator.getInstance("AES", getProviderName());
+        keyGenerator.init(128);
+        SecretKey key = keyGenerator.generateKey();
+        byte[] aesKeyBytes = key.getEncoded();
+        SecretKeySpec keySpec = new SecretKeySpec(aesKeyBytes, "AES");
+
+        // The actual plaintext payload is 20 bytes, embedded inside a 100-byte backing array
+        // at offset 40. This exercises the fix for issue #1564 where engineDoFinal incorrectly
+        // used input.length instead of inputLen for the output buffer size check.
+        // See: https://github.com/IBM/OpenJCEPlus/issues/1564 for more information on failing scenarios.
+        byte[] plaintext = "InteropSliceTest1234".getBytes(); // exactly 20 bytes
+        int inputOffset = 40;
+        int inputLen    = plaintext.length; // 20
+        byte[] inputBacking = new byte[100];
+        System.arraycopy(plaintext, 0, inputBacking, inputOffset, inputLen);
+
+        // -----------------------------------------------------------------------
+        // Scenario A: OpenJCEPlus encrypts the slice → BC decrypts → verify
+        // -----------------------------------------------------------------------
+        ibm.security.internal.spec.CCMParameterSpec ccmParamEnc =
+                new ibm.security.internal.spec.CCMParameterSpec(ccmTagLengthBits, iv);
+        Cipher encCipherOJP = Cipher.getInstance("AES/CCM/NoPadding", getProviderName());
+        encCipherOJP.init(Cipher.ENCRYPT_MODE, keySpec, ccmParamEnc);
+        encCipherOJP.updateAAD(aadBytes);
+
+        // Output buffer sized exactly for the slice: inputLen + tagLenInBytes = 36 bytes.
+        // Before the fix for issue #1564, this would throw a ShortBufferException
+        // because the check incorrectly used input.length (100) instead of inputLen (20).
+        // See: https://github.com/IBM/OpenJCEPlus/issues/1564 for more information on failing scenarios.
+        int encOutputLen = inputLen + tagLenInBytes; // 36
+        byte[] ciphertextA = new byte[encOutputLen];
+        int bytesEncrypted = encCipherOJP.doFinal(inputBacking, inputOffset, inputLen, ciphertextA, 0);
+
+        Assertions.assertEquals(encOutputLen, bytesEncrypted,
+                "Scenario A: OpenJCEPlus encrypted byte count should equal inputLen + tagLenInBytes");
+
+        // BC decrypts the ciphertext produced by OpenJCEPlus.
+        org.bouncycastle.crypto.MultiBlockCipher bcEngine =
+                org.bouncycastle.crypto.engines.AESEngine.newInstance();
+        org.bouncycastle.crypto.params.AEADParameters bcParams =
+                new org.bouncycastle.crypto.params.AEADParameters(
+                        new org.bouncycastle.crypto.params.KeyParameter(aesKeyBytes),
+                        ccmTagLengthBits, iv, null);
+        org.bouncycastle.crypto.modes.CCMModeCipher bcDecCipher =
+                org.bouncycastle.crypto.modes.CCMBlockCipher.newInstance(bcEngine);
+        bcDecCipher.init(false, bcParams);
+        bcDecCipher.processAADBytes(aadBytes, 0, aadBytes.length);
+        byte[] decryptedA = new byte[bcDecCipher.getOutputSize(ciphertextA.length)];
+        int decLen = bcDecCipher.processBytes(ciphertextA, 0, ciphertextA.length, decryptedA, 0);
+        bcDecCipher.doFinal(decryptedA, decLen);
+
+        Assertions.assertArrayEquals(plaintext, decryptedA,
+                "Scenario A: BC-decrypted bytes must match original plaintext");
+
+        // -----------------------------------------------------------------------
+        // Scenario B: BC encrypts → OpenJCEPlus decrypts the slice → verify
+        // -----------------------------------------------------------------------
+        org.bouncycastle.crypto.MultiBlockCipher bcEngineB =
+                org.bouncycastle.crypto.engines.AESEngine.newInstance();
+        org.bouncycastle.crypto.params.AEADParameters bcParamsB =
+                new org.bouncycastle.crypto.params.AEADParameters(
+                        new org.bouncycastle.crypto.params.KeyParameter(aesKeyBytes),
+                        ccmTagLengthBits, iv, null);
+        org.bouncycastle.crypto.modes.CCMModeCipher bcEncCipher =
+                org.bouncycastle.crypto.modes.CCMBlockCipher.newInstance(bcEngineB);
+        bcEncCipher.init(true, bcParamsB);
+        bcEncCipher.processAADBytes(aadBytes, 0, aadBytes.length);
+        byte[] ciphertextB = new byte[bcEncCipher.getOutputSize(plaintext.length)];
+        int bcEncLen = bcEncCipher.processBytes(plaintext, 0, plaintext.length, ciphertextB, 0);
+        bcEncCipher.doFinal(ciphertextB, bcEncLen);
+
+        // Place BC's ciphertext (36 bytes) inside a large backing array at an offset,
+        // so the backing array length (100) >> the slice length (36).
+        int cipherInputOffset = 32;
+        int cipherInputLen    = ciphertextB.length; // 36
+        byte[] cipherBacking = new byte[100];
+        System.arraycopy(ciphertextB, 0, cipherBacking, cipherInputOffset, cipherInputLen);
+
+        ibm.security.internal.spec.CCMParameterSpec ccmParamDec =
+                new ibm.security.internal.spec.CCMParameterSpec(ccmTagLengthBits, iv);
+        Cipher decCipherOJP = Cipher.getInstance("AES/CCM/NoPadding", getProviderName());
+        decCipherOJP.init(Cipher.DECRYPT_MODE, keySpec, ccmParamDec);
+        decCipherOJP.updateAAD(aadBytes);
+
+        // Output buffer sized exactly for the decrypted plaintext: cipherInputLen - tagLenInBytes = 20.
+        // Before the fix for issue #1564, this would throw a ShortBufferException
+        // because the check incorrectly used input.length (100) instead of inputLen (36).
+        // See: https://github.com/IBM/OpenJCEPlus/issues/1564 for more information on failing scenarios.
+        int decOutputLen = cipherInputLen - tagLenInBytes; // 20
+        byte[] decryptedB = new byte[decOutputLen];
+        int bytesDecrypted = decCipherOJP.doFinal(cipherBacking, cipherInputOffset, cipherInputLen,
+                decryptedB, 0);
+
+        Assertions.assertEquals(plaintext.length, bytesDecrypted,
+                "Scenario B: OpenJCEPlus decrypted byte count should equal original plaintext length");
+        Assertions.assertArrayEquals(plaintext, decryptedB,
+                "Scenario B: OpenJCEPlus-decrypted bytes must match original plaintext");
+    }
+
     private static byte[] encrypt(byte[] plaintext, byte[] aesKeyBytes, byte[] IV, int ccmTagLength)
             throws Exception {
         synchronized (myMutexObject) {

--- a/src/test/java/ibm/jceplus/junit/tests/TestAESCCM.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestAESCCM.java
@@ -288,6 +288,200 @@ public class TestAESCCM extends BaseTest {
         }
     } // end testAESCCM()
 
+    /**
+     * Tests that engineDoFinal correctly uses inputLen (not input.length) when checking whether
+     * the output buffer is large enough to hold the encryption result.
+     *
+     * When the caller passes a large backing array with inputOffset > 0, the output buffer must
+     * only be large enough to hold inputLen bytes of ciphertext plus the tag, not input.length
+     * bytes plus the tag.
+     */
+    @Test
+    public void testDoFinalEncryptWithInputSlice() throws Exception {
+        // Use a fixed, known-good tag length (128 bits = 16 bytes) and IV.
+        int ccmTagLengthBits  = 128;
+        int tagLenInBytes     = ccmTagLengthBits / 8; // 16
+        byte[] iv = {(byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04,
+                     (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08,
+                     (byte) 0x09, (byte) 0x0a, (byte) 0x0b, (byte) 0x0c,
+                     (byte) 0x0d};
+
+        KeyGenerator keyGenerator = KeyGenerator.getInstance("AES", getProviderName());
+        keyGenerator.init(128);
+        SecretKey key = keyGenerator.generateKey();
+        SecretKeySpec keySpec = new SecretKeySpec(key.getEncoded(), "AES");
+
+        // Build a large backing array with the plaintext starting at inputOffset.
+        // inputLen is intentionally much smaller than input.length.
+        int inputOffset = 40;
+        int inputLen    = 10;
+        byte[] input    = new byte[100]; // input.length >> inputLen
+        new java.security.SecureRandom().nextBytes(input);
+
+        CCMParameterSpec ccmParameterSpec = new CCMParameterSpec(ccmTagLengthBits, iv);
+        Cipher cipher = Cipher.getInstance("AES/CCM/NoPadding", getProviderName());
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec, ccmParameterSpec);
+
+        // The output buffer is exactly the right size for the slice being encrypted:
+        // inputLen + tagLenInBytes = 26 bytes. Before the fix for issue #1564, this would
+        // throw a ShortBufferException because the check used input.length instead of inputLen.
+        // See: https://github.com/IBM/OpenJCEPlus/issues/1564 for more information on failing scenarios.
+        byte[] output = new byte[inputLen + tagLenInBytes]; // 26 bytes — correct
+        int bytesWritten = cipher.doFinal(input, inputOffset, inputLen, output, 0);
+
+        Assertions.assertEquals(inputLen + tagLenInBytes, bytesWritten,
+                "Encrypted output length should equal inputLen + tagLenInBytes");
+    }
+
+    /**
+     * Tests that engineDoFinal correctly uses inputLen (not input.length) when checking whether
+     * the output buffer is large enough to hold the decryption result.
+     *
+     * When the ciphertext backing array is larger than the slice being decrypted, the output
+     * buffer must only be large enough to hold inputLen - tagLenInBytes bytes, not
+     * input.length - tagLenInBytes bytes.
+     */
+    @Test
+    public void testDoFinalDecryptWithInputSlice() throws Exception {
+        int ccmTagLengthBits = 128;
+        int tagLenInBytes    = ccmTagLengthBits / 8; // 16
+        byte[] iv = {(byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04,
+                     (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08,
+                     (byte) 0x09, (byte) 0x0a, (byte) 0x0b, (byte) 0x0c,
+                     (byte) 0x0d};
+
+        KeyGenerator keyGenerator = KeyGenerator.getInstance("AES", getProviderName());
+        keyGenerator.init(128);
+        SecretKey key = keyGenerator.generateKey();
+        SecretKeySpec keySpec = new SecretKeySpec(key.getEncoded(), "AES");
+
+        // First, encrypt a short plaintext to get valid ciphertext (plaintext + tag).
+        byte[] plaintext = "HelloWorld".getBytes(); // 10 bytes
+        CCMParameterSpec ccmParamEnc = new CCMParameterSpec(ccmTagLengthBits, iv);
+        Cipher encCipher = Cipher.getInstance("AES/CCM/NoPadding", getProviderName());
+        encCipher.init(Cipher.ENCRYPT_MODE, keySpec, ccmParamEnc);
+        byte[] ciphertext = encCipher.doFinal(plaintext); // 10 + 16 = 26 bytes
+
+        // Place the ciphertext (26 bytes) inside a larger backing array at an offset,
+        // so cipherInputArray.length (100) >> inputLen (26).
+        int inputOffset  = 40;
+        int inputLen     = ciphertext.length; // 26
+        byte[] cipherInputArray = new byte[100];
+        System.arraycopy(ciphertext, 0, cipherInputArray, inputOffset, inputLen);
+
+        CCMParameterSpec ccmParamDec = new CCMParameterSpec(ccmTagLengthBits, iv);
+        Cipher decCipher = Cipher.getInstance("AES/CCM/NoPadding", getProviderName());
+        decCipher.init(Cipher.DECRYPT_MODE, keySpec, ccmParamDec);
+
+        // The output buffer is exactly the right size for the decrypted plaintext:
+        // inputLen - tagLenInBytes = 10 bytes. Before the fix for issue #1564, this would
+        // throw a ShortBufferException because the check used input.length instead of inputLen.
+        // See: https://github.com/IBM/OpenJCEPlus/issues/1564 for more information on failing scenarios.
+        byte[] output = new byte[inputLen - tagLenInBytes]; // 10 bytes — correct
+        int bytesWritten = decCipher.doFinal(cipherInputArray, inputOffset, inputLen, output, 0);
+
+        Assertions.assertEquals(plaintext.length, bytesWritten,
+                "Decrypted output length should equal original plaintext length");
+        Assertions.assertArrayEquals(plaintext, output,
+                "Decrypted bytes should match original plaintext");
+    }
+
+    /**
+     * Negative test: verifies that a genuinely undersized output buffer still triggers a
+     * ShortBufferException when the input is a slice of a larger backing array.
+     *
+     * The input is a 10-byte slice of a 100-byte backing array. An output buffer one byte shorter
+     * than inputLen + tagLenInBytes must be rejected.
+     */
+    @Test
+    public void testDoFinalEncryptWithTrulyShortOutputBuffer() throws Exception {
+        int ccmTagLengthBits = 128;
+        int tagLenInBytes    = ccmTagLengthBits / 8; // 16
+        byte[] iv = {(byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04,
+                     (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08,
+                     (byte) 0x09, (byte) 0x0a, (byte) 0x0b, (byte) 0x0c,
+                     (byte) 0x0d};
+
+        KeyGenerator keyGenerator = KeyGenerator.getInstance("AES", getProviderName());
+        keyGenerator.init(128);
+        SecretKey key = keyGenerator.generateKey();
+        SecretKeySpec keySpec = new SecretKeySpec(key.getEncoded(), "AES");
+
+        // Large backing array, only a 10-byte slice is being encrypted.
+        int inputOffset = 40;
+        int inputLen    = 10;
+        byte[] input    = new byte[100];
+        new java.security.SecureRandom().nextBytes(input);
+
+        CCMParameterSpec ccmParameterSpec = new CCMParameterSpec(ccmTagLengthBits, iv);
+        Cipher cipher = Cipher.getInstance("AES/CCM/NoPadding", getProviderName());
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec, ccmParameterSpec);
+
+        // One byte short of what is needed: inputLen + tagLenInBytes - 1 = 25.
+        // The check uses inputLen (10), so 25 < 10+16 — ShortBufferException expected.
+        byte[] tooSmallOutput = new byte[inputLen + tagLenInBytes - 1]; // 25 bytes — one short
+
+        try {
+            cipher.doFinal(input, inputOffset, inputLen, tooSmallOutput, 0);
+            Assertions.fail("Expected ShortBufferException was not thrown for a genuinely undersized output buffer");
+        } catch (javax.crypto.ShortBufferException e) {
+            Assertions.assertEquals("The output buffer is too small to hold the encryption result.",
+                    e.getMessage(),
+                    "ShortBufferException should report that the output buffer is too small to hold the encryption result");
+        }
+    }
+
+    /**
+     * Negative test: mirrors testDoFinalEncryptWithTrulyShortOutputBuffer for the decrypt path.
+     *
+     * The ciphertext is a 26-byte slice inside a 100-byte backing array. An output buffer one
+     * byte shorter than inputLen - tagLenInBytes must be rejected.
+     */
+    @Test
+    public void testDoFinalDecryptWithTrulyShortOutputBuffer() throws Exception {
+        int ccmTagLengthBits = 128;
+        int tagLenInBytes    = ccmTagLengthBits / 8; // 16
+        byte[] iv = {(byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04,
+                     (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08,
+                     (byte) 0x09, (byte) 0x0a, (byte) 0x0b, (byte) 0x0c,
+                     (byte) 0x0d};
+
+        KeyGenerator keyGenerator = KeyGenerator.getInstance("AES", getProviderName());
+        keyGenerator.init(128);
+        SecretKey key = keyGenerator.generateKey();
+        SecretKeySpec keySpec = new SecretKeySpec(key.getEncoded(), "AES");
+
+        // Encrypt a 10-byte plaintext to get 26-byte ciphertext.
+        byte[] plaintext = "HelloWorld".getBytes(); // 10 bytes
+        CCMParameterSpec ccmParamEnc = new CCMParameterSpec(ccmTagLengthBits, iv);
+        Cipher encCipher = Cipher.getInstance("AES/CCM/NoPadding", getProviderName());
+        encCipher.init(Cipher.ENCRYPT_MODE, keySpec, ccmParamEnc);
+        byte[] ciphertext = encCipher.doFinal(plaintext); // 26 bytes
+
+        // Place ciphertext in a larger backing array at an offset.
+        int inputOffset = 40;
+        int inputLen    = ciphertext.length; // 26
+        byte[] cipherInputArray = new byte[100];
+        System.arraycopy(ciphertext, 0, cipherInputArray, inputOffset, inputLen);
+
+        CCMParameterSpec ccmParamDec = new CCMParameterSpec(ccmTagLengthBits, iv);
+        Cipher decCipher = Cipher.getInstance("AES/CCM/NoPadding", getProviderName());
+        decCipher.init(Cipher.DECRYPT_MODE, keySpec, ccmParamDec);
+
+        // One byte short: inputLen - tagLenInBytes - 1 = 9.
+        // The check uses inputLen (26), so 9 < 26-16 — ShortBufferException expected.
+        byte[] tooSmallOutput = new byte[inputLen - tagLenInBytes - 1]; // 9 bytes — one short
+
+        try {
+            decCipher.doFinal(cipherInputArray, inputOffset, inputLen, tooSmallOutput, 0);
+            Assertions.fail("Expected ShortBufferException was not thrown for a genuinely undersized output buffer");
+        } catch (javax.crypto.ShortBufferException e) {
+            Assertions.assertEquals("The output buffer is too small to hold the decryption result.",
+                    e.getMessage(),
+                    "ShortBufferException should report that the output buffer is too small to hold the decryption result");
+        }
+    }
+
     private byte[] encrypt(byte[] plaintext, SecretKey key, byte[] IV, int ccmTagLength)
             throws Exception {
         synchronized (myMutexObject) {


### PR DESCRIPTION
AESCCMCipher.engineDoFinal was using input.length (the full backing array length) instead of inputLen (the caller-specified byte count) when deciding whether the output buffer was large enough. This caused a false ShortBufferException whenever the caller passed a slice of a larger backing array via inputOffset + inputLen, because the backing array was wider than the actual data being processed.

Fix: replace input.length with inputLen in both the encrypt and decrypt output-size checks inside engineDoFinal.

Tests were also added to exercise slicing and ensure interop via sliced buffers is working as expected.

Fixes: https://github.com/IBM/OpenJCEPlus/issues/1564

Signed-off-by: Jason Katonica <katonica@us.ibm.com>