### PR TITLE
Update KeyAgreement classes to support Generic secret generation

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/DHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHKeyAgreement.java
@@ -198,9 +198,11 @@ public final class DHKeyAgreement extends KeyAgreementSpi {
             throw new NoSuchAlgorithmException("null algorithm");
         }
 
-        if (!algorithm.equalsIgnoreCase("TlsPremasterSecret") && !AllowKDF.VALUE) {
+        if (!(algorithm.equalsIgnoreCase("TlsPremasterSecret")
+                || algorithm.equalsIgnoreCase("Generic"))
+            && !AllowKDF.VALUE) {
             throw new NoSuchAlgorithmException(
-                    "Unsupported secret key " + "algorithm: " + algorithm);
+                    "Unsupported secret key algorithm: " + algorithm);
         }
 
         byte[] secret = engineGenerateSecret();
@@ -226,12 +228,15 @@ public final class DHKeyAgreement extends KeyAgreementSpi {
                 throw new InvalidKeyException("Key material is too short");
             }
             return skey;
-        } else if (algorithm.equals("TlsPremasterSecret")) {
+        } else if (algorithm.equalsIgnoreCase("TlsPremasterSecret")) {
             // remove leading zero bytes per RFC 5246 Section 8.1.2
-            return new SecretKeySpec(KeyUtil.trimZeroes(secret), "TlsPremasterSecret");
+            return new SecretKeySpec(
+                    KeyUtil.trimZeroes(secret), "TlsPremasterSecret");
+        } else if (algorithm.equalsIgnoreCase("Generic")) {
+            return new SecretKeySpec(secret, algorithm);
         } else {
             throw new NoSuchAlgorithmException(
-                    "Unsupported secret key " + "algorithm: " + algorithm);
+                    "Unsupported secret key algorithm: " + algorithm);
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/ECDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECDHKeyAgreement.java
@@ -227,10 +227,12 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi { // implements
         if (algorithm == null) {
             throw new NoSuchAlgorithmException("Algorithm must not be null");
         }
-        if (!(algorithm.equals("TlsPremasterSecret"))) {
-            throw new NoSuchAlgorithmException("Only supported for algorithm TlsPremasterSecret");
+        if (!(algorithm.equalsIgnoreCase("TlsPremasterSecret")
+                || algorithm.equalsIgnoreCase("Generic"))) {
+            throw new NoSuchAlgorithmException(
+                    "Unsupported secret key algorithm: " + algorithm);
         }
-        return new SecretKeySpec(engineGenerateSecret(), "TlsPremasterSecret");
+        return new SecretKeySpec(engineGenerateSecret(), algorithm);
     }
 
     @Override

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHKeyAgreement.java
@@ -146,9 +146,12 @@ abstract class XDHKeyAgreement extends KeyAgreementSpi {
             throws IllegalStateException, NoSuchAlgorithmException, InvalidKeyException {
         if (algorithm == null)
             throw new NoSuchAlgorithmException("Algorithm must not be null");
-        if (!(algorithm.equals("TlsPremasterSecret")))
-            throw new NoSuchAlgorithmException("Only supported for algorithm TlsPremasterSecret");
-        return new SecretKeySpec(engineGenerateSecret(), "TlsPremasterSecret");
+        if (!(algorithm.equalsIgnoreCase("TlsPremasterSecret")
+                || algorithm.equalsIgnoreCase("Generic"))) {
+            throw new NoSuchAlgorithmException(
+                    "Unsupported secret key algorithm: " + algorithm);
+        }
+        return new SecretKeySpec(engineGenerateSecret(), algorithm);
     }
 
     @Override

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2025
+ * Copyright IBM Corp. 2023, 2026
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestDH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -18,10 +18,12 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.Arrays;
+import java.util.List;
 import javax.crypto.KeyAgreement;
 import javax.crypto.spec.DHParameterSpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestDH extends BaseTestJunit5 {
@@ -211,6 +213,23 @@ public class BaseTestDH extends BaseTestJunit5 {
             assertTrue(true);
         }
 
+    }
+
+    @Test
+    public void test_engineGenerateSecret() throws Exception {
+        try {
+            KeyPairGenerator g = KeyPairGenerator.getInstance("DH", getProviderName());
+            KeyPair kp1 = g.generateKeyPair();
+            KeyPair kp2 = g.generateKeyPair();
+            KeyAgreement ka = KeyAgreement.getInstance("DH", getProviderName());
+            for (String alg : List.of("TlsPremasterSecret", "Generic")) {
+                ka.init(kp1.getPrivate());
+                ka.doPhase(kp2.getPublic(), true);
+                assertEquals(ka.generateSecret(alg).getAlgorithm(), alg);
+            }
+        } catch (Exception e) {
+            throw e;
+        }
     }
 
     void compute_dh_key(String idString, AlgorithmParameterSpec algParameterSpec)

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2025
+ * Copyright IBM Corp. 2023, 2026
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -31,10 +31,12 @@ import java.security.spec.InvalidParameterSpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
+import java.util.List;
 import javax.crypto.KeyAgreement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -321,6 +323,23 @@ public class BaseTestECDH extends BaseTestJunit5 {
         }
 
         fail("InvalidParameterSpecException expected but no exception was thrown");
+    }
+
+    @Test
+    public void test_engineGenerateSecret() throws Exception {
+        try {
+            KeyPairGenerator g = KeyPairGenerator.getInstance("DH", getProviderName());
+            KeyPair kp1 = g.generateKeyPair();
+            KeyPair kp2 = g.generateKeyPair();
+            KeyAgreement ka = KeyAgreement.getInstance("DH", getProviderName());
+            for (String alg : List.of("TlsPremasterSecret", "Generic")) {
+                ka.init(kp1.getPrivate());
+                ka.doPhase(kp2.getPublic(), true);
+                assertEquals(ka.generateSecret(alg).getAlgorithm(), alg);
+            }
+        } catch (Exception e) {
+            throw e;
+        }
     }
 
     void compute_ecdh_key_with_global_key(String idString, AlgorithmParameterSpec algParameterSpec)

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2025
+ * Copyright IBM Corp. 2023, 2026
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -30,6 +30,7 @@ import java.security.spec.X509EncodedKeySpec;
 import java.security.spec.XECPrivateKeySpec;
 import java.security.spec.XECPublicKeySpec;
 import java.util.Arrays;
+import java.util.List;
 import javax.crypto.KeyAgreement;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -102,6 +103,23 @@ public class BaseTestXDH extends BaseTestJunit5 {
         System.out.println(
                 "\n\n\n\n************************** Starting runCurveMixTest ************************");
         runCurveMixTest();
+    }
+
+    @Test
+    public void test_engineGenerateSecret() throws Exception {
+        try {
+            KeyPairGenerator g = KeyPairGenerator.getInstance("DH", getProviderName());
+            KeyPair kp1 = g.generateKeyPair();
+            KeyPair kp2 = g.generateKeyPair();
+            KeyAgreement ka = KeyAgreement.getInstance("DH", getProviderName());
+            for (String alg : List.of("TlsPremasterSecret", "Generic")) {
+                ka.init(kp1.getPrivate());
+                ka.doPhase(kp2.getPublic(), true);
+                assertEquals(ka.generateSecret(alg).getAlgorithm(), alg);
+            }
+        } catch (Exception e) {
+            throw e;
+        }
     }
 
     @Test


### PR DESCRIPTION
The engineGenerateSecret(String) method in KeyAgreement
classes currently only supports "TlsPremasterSecret",
but the expectation starting in Java 21 is that
"Generic" should be accepted as well. This change
accomplishes that.

Additional test cases to verify said behaviour are
added.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/573

Signed-off-by: Jason Katonica <katonica@us.ibm.com>