### PR TITLE
Add OpenJCEPlusFIPS to module-info.java provider registration

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023
+ * Copyright IBM Corp. 2023, 2026
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -13,5 +13,7 @@ module openjceplus {
     exports ibm.security.internal.spec;
     exports com.ibm.crypto.plus.provider;
 
-    provides java.security.Provider with com.ibm.crypto.plus.provider.OpenJCEPlus;
+    provides java.security.Provider with
+        com.ibm.crypto.plus.provider.OpenJCEPlus,
+        com.ibm.crypto.plus.provider.OpenJCEPlusFIPS;
 }


### PR DESCRIPTION
Register OpenJCEPlusFIPS alongside OpenJCEPlus as a java.security.Provider service in the module descriptor, enabling ServiceLoader-based discovery of the FIPS provider without requiring explicit instantiation.