### PR TITLE
Update test tags and method sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,7 @@
                       --add-exports=openjceplus/ibm.jceplus.junit.base.memstress=ALL-UNNAMED
                       --add-exports=openjceplus/ibm.jceplus.junit.suites=ALL-UNNAMED
                       --add-exports=openjceplus/ibm.jceplus.junit.tests=ALL-UNNAMED
+                      --add-exports=openjceplus/ibm.jceplus.junit.tests.parameters.resolvers=ALL-UNNAMED
                       --add-exports=openjceplus/ibm.jceplus.junit.openjceplus=ALL-UNNAMED
                       --add-exports=openjceplus/ibm.jceplus.junit.openjceplus.integration=ALL-UNNAMED
                       --add-exports=openjceplus/ibm.jceplus.junit.openjceplus.memstress=ALL-UNNAMED
@@ -259,6 +260,7 @@
                       --add-exports=openjceplus/ibm.jceplus.junit.openjceplusfips.multithread=ALL-UNNAMED
                       --add-opens=openjceplus/ibm.jceplus.junit.base=ALL-UNNAMED
                       --add-opens=openjceplus/ibm.jceplus.junit.tests=ALL-UNNAMED
+                      --add-opens=openjceplus/ibm.jceplus.junit.tests.parameters.resolvers=ALL-UNNAMED
                       --patch-module openjceplus="target${file.separator}classes${path.separator}target${file.separator}test-classes"
                       -Djava.security.auth.debug=${java.security.auth.debug}
                     </argLine>

--- a/src/test/java/ibm/jceplus/junit/suites/BaseTestMultiThread.java
+++ b/src/test/java/ibm/jceplus/junit/suites/BaseTestMultiThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -45,7 +45,7 @@ public abstract class BaseTestMultiThread {
      * Returns the tag name to filter tests by.
      * @return the tag name
      */
-    protected abstract String getTagName();
+    protected abstract String getTagExpression();
 
     /**
      * Returns the package name to search for tests in.
@@ -133,7 +133,7 @@ public abstract class BaseTestMultiThread {
         
         LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
             .selectors(selectPackage(getPackageName()))
-            .filters(includeTags(getTagName()))
+            .filters(includeTags(getTagExpression()))
             .build();
         
         Launcher launcher = LauncherFactory.create();
@@ -170,13 +170,13 @@ public abstract class BaseTestMultiThread {
     @Test
     public void testMultithread() {
         System.out.println("#threads=" + numThreads + " timeout=" + timeoutSec);
-        System.out.println("Discovering tests tagged with '" + getTagName() + "' in " + getPackageName() + " package...");
+        System.out.println("Discovering tests tagged with '" + getTagExpression() + "' in " + getPackageName() + " package...");
 
         List<String> testClasses = discoverTestClasses();
-        System.out.println("Found " + testClasses.size() + " test classes with " + getTagName() + " tag");
+        System.out.println("Found " + testClasses.size() + " test classes with " + getTagExpression() + " tag");
         
         if (testClasses.isEmpty()) {
-            fail("No test classes found with " + getTagName() + " tag");
+            fail("No test classes found with " + getTagExpression() + " tag");
         }
 
         List<String> failedTests = new ArrayList<>();

--- a/src/test/java/ibm/jceplus/junit/suites/TestAll.java
+++ b/src/test/java/ibm/jceplus/junit/suites/TestAll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -8,6 +8,9 @@
 
 package ibm.jceplus.junit.suites;
 
+import ibm.jceplus.junit.tests.Tags;
+import org.junit.platform.suite.api.ExcludeClassNamePatterns;
+import org.junit.platform.suite.api.IncludeTags;
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
@@ -17,5 +20,7 @@ import org.junit.platform.suite.api.Suite;
  */
 @Suite
 @SelectPackages("ibm.jceplus.junit.tests")
+@IncludeTags({Tags.OPENJCEPLUS_NAME, Tags.OPENJCEPLUS_FIPS_NAME})
+@ExcludeClassNamePatterns("^.*(?i)multithread.*$")
 public class TestAll {
 }

--- a/src/test/java/ibm/jceplus/junit/suites/TestMultiThreadOpenJCEPlus.java
+++ b/src/test/java/ibm/jceplus/junit/suites/TestMultiThreadOpenJCEPlus.java
@@ -21,7 +21,7 @@ public class TestMultiThreadOpenJCEPlus extends BaseTestMultiThread {
     }
 
     @Override
-    protected String getTagName() {
-        return Tags.OPENJCEPLUS_MULTITHREAD.getTag();
+    protected String getTagExpression() {
+        return Tags.OPENJCEPLUS.getTag() + " & " + Tags.MULTITHREAD.getTag();
     }
 }

--- a/src/test/java/ibm/jceplus/junit/suites/TestMultiThreadOpenJCEPlusFIPS.java
+++ b/src/test/java/ibm/jceplus/junit/suites/TestMultiThreadOpenJCEPlusFIPS.java
@@ -21,7 +21,7 @@ public class TestMultiThreadOpenJCEPlusFIPS extends BaseTestMultiThread {
     }
 
     @Override
-    protected String getTagName() {
-        return Tags.OPENJCEPLUS_FIPS_MULTITHREAD.getTag();
+    protected String getTagExpression() {
+        return Tags.OPENJCEPLUS_FIPS.getTag() + " & " + Tags.MULTITHREAD.getTag();
     }
 }

--- a/src/test/java/ibm/jceplus/junit/tests/BaseTest.java
+++ b/src/test/java/ibm/jceplus/junit/tests/BaseTest.java
@@ -8,8 +8,11 @@
 
 package ibm.jceplus.junit.tests;
 
+import ibm.jceplus.junit.tests.parameters.resolvers.ProviderListParameterResolver;
 import java.security.Provider;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ProviderListParameterResolver.class)
 abstract public class BaseTest {
 
     private String providerName;

--- a/src/test/java/ibm/jceplus/junit/tests/BaseTestRSA.java
+++ b/src/test/java/ibm/jceplus/junit/tests/BaseTestRSA.java
@@ -294,7 +294,7 @@ public abstract class BaseTestRSA extends BaseTestCipher {
     @CsvSource({"NoPadding",
                 "PKCS1Padding",
                 "OAEPWithSHA1AndMGF1Padding",
-                "OAEPWithSHA-11AndMGF1Padding",
+                "OAEPWithSHA-1AndMGF1Padding",
     })
     public void testDisallowSHA1inFIPS_padding(String padding) throws Exception {
         assumeTrue("OpenJCEPlusFIPS".equals(getProviderName()));

--- a/src/test/java/ibm/jceplus/junit/tests/Tags.java
+++ b/src/test/java/ibm/jceplus/junit/tests/Tags.java
@@ -15,14 +15,12 @@ public enum Tags {
 
     OPENJCEPLUS(TestProvider.OpenJCEPlus.getProviderName()),
     OPENJCEPLUS_FIPS(TestProvider.OpenJCEPlusFIPS.getProviderName()),
-    OPENJCEPLUS_MULTITHREAD("OpenJCEPlusMultithread"),
-    OPENJCEPLUS_FIPS_MULTITHREAD("OpenJCEPlusFIPSMultithread");
+    MULTITHREAD("Multithread");
 
     // Constants for tag names (can be used in annotations where compiler couldn't use a runtime method)
     public static final String OPENJCEPLUS_NAME = TestProvider.OPENJCEPLUS_NAME;
     public static final String OPENJCEPLUS_FIPS_NAME = TestProvider.OPENJCEPLUS_FIPS_NAME;
-    public static final String OPENJCEPLUS_MULTITHREAD_NAME = "OpenJCEPlusMultithread";
-    public static final String OPENJCEPLUS_FIPS_MULTITHREAD_NAME = "OpenJCEPlusFIPSMultithread";
+    public static final String MULTITHREAD_NAME = "Multithread";
 
     private final String tag;
 

--- a/src/test/java/ibm/jceplus/junit/tests/TestAES.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestAES.java
@@ -8,6 +8,7 @@
 
 package ibm.jceplus.junit.tests;
 
+import ibm.jceplus.junit.tests.parameters.resolvers.AESKeySizeListParameterResolver;
 import java.nio.ByteBuffer;
 import java.security.AlgorithmParameters;
 import java.security.InvalidAlgorithmParameterException;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.Parameter;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -40,11 +42,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(AESKeySizeListParameterResolver.class)
 @ParameterizedClass
-@MethodSource("ibm.jceplus.junit.tests.TestArguments#aesKeySizesAndJCEPlusProviders")
+@MethodSource("ibm.jceplus.junit.tests.TestArguments#keySizesAndProviders")
 public class TestAES extends BaseTestCipher {
 
     @Parameter(0)
@@ -1156,5 +1158,4 @@ public class TestAES extends BaseTestCipher {
 
         buffer.flip();
     }
-
 }

--- a/src/test/java/ibm/jceplus/junit/tests/TestAESCipherInputStreamExceptions.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestAESCipherInputStreamExceptions.java
@@ -36,8 +36,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestAESCopySafe.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestAESCopySafe.java
@@ -31,8 +31,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestAESGCM.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestAESGCM.java
@@ -8,6 +8,7 @@
 
 package ibm.jceplus.junit.tests;
 
+import ibm.jceplus.junit.tests.parameters.resolvers.AESKeySizeListParameterResolver;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.security.AlgorithmParameters;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.Parameter;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -41,11 +43,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(AESKeySizeListParameterResolver.class)
 @ParameterizedClass
-@MethodSource("ibm.jceplus.junit.tests.TestArguments#aesKeySizesAndJCEPlusProviders")
+@MethodSource("ibm.jceplus.junit.tests.TestArguments#keySizesAndProviders")
 public class TestAESGCM extends BaseTest {
 
     @Parameter(0)
@@ -1140,5 +1142,4 @@ public class TestAESGCM extends BaseTest {
         }
 
     }
-
 }

--- a/src/test/java/ibm/jceplus/junit/tests/TestAESGCMCICOWithGCM.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestAESGCMCICOWithGCM.java
@@ -28,8 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestAESGCMCICOWithGCMAndAAD.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestAESGCMCICOWithGCMAndAAD.java
@@ -30,8 +30,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestAESGCMLong.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestAESGCMLong.java
@@ -27,8 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestAESGCMNonExpanding.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestAESGCMNonExpanding.java
@@ -37,8 +37,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestAESGCMSameBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestAESGCMSameBuffer.java
@@ -30,8 +30,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestAESGCMWithByteBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestAESGCMWithByteBuffer.java
@@ -28,8 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestArguments.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestArguments.java
@@ -10,6 +10,7 @@ package ibm.jceplus.junit.tests;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.Arguments;
@@ -20,42 +21,21 @@ import org.junit.jupiter.params.provider.Arguments;
 public class TestArguments {
 
     /**
-     * Generates test combinations for each AES key size with the active OpenJCEPlus* providers.
-     * 
-     * @return Stream of Arguments containing AES key sizes and OpenJCEPlus* providers
-     */ 
-    protected static Stream<Arguments> aesKeySizesAndJCEPlusProviders() {
-        int[] aesKeySizes = {128, 192, 256};
-        return keySizesAndJCEPlusProviders(aesKeySizes);
-    }
-
-    /**
-     * Generates test combinations for each RSA key size with the active OpenJCEPlus* providers.
-     *
-     * @return Stream of Arguments containing RSA key sizes and OpenJCEPlus* providers
-     */
-    protected static Stream<Arguments> rsaKeySizesAndJCEPlusProviders() {
-        int[] rsaKeySizes = {512, 1024, 2048, 3072, 4096};
-        return keySizesAndJCEPlusProviders(rsaKeySizes);
-    }
-
-    /**
-     * Generates test combinations for RSA key size with the active OpenJCEPlus* providers for multi-threading.
-     *
-     * @return Stream of Arguments containing RSA key size and OpenJCEPlus* providers
-     */
-    protected static Stream<Arguments> rsaMultithreadKeySizesAndProviders() {
-        int[] rsaKeySizes = {2048};
-        return keySizesAndJCEPlusProviders(rsaKeySizes);
-    }
-
-    /**
      * Generates combinations of OpenJCEPlus* providers with the SUN provider for interoperability testing.
      *
      * @return Stream of Arguments containing (JCEProviders, SUN) pairs
      */
-    protected static Stream<Arguments> getOpenJCEPlusWithSUNInteropProvider() {
-        return getOpenJCEPlusWithInteropProviders(TestProvider.SUN);
+    protected static Stream<Arguments> getOpenJCEPlusWithSUNInteropProvider(Set<String> providers) {
+        return getOpenJCEPlusWithInteropProviders(providers, TestProvider.SUN);
+    }
+
+    /**
+     * Generates combinations of OpenJCEPlus* providers with the SunJCE provider for interoperability testing.
+     *
+     * @return Stream of Arguments containing (JCEProviders, SunJCE) pairs
+     */
+    protected static Stream<Arguments> getOpenJCEPlusWithSunJCEInteropProvider(Set<String> providers) {
+        return getOpenJCEPlusWithInteropProviders(providers, TestProvider.SunJCE);
     }
 
     /**
@@ -64,81 +44,53 @@ public class TestArguments {
      *
      * @return Stream of Arguments containing (OpenJCEPlus, BC) pair
      */
-    protected static Stream<Arguments> getOpenJCEPlusOnlyWithBCInteropProvider() {
-        List<Arguments> arguments = new ArrayList<>();
-
-        for (TestProvider provider : getOpenJCEPlusOnly().collect(Collectors.toList())) {
-            arguments.add(Arguments.of(provider, TestProvider.BC));
-        }
-
-        return arguments.stream();
+    protected static Stream<Arguments> getOpenJCEPlusWithBCInteropProvider(Set<String> providers) {
+        return getOpenJCEPlusWithInteropProviders(providers, TestProvider.BC);
     }
 
-    /**
-     * Generates combination of only OpenJCEPlus (non-FIPS) provider
-     * with the SunJCE provider for interoperability testing.
-     *
-     * @return Stream of Arguments containing (OpenJCEPlus, SunJCE) pair
-     */
-    protected static Stream<Arguments> getOpenJCEPlusOnlyWithSunJCEInteropProvider() {
-        List<Arguments> arguments = new ArrayList<>();
-
-        for (TestProvider provider : getOpenJCEPlusOnly().collect(Collectors.toList())) {
-            arguments.add(Arguments.of(provider, TestProvider.SunJCE));
-        }
-
-        return arguments.stream();
-    }
-
-    /**
-     * Generates combinations of all key sizes and OpenJCEPlus* providers under test.
-     * 
-     * If no tags are found, all variations are returned.
-     * 
-     * @param keySizes Array of key sizes to combine with providers
-     * 
-     * @return Stream of Arguments containing key sizes and OpenJCEPlus* providers
-     */
-    private static Stream<Arguments> keySizesAndJCEPlusProviders(int[] keySizes) {
-
-        // Check if provider tags are present and build a list. Defaults to all providers.
-        List<TestProvider> activeProviders = getEnabledProviders().collect(Collectors.toList());
+    public static Stream<Arguments> keySizesAndProviders(Set<String> providers, List<Integer> keySizes) {
+        // Determine enabled providers.
+        List<TestProvider> enabledProviders = getEnabledProviders(providers).collect(Collectors.toList());
 
         // Generate all combinations of key sizes and providers determined above.
         List<Arguments> arguments = new ArrayList<>();
-        for (TestProvider provider : activeProviders) {
+        for (TestProvider provider : enabledProviders) {
             for (int keySize : keySizes) {
                 arguments.add(Arguments.of(keySize, provider));
             }
         }
 
         if (arguments.isEmpty()) {
-            throw new IllegalArgumentException("No test arguments, unlikey this is what was asked for.");
+            throw new IllegalArgumentException("No test arguments, unlikely this is what was asked for.");
         }
         return arguments.stream();
     }
 
     /**
-     * Resolves enabled OpenJCEPlus* providers from -Dgroups, defaulting to all when none are specified.
+     * Resolves enabled OpenJCEPlus* providers from -Dgroups, defaulting to all specified through tags, if none are specified.
      *
      * @return A stream of enabled TestProvider.
      */
-    protected static Stream<TestProvider> getEnabledProviders() {
+    protected static Stream<TestProvider> getEnabledProviders(Set<String> providers) {
 
         // Get active provider tags from -Dgroups system property
         String[] groupPropertyTags = BaseTest.getTagsPropertyAsArray();
 
         //retrieve enabled providers based on tags
-        List<TestProvider> enabledProviders = new ArrayList<>();
+        List<TestProvider> enabledProviders;
+        List<TestProvider> taggedProviders = providers.stream().map(pName -> TestProvider.valueOf(pName)).collect(Collectors.toList());
         if (groupPropertyTags.length == 0) {
-            enabledProviders.add(TestProvider.OpenJCEPlus);
-            enabledProviders.add(TestProvider.OpenJCEPlusFIPS);
+            enabledProviders = taggedProviders;
         } else {
+            enabledProviders = new ArrayList<>();
             for (String tag : groupPropertyTags) {
-                if (TestProvider.OpenJCEPlus.getProviderName().equalsIgnoreCase(tag)) {
-                    enabledProviders.add(TestProvider.OpenJCEPlus);
-                } else if (TestProvider.OpenJCEPlusFIPS.getProviderName().equalsIgnoreCase(tag)) {
-                    enabledProviders.add(TestProvider.OpenJCEPlusFIPS);
+                try {
+                    TestProvider tp = TestProvider.valueOf(tag);
+                    if (taggedProviders.contains(tp)) {
+                        enabledProviders.add(tp);
+                    }
+                } catch (IllegalArgumentException | NullPointerException e) {
+                    throw new IllegalStateException("The -Dgroup property values are incorrect", e);
                 }
             }
         }
@@ -151,8 +103,8 @@ public class TestArguments {
      * @param interopProvider The interoperability provider to combine with OpenJCEPlus* providers
      * @return Stream of Arguments containing (JCEProviders, interopProvider) pairs
      */
-    protected static Stream<Arguments> getOpenJCEPlusWithInteropProviders(TestProvider interopProvider) {
-        List<TestProvider> enabledProviders = getEnabledProviders().collect(Collectors.toList());
+    protected static Stream<Arguments> getOpenJCEPlusWithInteropProviders(Set<String> providers, TestProvider interopProvider) {
+        List<TestProvider> enabledProviders = getEnabledProviders(providers).collect(Collectors.toList());
 
         List<Arguments> arguments = new ArrayList<>();
         for (TestProvider jceProvider : enabledProviders) {
@@ -160,26 +112,5 @@ public class TestArguments {
         }
 
         return arguments.stream();
-    }
-
-    /**
-     * Resolves enabled OpenJCEPlus (non-FIPS) provider from -Dgroups, defaulting to OpenJCEPlus when none are specified.
-     *
-     * @return A stream of enabled TestProvider.
-     */
-    protected static Stream<TestProvider> getOpenJCEPlusOnly() {
-        String[] groupPropertyTags = BaseTest.getTagsPropertyAsArray();
-        if (groupPropertyTags.length == 0) {
-            return Stream.of(TestProvider.OpenJCEPlus);
-        }
-
-        List<TestProvider> enabledProviders = new ArrayList<>();
-        for (String tag : groupPropertyTags) {
-            if (TestProvider.OpenJCEPlus.getProviderName().equalsIgnoreCase(tag)) {
-                enabledProviders.add(TestProvider.OpenJCEPlus);
-            }
-        }
-
-        return enabledProviders.stream();
     }
 }

--- a/src/test/java/ibm/jceplus/junit/tests/TestChaCha20.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestChaCha20.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 @Tag(Tags.OPENJCEPLUS_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
-@MethodSource("ibm.jceplus.junit.tests.TestArguments#getOpenJCEPlusOnly")
+@MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")
 public class TestChaCha20 extends BaseTest implements ChaCha20Constants {
 
     @Parameter(0)

--- a/src/test/java/ibm/jceplus/junit/tests/TestChaCha20KAT.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestChaCha20KAT.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 @Tag(Tags.OPENJCEPLUS_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
-@MethodSource("ibm.jceplus.junit.tests.TestArguments#getOpenJCEPlusOnly")
+@MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")
 public class TestChaCha20KAT extends BaseTest {
 
     @Parameter(0)

--- a/src/test/java/ibm/jceplus/junit/tests/TestChaCha20NoReuse.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestChaCha20NoReuse.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 @Tag(Tags.OPENJCEPLUS_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
-@MethodSource("ibm.jceplus.junit.tests.TestArguments#getOpenJCEPlusOnly")
+@MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")
 public class TestChaCha20NoReuse extends BaseTest implements ChaCha20Constants {
 
     @Parameter(0)

--- a/src/test/java/ibm/jceplus/junit/tests/TestChaCha20Poly1305.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestChaCha20Poly1305.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 @Tag(Tags.OPENJCEPLUS_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
-@MethodSource("ibm.jceplus.junit.tests.TestArguments#getOpenJCEPlusOnly")
+@MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")
 public class TestChaCha20Poly1305 extends BaseTest implements ChaCha20Constants {
 
     @Parameter(0)

--- a/src/test/java/ibm/jceplus/junit/tests/TestChaCha20Poly1305ByteBuffer.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestChaCha20Poly1305ByteBuffer.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Tag(Tags.OPENJCEPLUS_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
-@MethodSource("ibm.jceplus.junit.tests.TestArguments#getOpenJCEPlusOnly")
+@MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")
 public class TestChaCha20Poly1305ByteBuffer extends BaseTest {
 
     @Parameter(0)

--- a/src/test/java/ibm/jceplus/junit/tests/TestChaCha20Poly1305ChunkUpdate.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestChaCha20Poly1305ChunkUpdate.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Tag(Tags.OPENJCEPLUS_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
-@MethodSource("ibm.jceplus.junit.tests.TestArguments#getOpenJCEPlusOnly")
+@MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")
 public class TestChaCha20Poly1305ChunkUpdate extends BaseTest
         implements ChaCha20Constants {
 

--- a/src/test/java/ibm/jceplus/junit/tests/TestDESede.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestDESede.java
@@ -36,8 +36,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestDSASignatureInterop.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestDSASignatureInterop.java
@@ -34,8 +34,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getOpenJCEPlusWithSUNInteropProvider")

--- a/src/test/java/ibm/jceplus/junit/tests/TestDSASignatureInterop2.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestDSASignatureInterop2.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 @Tag(Tags.OPENJCEPLUS_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
-@MethodSource("ibm.jceplus.junit.tests.TestArguments#getOpenJCEPlusOnlyWithBCInteropProvider")
+@MethodSource("ibm.jceplus.junit.tests.TestArguments#getOpenJCEPlusWithBCInteropProvider")
 public class TestDSASignatureInterop2 extends BaseTestSignatureInterop {
 
     @Parameter(0)

--- a/src/test/java/ibm/jceplus/junit/tests/TestECDSASignature.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestECDSASignature.java
@@ -47,8 +47,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestHmacMD5.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestHmacMD5.java
@@ -21,10 +21,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
-@MethodSource("ibm.jceplus.junit.tests.TestArguments#getOpenJCEPlusOnly")
+@MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")
 public class TestHmacMD5 extends BaseTest {
 
     @Parameter(0)

--- a/src/test/java/ibm/jceplus/junit/tests/TestHmacMD5Interop.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestHmacMD5Interop.java
@@ -23,10 +23,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
-@MethodSource("ibm.jceplus.junit.tests.TestArguments#getOpenJCEPlusOnlyWithSunJCEInteropProvider")
+@MethodSource("ibm.jceplus.junit.tests.TestArguments#getOpenJCEPlusWithSunJCEInteropProvider")
 public class TestHmacMD5Interop extends BaseTestInterop {
 
     @Parameter(0)

--- a/src/test/java/ibm/jceplus/junit/tests/TestHmacSHA3_224.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestHmacSHA3_224.java
@@ -23,8 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestHmacSHA3_256.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestHmacSHA3_256.java
@@ -23,8 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestHmacSHA3_384.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestHmacSHA3_384.java
@@ -23,8 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestHmacSHA3_512.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestHmacSHA3_512.java
@@ -23,8 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestMiniRSAPSS2.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestMiniRSAPSS2.java
@@ -31,8 +31,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestPBMAC1Interop.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestPBMAC1Interop.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 @Tag(Tags.OPENJCEPLUS_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
-@MethodSource("ibm.jceplus.junit.tests.TestArguments#getOpenJCEPlusOnly")
+@MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")
 public class TestPBMAC1Interop extends BaseTestInterop {
 
     @Parameter(0)

--- a/src/test/java/ibm/jceplus/junit/tests/TestProvider.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestProvider.java
@@ -27,7 +27,7 @@ public enum TestProvider {
     public static final String SUNRSASIGN_NAME = "SunRsaSign";
     public static final String SUNEC_NAME = "SunEC";
     public static final String OPENJCEPLUS_NAME = "OpenJCEPlus";
-    public static final String OPENJCEPLUS_FIPS_NAME = "OpenJCEPlusFIPS";    
+    public static final String OPENJCEPLUS_FIPS_NAME = "OpenJCEPlusFIPS";
 
     private final String providerName;
     private final String providerClassName;

--- a/src/test/java/ibm/jceplus/junit/tests/TestProviderServices.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestProviderServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2025, 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -32,10 +32,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestRSA.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestRSA.java
@@ -8,12 +8,15 @@
 
 package ibm.jceplus.junit.tests;
 
+import ibm.jceplus.junit.tests.parameters.resolvers.RSAKeySizeListParameterResolver;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@MethodSource("ibm.jceplus.junit.tests.TestArguments#rsaKeySizesAndJCEPlusProviders")
+@ExtendWith(RSAKeySizeListParameterResolver.class)
+@MethodSource("ibm.jceplus.junit.tests.TestArguments#keySizesAndProviders")
 public class TestRSA extends BaseTestRSA {
-// This class is empty which is used to pass the key size and provider parameters to the BaseTestRSA class.
+    // This class is only used to pass the key size parameter to the BaseTestRSA class.
 }

--- a/src/test/java/ibm/jceplus/junit/tests/TestRSAMultiThread.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestRSAMultiThread.java
@@ -8,12 +8,16 @@
 
 package ibm.jceplus.junit.tests;
 
+import ibm.jceplus.junit.tests.parameters.resolvers.RSAMultithreadKeySizeListParameterResolver;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.provider.MethodSource;
 
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
-@MethodSource("ibm.jceplus.junit.tests.TestArguments#rsaMultithreadKeySizesAndProviders")
+@Tag(Tags.OPENJCEPLUS_NAME)
+@Tag(Tags.OPENJCEPLUS_FIPS_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
+@ExtendWith(RSAMultithreadKeySizeListParameterResolver.class)
+@MethodSource("ibm.jceplus.junit.tests.TestArguments#keySizesAndProviders")
 public class TestRSAMultiThread extends BaseTestRSA {
-// This class is empty which is used to pass the key size and provider parameters to the BaseTestRSA class.
+    // This class is only used to pass the key size parameter to the BaseTestRSA class.
 }

--- a/src/test/java/ibm/jceplus/junit/tests/TestSHA3_224KAT.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestSHA3_224KAT.java
@@ -21,8 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestSHA3_256KAT.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestSHA3_256KAT.java
@@ -21,8 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestSHA3_384KAT.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestSHA3_384KAT.java
@@ -21,8 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestSHA3_512KAT.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestSHA3_512KAT.java
@@ -21,8 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestSHA512.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestSHA512.java
@@ -21,8 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestSHA512_224.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestSHA512_224.java
@@ -21,8 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/TestSHA512_256.java
+++ b/src/test/java/ibm/jceplus/junit/tests/TestSHA512_256.java
@@ -21,8 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(Tags.OPENJCEPLUS_NAME)
 @Tag(Tags.OPENJCEPLUS_FIPS_NAME)
-@Tag(Tags.OPENJCEPLUS_MULTITHREAD_NAME)
-@Tag(Tags.OPENJCEPLUS_FIPS_MULTITHREAD_NAME)
+@Tag(Tags.MULTITHREAD_NAME)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ParameterizedClass
 @MethodSource("ibm.jceplus.junit.tests.TestArguments#getEnabledProviders")

--- a/src/test/java/ibm/jceplus/junit/tests/parameters/resolvers/AESKeySizeListParameterResolver.java
+++ b/src/test/java/ibm/jceplus/junit/tests/parameters/resolvers/AESKeySizeListParameterResolver.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright IBM Corp. 2026
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.junit.tests.parameters.resolvers;
+
+import java.util.List;
+
+public class AESKeySizeListParameterResolver extends KeySizeListParameterResolver {
+
+    public AESKeySizeListParameterResolver() {
+        super(List.of(128, 192, 256));
+    }
+}

--- a/src/test/java/ibm/jceplus/junit/tests/parameters/resolvers/KeySizeListParameterResolver.java
+++ b/src/test/java/ibm/jceplus/junit/tests/parameters/resolvers/KeySizeListParameterResolver.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright IBM Corp. 2026
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.junit.tests.parameters.resolvers;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+public abstract class KeySizeListParameterResolver implements ParameterResolver {
+    private List<Integer> keySizes;
+
+    protected KeySizeListParameterResolver(List<Integer> keySizes) {
+        this.keySizes = keySizes;
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        Type type = parameterContext.getParameter().getParameterizedType();
+        if (!(type instanceof ParameterizedType)) return false;
+        ParameterizedType pt = (ParameterizedType) type;
+        return pt.getRawType() == List.class &&
+                pt.getActualTypeArguments()[0] == Integer.class;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return keySizes;
+    }
+}

--- a/src/test/java/ibm/jceplus/junit/tests/parameters/resolvers/ProviderListParameterResolver.java
+++ b/src/test/java/ibm/jceplus/junit/tests/parameters/resolvers/ProviderListParameterResolver.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright IBM Corp. 2026
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.junit.tests.parameters.resolvers;
+
+import ibm.jceplus.junit.tests.Tags;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+public class ProviderListParameterResolver implements ParameterResolver {
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        Type type = parameterContext.getParameter().getParameterizedType();
+        if (!(type instanceof ParameterizedType)) return false;
+        ParameterizedType pt = (ParameterizedType) type;
+        return pt.getRawType() == Set.class &&
+                pt.getActualTypeArguments()[0] == String.class;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        Set<String> providers = extensionContext.getTags().stream()
+                                        .filter(pn -> !pn.equalsIgnoreCase(Tags.MULTITHREAD_NAME))
+                                        .collect(Collectors.toSet());
+        return providers;
+    }
+}

--- a/src/test/java/ibm/jceplus/junit/tests/parameters/resolvers/RSAKeySizeListParameterResolver.java
+++ b/src/test/java/ibm/jceplus/junit/tests/parameters/resolvers/RSAKeySizeListParameterResolver.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright IBM Corp. 2026
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.junit.tests.parameters.resolvers;
+
+import java.util.List;
+
+public class RSAKeySizeListParameterResolver extends KeySizeListParameterResolver {
+
+    public RSAKeySizeListParameterResolver() {
+        super(List.of(512, 1024, 2048, 3072, 4096));
+    }
+}

--- a/src/test/java/ibm/jceplus/junit/tests/parameters/resolvers/RSAMultithreadKeySizeListParameterResolver.java
+++ b/src/test/java/ibm/jceplus/junit/tests/parameters/resolvers/RSAMultithreadKeySizeListParameterResolver.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright IBM Corp. 2026
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package ibm.jceplus.junit.tests.parameters.resolvers;
+
+import java.util.List;
+
+public class RSAMultithreadKeySizeListParameterResolver extends KeySizeListParameterResolver {
+
+    public RSAMultithreadKeySizeListParameterResolver() {
+        super(List.of(2048));
+    }
+}


### PR DESCRIPTION
Methods within the `TestArguments` class are utilized through the `MethodSource` annotation to parameterize class attributes (e.g., provider and key sizes).

This change allows the passing of parameters to these methods. The parameters pertain to information about the calling class, like defined tags or other static field, like lists of key sizes.

The test tags are, also, updated to only include specific providers and a dedicated tag for multithreaded tests. The top level tests are altered to look for tag expressions that indicate provider and the multithreaded tag when looking for appropriate tests.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1625

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>