### PR TITLE
Update OCK reference to V_8.9.22 (July 1st 2026)

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: IBM/OpenCryptographyKitC
-          ref: dc6dbf5c79365cba7092f917162124eb24c2b5a6 # Branch V_8.9.21 on May 19th 2026.
+          ref: 48676fbab3122591b5e4e6dcef925d1ad24fd578 # Branch V_8.9.22 on July 1st 2026.
           path: ${{ github.workspace }}/OpenCryptographyKitC
       - name: Compile Open Cryptography Kit C
         run: |


### PR DESCRIPTION
Update the OCK checkout ref in github-actions.yml from the V_8.9.21 commit (dc6dbf5) to the V_8.9.22 commit (48676fb), which is latest commit on July 1st 2026.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>