### PR TITLE
Prevent key pair gen in EdDSA/XDH constructor

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/EdDSAPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/EdDSAPrivateKeyImpl.java
@@ -29,6 +29,14 @@ final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKey {
 
     private static final long serialVersionUID = 1L;
 
+    // Emergency fallback property to allow legacy key pair generation behavior
+    // when h parameter is null. This should only be used in emergency situations
+    // as generating a key pair in a private key constructor is not a valid scenario.
+    //
+    // TODO: Remove this property in the future
+    private static final boolean ALLOW_KEYPAIR_GENERATION_IN_CONSTRUCTOR =
+        Boolean.getBoolean("openjceplus.eddsa.allowKeyPairGenerationInConstructor");
+
     private static final byte TAG_PARAMETERS_ATTRS = 0x00;
     private OpenJCEPlusProvider provider = null;
     private transient byte[] h;
@@ -93,9 +101,16 @@ final class EdDSAPrivateKeyImpl extends PKCS8Key implements EdECPrivateKey {
             }
 
             if (this.key == null) {
-                int keySize = CurveUtil.getCurveSize(curve);
-                this.xecKey = XECKey.generateKeyPair(
-                        this.curve.ordinal(), keySize, provider);
+                // Key pair generation in a private key constructor is not a valid scenario.
+                // This code path should never be reached in normal operation.
+                if (ALLOW_KEYPAIR_GENERATION_IN_CONSTRUCTOR) {
+                    int keySize = CurveUtil.getCurveSize(curve);
+                    this.xecKey = XECKey.generateKeyPair(
+                            this.curve.ordinal(), keySize, provider);
+                } else {
+                    throw new InvalidParameterException(
+                        "Cannot create EdDSA private key without key bytes parameter.");
+                }
             } else {
                 this.algid = CurveUtil.getAlgId(this.curve);
                 byte[] der = buildOCKPrivateKeyBytes();

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
@@ -38,6 +38,14 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
     // Field serialVersionUID per tag [SERIALIZATION] in DesignNotes.txt
     private static final long serialVersionUID = 6034044314589513430L;
 
+    // Emergency fallback property to allow legacy key pair generation behavior
+    // when scalar parameter is null. This should only be used in emergency situations
+    // as generating a key pair in a private key constructor is not a valid scenario.
+    //
+    // TODO: Remove this property in the future
+    private static final boolean ALLOW_KEYPAIR_GENERATION_IN_CONSTRUCTOR =
+        Boolean.getBoolean("openjceplus.xdh.allowKeyPairGenerationInConstructor");
+
     private OpenJCEPlusProvider provider = null;
     private transient NamedParameterSpec params;
     private CURVE curve;
@@ -136,8 +144,15 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
             k = scalar.get();
         try {
             if (k == null) {
-                int keySize = CurveUtil.getCurveSize(curve);
-                this.xecKey = XECKey.generateKeyPair(this.curve.ordinal(), keySize, provider);
+                // Key pair generation in a private key constructor is not a valid scenario.
+                // This code path should never be reached in normal operation.
+                if (ALLOW_KEYPAIR_GENERATION_IN_CONSTRUCTOR) {
+                    int keySize = CurveUtil.getCurveSize(curve);
+                    this.xecKey = XECKey.generateKeyPair(this.curve.ordinal(), keySize, provider);
+                } else {
+                    throw new InvalidParameterException(
+                        "Cannot create XDH private key without scalar parameter.");
+                }
             } else {
                 this.algid = CurveUtil.getAlgId(this.params.getName());
                 byte[] der = buildOCKPrivateKeyBytes();


### PR DESCRIPTION
Key pair generation in a private key constructor is not a valid scenario. This change ensures proper key construction and prevents unexpected behavior.

- Add validation to reject null key bytes/scalar in EdDSAPrivateKeyImpl and XDHPrivateKeyImpl
- Throw InvalidParameterException when attempting to create private keys without key material
- Add emergency fallback system properties for backward compatibility:
  * openjceplus.eddsa.allowKeyPairGenerationInConstructor
  * openjceplus.xdh.allowKeyPairGenerationInConstructor

Fixes: https://github.com/IBM/OpenJCEPlus/issues/1521

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1554

Signed-off-by: Jason Katonica <katonica@us.ibm.com>