### PR TITLE
Use ICC_EVP_PKEY_size for XDH key agreement buffer sizing

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
@@ -28,9 +28,6 @@ import javax.crypto.spec.SecretKeySpec;
 
 abstract class XDHKeyAgreement extends KeyAgreementSpi {
 
-    private static final int SECRET_BUFFER_SIZE_X25519 = 32;
-    private static final int SECRET_BUFFER_SIZE_X448 = 56;
-
     private OpenJCEPlusProvider provider = null;
     private long genCtx;
     private XECKey ockXecKeyPub = null;
@@ -102,16 +99,6 @@ abstract class XDHKeyAgreement extends KeyAgreementSpi {
         }
 
         try {
-            int secrectBufferSize = 0;
-            if (System.getProperty("os.name").equals("z/OS")) {
-                String curveName = ((NamedParameterSpec) xdhPublicKeyImpl.getParams()).getName();
-                if (NamedParameterSpec.X25519.getName().equalsIgnoreCase(curveName)) {
-                    secrectBufferSize = SECRET_BUFFER_SIZE_X25519; // X25519 secret buffer size
-                } else if (NamedParameterSpec.X448.getName().equalsIgnoreCase(curveName)) {
-                    secrectBufferSize = SECRET_BUFFER_SIZE_X448; // X448 secret buffer size
-                }
-            }
-
             String configAlgName = this.alg;
             
             if (configAlgName == null) {
@@ -119,7 +106,7 @@ abstract class XDHKeyAgreement extends KeyAgreementSpi {
             }
 
             this.secret = XECKey.computeECDHSecret(genCtx,
-                    ockXecKeyPub.getPKeyId(), ockXecKeyPriv.getPKeyId(), secrectBufferSize, provider, configAlgName);
+                    ockXecKeyPub.getPKeyId(), ockXecKeyPriv.getPKeyId(), provider, configAlgName);
         } catch (NativeException e) {
             //Validate the secret value for a small order point condition.
             byte orValue = (byte) 0;

--- a/src/main/java/com/ibm/crypto/plus/provider/base/NativeInterface.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/NativeInterface.java
@@ -547,7 +547,7 @@ public interface NativeInterface {
             long privEcKeyId) throws NativeException;
 
     public byte[] XECKEY_computeECDHSecret(long genCtx,
-            long pubEcKeyId, long privEcKeyId, int secrectBufferSize) throws NativeException;
+            long pubEcKeyId, long privEcKeyId) throws NativeException;
 
 
     public byte[] ECKEY_signDatawithECDSA(byte[] digestBytes,

--- a/src/main/java/com/ibm/crypto/plus/provider/base/XECKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/XECKey.java
@@ -66,7 +66,7 @@ public final class XECKey implements AsymmetricKey {
     }
 
     public static byte[] computeECDHSecret(long genCtx, long pubId,
-            long privId, int secrectBufferSize, OpenJCEPlusProvider provider, String configAlgName) throws NativeException {
+            long privId, OpenJCEPlusProvider provider, String configAlgName) throws NativeException {
         if (pubId == 0)
             throw new IllegalArgumentException("The public key parameter is not valid");
         if (privId == 0)
@@ -74,7 +74,7 @@ public final class XECKey implements AsymmetricKey {
 
         NativeInterface nativeInterface = NativeCryptoSelector.selectBackend(provider, "KeyAgreement", configAlgName);
         byte[] sharedSecretBytes = nativeInterface.XECKEY_computeECDHSecret(
-                genCtx, pubId, privId, secrectBufferSize);
+                genCtx, pubId, privId);
         //OCKDebug.Msg (debPrefix, methodName,  "pubId :" + pubId + " privId :" + privId + " sharedSecretBytes :", sharedSecretBytes);
         return sharedSecretBytes;
     }

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKAdapter.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKAdapter.java
@@ -1112,9 +1112,9 @@ public abstract class NativeOCKAdapter implements NativeInterface {
     }
 
     @Override
-    public byte[] XECKEY_computeECDHSecret(long genCtx, long pubEcKeyId, long privEcKeyId, int secrectBufferSize)
+    public byte[] XECKEY_computeECDHSecret(long genCtx, long pubEcKeyId, long privEcKeyId)
             throws OCKException {
-        return NativeOCKImplementation.XECKEY_computeECDHSecret(ockContext.getId(), genCtx, pubEcKeyId, privEcKeyId, secrectBufferSize);
+        return NativeOCKImplementation.XECKEY_computeECDHSecret(ockContext.getId(), genCtx, pubEcKeyId, privEcKeyId);
     }
 
     @Override

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKImplementation.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKImplementation.java
@@ -724,7 +724,7 @@ final class NativeOCKImplementation {
             long privEcKeyId) throws OCKException;
 
     static public native byte[] XECKEY_computeECDHSecret(long ockContextId, long genCtx,
-            long pubEcKeyId, long privEcKeyId, int secrectBufferSize) throws OCKException;
+            long pubEcKeyId, long privEcKeyId) throws OCKException;
 
 
     static public native byte[] ECKEY_signDatawithECDSA(long ockContextId, byte[] digestBytes,

--- a/src/main/native/ock/ECKey.c
+++ b/src/main/native/ock/ECKey.c
@@ -2274,24 +2274,24 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_ECKEY_1computeECDH
 /*
  * Class:     com_ibm_crypto_plus_provider_ock_NativeOCKImplementation
  * Method:    XECKEY_computeECDHSecret
- * Signature: (JJJJI)[B
+ * Signature: (JJJJ)[B
  */
 JNIEXPORT jbyteArray JNICALL
 Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_XECKEY_1computeECDHSecret(
     JNIEnv *env, jclass thisObj, jlong ockContextId, jlong genCtx,
-    jlong pubXecKeyId, jlong privXecKeyId, jint secretBufferSize) {
+    jlong pubXecKeyId, jlong privXecKeyId) {
     static const char *functionName =
         "NativeInterface_XECKEY_1computeECDHSecret";
 
-    ICC_CTX            *ockCtx       = (ICC_CTX *)((intptr_t)ockContextId);
-    ICC_EVP_PKEY       *ockPubXecKey = (ICC_EVP_PKEY *)((intptr_t)pubXecKeyId);
-    const ICC_EVP_PKEY *ockPrivXecKey =
+    ICC_CTX            *ockCtx          = (ICC_CTX *)((intptr_t)ockContextId);
+    ICC_EVP_PKEY       *ockPubXecKey    = (ICC_EVP_PKEY *)((intptr_t)pubXecKeyId);
+    const ICC_EVP_PKEY *ockPrivXecKey   =
         (const ICC_EVP_PKEY *)((intptr_t)privXecKeyId);
     ICC_EVP_PKEY_CTX *gen_ctx           = NULL;
     jbyteArray        secretBytes       = NULL;
     unsigned char    *secretBytesNative = NULL;
     jboolean          isCopy            = 0;
-    size_t            required_len      = 0;
+    int               required_len      = 0;
     size_t            secret_key_len    = 0;
     int               rc                = 0;
 
@@ -2318,32 +2318,15 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_XECKEY_1computeECD
         goto cleanup;
     }
 
-    if (secretBufferSize > 0) {
-        /*
-         * On z/OS, querying the required secret size may not work properly.
-         * In that case, use the caller-provided secretBufferSize as the
-         * expected derived secret size.
-         */
-        required_len = (size_t) secretBufferSize;
-    } else {
-        /*
-         * Query the required secret size before deriving the secret.
-         * This avoids deriving into a buffer with an incorrect size.
-         */
-        rc = ICC_EVP_PKEY_derive(ockCtx, gen_ctx, NULL, &required_len); /* Get secret key size */
-        if (ICC_OSSL_SUCCESS != rc) {
-            throwOCKException(env, 0,
-                    "ICC_EVP_PKEY_derive failed to get secret size");
-            goto cleanup;
-        }
-        if (required_len == 0) {
-            throwOCKException(env, 0, "Derived secret size is zero");
-            goto cleanup;
-        }
+    /* Determine buffer size using ICC_EVP_PKEY_size with the public key */
+    required_len = ICC_EVP_PKEY_size(ockCtx, ockPubXecKey);
+    if (required_len <= 0) {
+        throwOCKException(env, 0, "Derived secret size is zero");
+        goto cleanup;
     }
-    secret_key_len = required_len;
 
-    secretBytes = (*env)->NewByteArray(env, secret_key_len); /* Create Java secret bytes array */
+    secret_key_len = (size_t)required_len;
+    secretBytes = (*env)->NewByteArray(env, (jsize) secret_key_len); /* Create Java secret bytes array */
     if (NULL == secretBytes) {
         throwOCKException(env, 0, "NewByteArray failed");
         goto cleanup;
@@ -2362,9 +2345,8 @@ Java_com_ibm_crypto_plus_provider_ock_NativeOCKImplementation_XECKEY_1computeECD
         goto cleanup;
     }
 
-    if (secret_key_len != required_len) {
-        throwOCKException(env, 0,
-                          "Derived secret size does not match required size");
+    if (secret_key_len != (size_t)required_len) {
+        throwOCKException(env, 0, "Derived secret size does not match required size");
         goto cleanup;
     }
 


### PR DESCRIPTION
Replace ICC_EVP_PKEY_derive size query with ICC_EVP_PKEY_size call to determine buffer size before deriving shared secret. Removes platform-specific workarounds and simplifies the implementation.

This is a back port PR from PR: https://github.com/IBM/OpenJCEPlus/pull/1617