### PR TITLE
Fix missing return on failure in HMAC_init

### DIFF
--- a/src/main/native/ock/HMAC.c
+++ b/src/main/native/ock/HMAC.c
@@ -235,7 +235,11 @@ int HMAC_init(JNIEnv *env, jclass thisObj, jlong ockContextId, jlong hmacId,
             gslogMessage("DETAIL_HMAC FAILURE to allocate keyNative");
         }
 #endif
+        if (debug) {
+            gslogFunctionExit(functionName);
+        }
         throwOCKException(env, 0, "NULL from GetPrimitiveArrayCritical!");
+        return FAIL_HMAC_INTERNAL_INIT;
     }
 
     result = HMAC_init_internal(ockCtx, ockHMAC, keyNative, keySize);


### PR DESCRIPTION
When GetPrimitiveArrayCritical returned NULL for keyNative, the code threw an OCK exception but fell through to call HMAC_init_internal with a NULL keyNative pointer, leading to a potential invalid memory access.

Add an early return of FAIL_HMAC_INTERNAL_INIT after the exception is thrown, and add the missing gslogFunctionExit call inside the debug block to keep exit logging consistent with other error paths.

Fixes #1253

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1593

Signed-off-by: Jason Katonica <katonica@us.ibm.com>