### PR TITLE
Update jacoco-maven-plugin version to 0.8.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -630,7 +630,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.14</version>
+                <version>0.8.15</version>
                 <executions>
                     <execution>
                         <id>start-agent</id>
@@ -882,7 +882,7 @@
         <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.14</version>
+            <version>0.8.15</version>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>


### PR DESCRIPTION
Bump the JaCoCo Maven plugin from 0.8.14 to 0.8.15 in both the plugin configuration and the dependency management sections of pom.xml.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1616

Signed-off-by: Jason Katonica <katonica@us.ibm.com>