### PR TITLE
Check and add error handling for native DH and XEC

### DIFF
--- a/src/main/native/ock/DHKey.c
+++ b/src/main/native/ock/DHKey.c
@@ -695,7 +695,24 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_DHKEY_1getPrivateK
 #endif
         throwOCKException(env, 0, "ICC_EVP_PKEY_new failed");
     } else {
-        ICC_EVP_PKEY_set1_DH(ockCtx, ockPKey, ockDH);
+        int rc = ICC_EVP_PKEY_set1_DH(ockCtx, ockPKey, ockDH);
+        if (rc != ICC_OSSL_SUCCESS) {
+            ockCheckStatus(ockCtx);
+#ifdef DEBUG_DH_DETAIL
+            if (debug) {
+                gslogMessage("DETAIL_DH FAILURE ICC_EVP_PKEY_set1_DH");
+            }
+#endif
+            throwOCKException(env, 0, "ICC_EVP_PKEY_set1_DH failed");
+            if (ockPKey != NULL) {
+                ICC_EVP_PKEY_free(ockCtx, ockPKey);
+            }
+            if (debug) {
+                gslogFunctionExit(functionName);
+            }
+            return NULL;
+        }
+        
         size = ICC_i2d_PrivateKey(ockCtx, ockPKey, NULL);
 
         if (size <= 0) {
@@ -820,7 +837,24 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_DHKEY_1getPublicKe
 #endif
         throwOCKException(env, 0, "ICC_EVP_PKEY_new failed");
     } else {
-        ICC_EVP_PKEY_set1_DH(ockCtx, ockPKey, ockDH);
+        int rc = ICC_EVP_PKEY_set1_DH(ockCtx, ockPKey, ockDH);
+        if (rc != ICC_OSSL_SUCCESS) {
+            ockCheckStatus(ockCtx);
+#ifdef DEBUG_DH_DETAIL
+            if (debug) {
+                gslogMessage("DETAIL_DH FAILURE ICC_EVP_PKEY_set1_DH");
+            }
+#endif
+            throwOCKException(env, 0, "ICC_EVP_PKEY_set1_DH failed");
+            if (ockPKey != NULL) {
+                ICC_EVP_PKEY_free(ockCtx, ockPKey);
+            }
+            if (debug) {
+                gslogFunctionExit(functionName);
+            }
+            return NULL;
+        }
+        
         size = ICC_i2d_PUBKEY(ockCtx, ockPKey, NULL);
 
         if (size <= 0) {
@@ -985,17 +1019,18 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_DHKEY_1computeDHSe
     jlong privKeyId) {
     static const char *functionName = "NativeInterface.DHKEY_computeDHSecret";
 
-    ICC_CTX       *ockCtx            = (ICC_CTX *)((intptr_t)ockContextId);
-    ICC_DH        *ockPubDHKey       = (ICC_DH *)((intptr_t)pubKeyId);
-    ICC_DH        *ockPrivDHKey      = (ICC_DH *)((intptr_t)privKeyId);
-    ICC_BIGNUM    *ockPubDHKeyBN     = NULL;
-    jbyteArray     secretBytes       = NULL;
-    unsigned char *secretBytesNative = NULL;
-    jbyteArray     retSecretBytes    = NULL;
-    unsigned char *bbbuf             = NULL;
-    jboolean       isCopy            = 0;
-    int            lena              = 0;
-    int            keylen            = 0;
+    ICC_CTX             *ockCtx             = (ICC_CTX *)((intptr_t)ockContextId);
+    ICC_DH              *ockPubDHKey        = (ICC_DH *)((intptr_t)pubKeyId);
+    ICC_DH              *ockPrivDHKey       = (ICC_DH *)((intptr_t)privKeyId);
+    ICC_BIGNUM          *ockPubDHKeyBN      = NULL;
+    const ICC_BIGNUM    *ockPubKey          = NULL;
+    jbyteArray          secretBytes         = NULL;
+    unsigned char       *secretBytesNative  = NULL;
+    jbyteArray          retSecretBytes      = NULL;
+    unsigned char       *bbbuf              = NULL;
+    jboolean            isCopy              = 0;
+    int                 lena                = 0;
+    int                 keylen              = 0;
 
     if (debug) {
         gslogFunctionEntry(functionName);
@@ -1009,8 +1044,22 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_DHKEY_1computeDHSe
         return retSecretBytes;
     }
 
-    keylen =
-        ICC_BN_num_bytes(ockCtx, ICC_DH_get_PublicKey(ockCtx, ockPubDHKey));
+    ockPubKey = ICC_DH_get_PublicKey(ockCtx, ockPubDHKey);
+    if (ockPubKey == NULL) {
+        ockCheckStatus(ockCtx);
+#ifdef DEBUG_DH_DETAIL
+        if (debug) {
+            gslogMessage("DETAIL_DH FAILURE ICC_DH_get_PublicKey");
+        }
+#endif
+        throwOCKException(env, 0, "ICC_DH_get_PublicKey failed");
+        if (debug) {
+            gslogFunctionExit(functionName);
+        }
+        return NULL;
+    }
+    
+    keylen = ICC_BN_num_bytes(ockCtx, ockPubKey);
     if (keylen <= 0) {
         ockCheckStatus(ockCtx);
 #ifdef DEBUG_DH_DETAIL
@@ -1022,9 +1071,20 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_DHKEY_1computeDHSe
         throwOCKException(env, 0, "ICC_BN_num_bytes failed");
     } else {
         bbbuf = (unsigned char *)malloc(keylen);
+        if (bbbuf == NULL) {
+#ifdef DEBUG_DH_DETAIL
+            if (debug) {
+                gslogMessage("DETAIL_DH FAILURE malloc keylen=%d", keylen);
+            }
+#endif
+            throwOCKException(env, 0, "malloc failed");
+            if (debug) {
+                gslogFunctionExit(functionName);
+            }
+            return NULL;
+        }
         /* Don't forget the save the REAL length of the buffer ... */
-        keylen = ICC_BN_bn2bin(
-            ockCtx, ICC_DH_get_PublicKey(ockCtx, ockPubDHKey), bbbuf);
+        keylen = ICC_BN_bn2bin(ockCtx, ockPubKey, bbbuf);
         if (keylen <= 0) {
             ockCheckStatus(ockCtx);
 #ifdef DEBUG_DH_DETAIL

--- a/src/main/native/ock/ECKey.c
+++ b/src/main/native/ock/ECKey.c
@@ -1223,8 +1223,25 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_XECKEY_1createPriv
                 gslogMessage("DETAIL_XEC returning xecKeyId=%lx", xecKeyId);
             }
 #endif
-            ICC_EVP_PKEY_get_raw_public_key(ockCtx, ockEVPKey,
+            int rc = ICC_EVP_PKEY_get_raw_public_key(ockCtx, ockEVPKey,
                                             (unsigned char *)bufferPtr, &size);
+            if (rc != ICC_OSSL_SUCCESS) {
+                ockCheckStatus(ockCtx);
+#ifdef DEBUG_EC_DETAIL
+                if (debug) {
+                    gslogMessage("DETAIL_XEC FAILURE ICC_EVP_PKEY_get_raw_public_key");
+                }
+#endif
+                throwOCKException(env, 0, "ICC_EVP_PKEY_get_raw_public_key failed");
+                if (keyBytesNative != NULL) {
+                    (*env)->ReleasePrimitiveArrayCritical(env, privateKeyBytes,
+                                                          keyBytesNative, 0);
+                }
+                if (debug) {
+                    gslogFunctionExit(functionName);
+                }
+                return 0;
+            }
         }
     }
 
@@ -1730,14 +1747,32 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_XECKEY_1getPrivate
         }
         return retKeyBytes;
     }
-    size     = ICC_i2d_PrivateKey(ockCtx, ockEVPKey, NULL);
+    size = ICC_i2d_PrivateKey(ockCtx, ockEVPKey, NULL);
+    if (size <= 0) {
+        ockCheckStatus(ockCtx);
+        throwOCKException(env, 0, "ICC_i2d_PrivateKey failed to get size");
+        if (debug) {
+            gslogFunctionExit(functionName);
+        }
+        return NULL;
+    }
     keyBytes = (*env)->NewByteArray(env, size);
     if (keyBytes != NULL) {
         keyBytesNative = (unsigned char *)((*env)->GetPrimitiveArrayCritical(
             env, keyBytes, &isCopy));
         if (keyBytesNative != NULL) {
-            pBytes      = (unsigned char *)keyBytesNative;
-            size        = ICC_i2d_PrivateKey(ockCtx, ockEVPKey, &pBytes);
+            pBytes = (unsigned char *)keyBytesNative;
+            size   = ICC_i2d_PrivateKey(ockCtx, ockEVPKey, &pBytes);
+            if (size <= 0) {
+                ockCheckStatus(ockCtx);
+                (*env)->ReleasePrimitiveArrayCritical(env, keyBytes, keyBytesNative, 0);
+                (*env)->DeleteLocalRef(env, keyBytes);
+                throwOCKException(env, 0, "ICC_i2d_PrivateKey failed");
+                if (debug) {
+                    gslogFunctionExit(functionName);
+                }
+                return NULL;
+            }
             retKeyBytes = keyBytes;
             (*env)->ReleasePrimitiveArrayCritical(env, keyBytes, keyBytesNative,
                                                   0);
@@ -1875,8 +1910,19 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_XECKEY_1getPublicK
     jbyteArray     keyBytes       = NULL;
     size_t         size;
     jboolean       isCopy = 0;
+    int            rc     = 0;
 
-    ICC_EVP_PKEY_get_raw_public_key(ockCtx, ockEVPKey, NULL, &size);
+    rc = ICC_EVP_PKEY_get_raw_public_key(ockCtx, ockEVPKey, NULL, &size);
+    if (rc != ICC_OSSL_SUCCESS) {
+#ifdef DEBUG_EC_DETAIL
+        if (debug) {
+            gslogMessage("DETAIL_EC FAILURE ICC_EVP_PKEY_get_raw_public_key");
+        }
+#endif
+        ockCheckStatus(ockCtx);
+        throwOCKException(env, 0, "ICC_EVP_PKEY_get_raw_public_key failed");
+        return NULL;
+    }
     keyBytes = (*env)->NewByteArray(env, size);
     if (keyBytes == NULL) {
 #ifdef DEBUG_EC_DETAIL
@@ -1897,10 +1943,16 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_XECKEY_1getPublicK
             throwOCKException(env, 0, "NULL from GetPrimitiveArrayCritical");
         } else {
             if (keyBytesNative != NULL) {
-                ICC_EVP_PKEY_get_raw_public_key(ockCtx, ockEVPKey,
+                rc = ICC_EVP_PKEY_get_raw_public_key(ockCtx, ockEVPKey,
                                                 keyBytesNative, &size);
                 (*env)->ReleasePrimitiveArrayCritical(env, keyBytes,
                                                       keyBytesNative, 0);
+                if (rc != ICC_OSSL_SUCCESS) {
+                    ockCheckStatus(ockCtx);
+                    (*env)->DeleteLocalRef(env, keyBytes);
+                    throwOCKException(env, 0, "ICC_EVP_PKEY_get_raw_public_key failed");
+                    return NULL;
+                }
             }
             if ((keyBytes != NULL)) {
                 (*env)->DeleteLocalRef(env, keyBytes);


### PR DESCRIPTION
Check and add error handling for native DH and XEC key operations. Improve robustness of DHKey.c and ECKey.c by checking return codes and error.

These changes prevent potential crashes from unchecked API failures and improve error reporting for debugging native key operations.

This is a back port PR from PR: https://github.com/IBM/OpenJCEPlus/pull/1550