### PR TITLE
Validate expanded PQC private key encodings

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,8 @@ OpenJCEPlus provider enhances the security of Java applications by providing an 
 
 No keytool or certificate support was added other than what is already in a given Java runtime environment.
 
+OpenJCEPlus only accepts a `Expanded` Format of ML-KEM private key as defined in [RFC 9935](https://datatracker.ietf.org/doc/rfc9935/).
+
 ### ML-DSA
 
 Quantum-Resistant Module-Lattice-Based Digital Signature Algorithm (`ML-DSA`)
@@ -527,6 +529,8 @@ Quantum-Resistant Module-Lattice-Based Digital Signature Algorithm (`ML-DSA`)
 OpenJCEPlus provider enhances the security of Java applications by providing an implementation of quantum-resistant Module-Lattice-Based Digital Signature Algorithm (`ML-DSA`). Digital signatures are used to detect unauthorized modifications to data and to authenticate the identities of signatories. `ML-DSA` is designed to be secure against future quantum computing attacks and has been standardized by the United States National Institute of Standards and Technology (NIST) in [FIPS 204](https://csrc.nist.gov/pubs/fips/204/final).
 
 No keytool or certificate support was added other than what is already in a given Java runtime environment.
+
+OpenJCEPlus only accepts a `Expanded` Format of ML-DSA private key as defined in [RFC 9881](https://datatracker.ietf.org/doc/rfc9881/).
 
 ### ECKeyPairGenerator incorrect keysize
 

--- a/src/main/java/com/ibm/crypto/plus/provider/PQCPrivateKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCPrivateKey.java
@@ -11,6 +11,7 @@ package com.ibm.crypto.plus.provider;
 import com.ibm.crypto.plus.provider.base.PQCKey;
 import java.io.IOException;
 import java.security.InvalidKeyException;
+import java.security.ProviderException;
 import java.util.Arrays;
 import javax.security.auth.DestroyFailedException;
 import sun.security.pkcs.PKCS8Key;
@@ -79,7 +80,13 @@ final class PQCPrivateKey extends PKCS8Key {
         try {
             this.provider = provider;
             this.pqcKey = pqcKey;
+            this.name = PQCKnownOIDs.findMatch(pqcKey.getAlgorithm()).stdName();
+            this.algid = new AlgorithmId(PQCAlgorithmId.getOID(name));
 
+            validateKeyLength(pqcKey.getPrivateKeyBytes());
+            if (!isExpandedChoice(this.name, pqcKey.getPrivateKeyBytes())) {
+                throw new InvalidKeyException("Only expanded keys are supported by OpenJCEPlus");
+            }
             //Check to determine if the key bytes have the Octet tag.
             if (OctectStringEncoded(pqcKey.getPrivateKeyBytes())) {
                 this.key = pqcKey.getPrivateKeyBytes();
@@ -93,9 +100,6 @@ final class PQCPrivateKey extends PKCS8Key {
                     pkOct.clear();
                 }
             }
-
-            this.name = PQCKnownOIDs.findMatch(pqcKey.getAlgorithm()).stdName();
-            this.algid = new AlgorithmId(PQCAlgorithmId.getOID(name));
         } catch (Exception exception) {
             throw provider.providerException("Failure in PQCPrivateKey" + exception.getMessage(), exception);
         }
@@ -111,7 +115,10 @@ final class PQCPrivateKey extends PKCS8Key {
         this.provider = provider;
 
         this.name = PQCKnownOIDs.findMatch(this.algid.getName()).stdName();
-
+        validateKeyLength(this.key);
+        if (!isExpandedChoice(this.name, this.key)) {
+            throw new InvalidKeyException("Only expanded keys are supported by OpenJCEPlus");
+        }
         try {
             //Check to determine if the key bytes have the Octet tag.
             if (!(OctectStringEncoded(this.key))) {
@@ -236,4 +243,78 @@ final class PQCPrivateKey extends PKCS8Key {
         }
     }
 
+    /**
+     * Validates that the supplied key bytes are non-null and long enough to
+     * contain a valid DER-encoded expanded PQC private key (at least 4 bytes).
+     *
+     * @param key the raw key bytes to validate
+     * @throws InvalidKeyException if {@code key} is {@code null} or has fewer
+     *         than 4 bytes
+     */
+    private static void validateKeyLength(byte[] key) throws InvalidKeyException {
+        if (key == null) {
+            throw new InvalidKeyException("Private key material is null");
+        }
+        if (key.length < 4) {
+            throw new InvalidKeyException(
+                    "Private key material is too short: expected at least 4 bytes, got " + key.length);
+        }
+    }
+
+    /**
+     * Returns the expected byte length of the expanded private key for the
+     * given PQC algorithm name.
+     *
+     * @param algName the standard PQC algorithm name (e.g. {@code "ML-DSA-44"})
+     * @return the expected expanded private key length in bytes
+     * @throws ProviderException if {@code algName} is not a recognised PQC
+     *                           algorithm
+     */
+    private static int getExpandedKeyLength(String algName) {
+        if ("ML-DSA-44".equals(algName)) {
+            return 2560;
+        } else if ("ML-DSA-65".equals(algName)) {
+            return 4032;
+        } else if ("ML-DSA-87".equals(algName)) {
+            return 4896;
+        } else if ("ML-KEM-512".equals(algName)) {
+            return 1632;
+        } else if ("ML-KEM-768".equals(algName)) {
+            return 2400;
+        } else if ("ML-KEM-1024".equals(algName)) {
+            return 3168;
+        } else {
+            throw new ProviderException("Unexpected PQC algorithm: " + algName);
+        }
+    }
+
+    /**
+     * Determines whether the supplied private key material represents an
+     * expanded PQC private key.
+     *
+     * <p>RFC 9881 and RFC 9935 define PQC private key material as a CHOICE.
+     * An expanded key is encoded as an OCTET STRING. For the currently
+     * supported ML-DSA and ML-KEM parameter sets, the expanded key lengths
+     * are large enough that the DER OCTET STRING encoding uses long-form
+     * length encoding.</p>
+     *
+     * <p>This method checks the private key material contained in the PKCS#8
+     * privateKey OCTET STRING, not the complete PKCS#8 encoding.</p>
+     *
+     * @param algName the standard PQC algorithm name
+     * @param key the private key material to check
+     *
+     * @return true if the key material is an expanded private key encoding;
+     *         false otherwise
+     */
+    private boolean isExpandedChoice(String algName, byte[] key) {
+        int expandedLen = getExpandedKeyLength(algName);
+
+        int derLen = ((key[2] & 0xFF) << 8) | (key[3] & 0xFF);
+
+        return key.length == expandedLen + 4
+                && ((key[0] & 0xFF) == 0x04)
+                && ((key[1] & 0xFF) == 0x82)
+                && derLen == expandedLen;
+    }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeyInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeyInterop.java
@@ -16,6 +16,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.security.spec.EncodedKeySpec;
+import java.security.spec.KeySpec;
 import java.security.spec.NamedParameterSpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -82,6 +84,8 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
 
         //This is not in the FIPS provider yet.
         assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+        // BC provider generates seed format privatekey
+        assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName()));
 
         keyPairGenPlus = KeyPairGenerator.getInstance(pqcAlgorithm, getProviderName());
         keyFactoryPlus = KeyFactory.getInstance(pqcAlgorithm, getProviderName());
@@ -454,4 +458,76 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
                 "Keys do not match for test 2 with " + parameterSet);
     }
 
+    @ParameterizedTest
+    @CsvSource({"ML-KEM", "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+    public void testMLKEMGetKeySpecPrivateInteropToPlus(String algorithm)
+            throws Exception {
+        // This is not in the FIPS provider yet.
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+        assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName()));
+
+        KeyFactory openjceplusKeyFactory = KeyFactory.getInstance(algorithm, getProviderName());
+        KeyPairGenerator interopKpg = KeyPairGenerator.getInstance(algorithm, getInteropProviderName());
+        KeyPair interopKeyPair = interopKpg.generateKeyPair();
+        PrivateKey interopPrivateKey = interopKeyPair.getPrivate();
+        KeySpec interopPrivKeySpec = new PKCS8EncodedKeySpec(interopPrivateKey.getEncoded());
+        PrivateKey openjceplusPrivateKey = openjceplusKeyFactory.generatePrivate(interopPrivKeySpec);
+
+        KEM interopKem = KEM.getInstance(algorithm, getInteropProviderName());
+        KEM.Encapsulator encapsulator =
+                interopKem.newEncapsulator(interopKeyPair.getPublic());
+
+        KEM.Encapsulated encapsulated = encapsulator.encapsulate();
+
+        KEM openjceplusKem = KEM.getInstance(algorithm, getProviderName());
+        KEM.Decapsulator decapsulator =
+                openjceplusKem.newDecapsulator(openjceplusPrivateKey);
+
+        SecretKey openjceplusSecret =
+                decapsulator.decapsulate(encapsulated.encapsulation());
+
+        assertArrayEquals(encapsulated.key().getEncoded(),
+            openjceplusSecret.getEncoded());
+
+        KeySpec keySpec = openjceplusKeyFactory.getKeySpec(openjceplusPrivateKey, interopPrivKeySpec.getClass());
+        assertEquals(interopPrivKeySpec.getClass(), keySpec.getClass());
+        assertPrivateKeyPKCS8SpecEquals(interopPrivKeySpec, keySpec);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"ML-DSA", "ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
+    public void testMLDSAGetKeySpecPrivateInteropToPlus(String algorithm)
+            throws Exception {
+        // This is not in the FIPS provider yet.
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+        assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName()));
+
+        KeyFactory openjceplusKeyFactory = KeyFactory.getInstance(algorithm, getProviderName());
+        KeyPairGenerator interopKpg = KeyPairGenerator.getInstance(algorithm, getInteropProviderName2());
+        KeyPair interopKeyPair = interopKpg.generateKeyPair();
+        PrivateKey interopPrivateKey = interopKeyPair.getPrivate();
+        KeySpec interopPrivKeySpec = new PKCS8EncodedKeySpec(interopPrivateKey.getEncoded());
+        PrivateKey openjceplusPrivateKey = openjceplusKeyFactory.generatePrivate(interopPrivKeySpec);
+
+        Signature signerPlus = Signature.getInstance(algorithm, getProviderName());
+        signerPlus.initSign(openjceplusPrivateKey);
+        signerPlus.update(origMsg);
+        byte[] signaturePlus = signerPlus.sign();
+
+        Signature verifierInterop = Signature.getInstance(algorithm, getInteropProviderName2());
+        verifierInterop.initVerify(interopKeyPair.getPublic());
+        verifierInterop.update(origMsg);
+        assertTrue(verifierInterop.verify(signaturePlus), "Signature verification failed");
+    }
+
+    private void assertPrivateKeyPKCS8SpecEquals(KeySpec expected, KeySpec actual) {
+        assertEquals(PKCS8EncodedKeySpec.class, actual.getClass());
+
+        PKCS8EncodedKeySpec expectedSpec = (PKCS8EncodedKeySpec) expected;
+        PKCS8EncodedKeySpec actualSpec = (PKCS8EncodedKeySpec) actual;
+
+        assertArrayEquals(expectedSpec.getEncoded(), actualSpec.getEncoded());
+        assertEquals(expectedSpec.getAlgorithm(), actualSpec.getAlgorithm());
+        assertEquals(expectedSpec.getFormat(), actualSpec.getFormat());
+    }
 }

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeys.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeys.java
@@ -23,14 +23,20 @@ import java.security.spec.NamedParameterSpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HexFormat;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import sun.security.util.DerValue;
 import sun.security.x509.AlgorithmId;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class BaseTestPQCKeys extends BaseTestJunit5 {
 
@@ -38,7 +44,47 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
     protected KeyPairGenerator pqcKeyPairGen;
     protected KeyFactory pqcKeyFactory;
 
+    private static final String RFC9881_ML_DSA_44_PRIVATE_KEY_SEED = """
+            -----BEGIN PRIVATE KEY-----
+            MDQCAQAwCwYJYIZIAWUDBAMRBCKAIAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZ
+            GhscHR4f
+            -----END PRIVATE KEY-----
+            """;
 
+    private static final String RFC9881_ML_DSA_65_PRIVATE_KEY_SEED = """
+            -----BEGIN PRIVATE KEY-----
+            MDQCAQAwCwYJYIZIAWUDBAMSBCKAIAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZ
+            GhscHR4f
+            -----END PRIVATE KEY-----
+            """;
+
+    private static final String RFC9881_ML_DSA_87_PRIVATE_KEY_SEED = """
+            -----BEGIN PRIVATE KEY-----
+            MDQCAQAwCwYJYIZIAWUDBAMTBCKAIAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZ
+            GhscHR4f
+            -----END PRIVATE KEY-----
+            """;
+
+    private static final String RFC9935_ML_KEM_512_PRIVATE_KEY_SEED = """
+            -----BEGIN PRIVATE KEY-----
+            MFQCAQAwCwYJYIZIAWUDBAQBBEKAQAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZ
+            GhscHR4fICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8=
+            -----END PRIVATE KEY-----
+            """;
+
+    private static final String RFC9935_ML_KEM_768_PRIVATE_KEY_SEED = """
+            -----BEGIN PRIVATE KEY-----
+            MFQCAQAwCwYJYIZIAWUDBAQCBEKAQAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZ
+            GhscHR4fICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8=
+            -----END PRIVATE KEY-----
+            """;
+
+    private static final String RFC9935_ML_KEM_1024_PRIVATE_KEY_SEED = """
+            -----BEGIN PRIVATE KEY-----
+            MFQCAQAwCwYJYIZIAWUDBAQDBEKAQAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZ
+            GhscHR4fICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8=
+            -----END PRIVATE KEY-----
+            """;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -132,6 +178,48 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
             // Expected
         }
 
+    }
+
+    @ParameterizedTest
+    @MethodSource("rfcSeedPrivateKeys")
+    public void testRFC9881MLDSARFC9935MLKEMKeyFactory(String algorithm, String privateKeyPem) throws Exception {
+
+        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+        KeyFactory openjceplusKeyFactory = KeyFactory.getInstance(algorithm, getProviderName());
+        byte[] rfcPrivateKeyEncoded = decodePEM(privateKeyPem);
+
+        String expectedMessage = "Only expanded keys are supported by OpenJCEPlus";
+        try {
+            openjceplusKeyFactory.generatePrivate(new PKCS8EncodedKeySpec(rfcPrivateKeyEncoded));
+            fail("Expected InvalidKeySpecException for seed-only private key.");
+        } catch (InvalidKeySpecException e) {
+            assertEquals(expectedMessage, e.getCause().getMessage());
+        }
+    }
+
+    private static Stream<Arguments> rfcSeedPrivateKeys() {
+        return Stream.of(
+                Arguments.of("ML-DSA-44",
+                        RFC9881_ML_DSA_44_PRIVATE_KEY_SEED),
+                Arguments.of("ML-DSA-65",
+                        RFC9881_ML_DSA_65_PRIVATE_KEY_SEED),
+                Arguments.of("ML-DSA-87",
+                        RFC9881_ML_DSA_87_PRIVATE_KEY_SEED),
+                Arguments.of("ML-KEM-512",
+                        RFC9935_ML_KEM_512_PRIVATE_KEY_SEED),
+                Arguments.of("ML-KEM-768",
+                        RFC9935_ML_KEM_768_PRIVATE_KEY_SEED),
+                Arguments.of("ML-KEM-1024",
+                        RFC9935_ML_KEM_1024_PRIVATE_KEY_SEED)
+        );
+    }
+
+    private static byte[] decodePEM(String pem) {
+        String base64 = pem
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replaceAll("\\s", "");
+        return Base64.getDecoder().decode(base64);
     }
 
     protected KeyPair generateKeyPair(String Algorithm) throws Exception {


### PR DESCRIPTION
Update PQCPrivateKey to validate ML-DSA and ML-KEM private key material using the RFC 9881 / RFC 9935 expandedKey CHOICE encoding.

The validation checks that the private key material contained in the PKCS#8 privateKey OCTET STRING is encoded as a DER OCTET STRING with the expected expanded key length for the corresponding parameter set. Unsupported private key encodings are rejected with an InvalidKeyException.

Backported from: https://github.com/IBM/OpenJCEPlus/pull/1520