### PR TITLE
Add optional OCKC native test, perf, and trace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,10 @@ import groovy.transform.Field;
 @Field ADDITIONAL_ENVARS
 @Field ADDITIONAL_CMD_ARGS
 @Field TIMEOUT_TIME
+@Field CAPTURE_OCKC_TRACE
+@Field RUN_OCKC_TESTS
+@Field RUN_OCKC_PERF
+@Field OCKC_PERF_THREADS
 @Field externalLibrary
 
 GIT_BRANCH_NAME = ""
@@ -278,7 +282,9 @@ def run(platform) {
                     echo "Maven fetched"
                     def command = "install"
                     command += getTestFlag(hardware, software)
-                    externalLibrary.runOpenJCEPlus(command, software)
+                    externalLibrary.runOckcTests(platform, iteration + 1, software)
+                    externalLibrary.runOckcPerf(platform, iteration + 1, software)
+                    externalLibrary.runOpenJCEPlus(command, platform, iteration + 1, software)
                     echo "OpenJCEPlus built"
                 } finally {
                     iteration++
@@ -398,10 +404,29 @@ pipeline {
             """
         )
         booleanParam(name: 'EXECUTE_TESTS', defaultValue: true, description:'\
-            Execute tests during the build')
+            Execute Maven tests during the build')
         string(name: 'SPECIFIC_TEST', defaultValue: '', description: '\
             Set this to only execute a specific test, instead of the whole test suite.<br> \
             Keep in mind that EXECUTE_TESTS has to be set too for this to work.')
+        booleanParam(name: 'RUN_OCKC_TESTS', defaultValue: false, description: '\
+            Run the native OCKC self-test (jcctest) before executing the Maven test suite.<br> \
+            jcctest loads and initializes the OCKC library and exercises its built-in self-tests.<br> \
+            Output is archived as ockctest-{iteration}-{platform}.log.')
+        booleanParam(name: 'RUN_OCKC_PERF', defaultValue: false, description: '\
+            Run the native OCKC performance test (jicc_perf) before executing the Maven test suite.<br> \
+            jicc_perf benchmarks digest and cipher streaming speeds and stresses threading paths.<br> \
+            Use OCKC_PERF_THREADS to control the number of threads (default: 4).<br> \
+            Output is archived as ockctest_perf-{iteration}-{platform}.log.<br>')
+        string(name: 'OCKC_PERF_THREADS', defaultValue: '4', description: '\
+            Number of threads to pass to jicc_perf via the -t flag (default: 4).<br> \
+            Setting a higher thread count stresses thread-safety paths that may expose platform-specific failures.<br> \
+            Only used when RUN_OCKC_PERF is enabled.')
+        booleanParam(name: 'CAPTURE_OCKC_TRACE', defaultValue: false, description: '\
+            Capture an OCKC (GSKit) startup trace during the test run.<br> \
+            When enabled, a GSKIT_CRYPTO.log file is created in the build directory before Maven \
+            runs, which causes the OCKC native library to log its initialization and module loading.<br> \
+            The log is renamed and archived as GSKIT_CRYPTO-{iteration}-{platform}.log after the run.<br> \
+            Any existing log from a prior run is removed first so captured output is always fresh.')
         string(name: 'PARALLEL_ITERATIONS', defaultValue: '', description: '\
             Number of iterations to run all stages for each of the specified platforms. The iterations will run in parallel.')
         separator(name: "ExtendedOptions", sectionHeader: "Extended Options",
@@ -463,6 +488,10 @@ pipeline {
                         OCK_FULL_URL="${params.OCK_FULL_URL}"
                         EXECUTE_TESTS="${params.EXECUTE_TESTS}"
                         SPECIFIC_TEST="${params.SPECIFIC_TEST}"
+                        RUN_OCKC_TESTS="${params.RUN_OCKC_TESTS}"
+                        RUN_OCKC_PERF="${params.RUN_OCKC_PERF}"
+                        OCKC_PERF_THREADS="${params.OCKC_PERF_THREADS}"
+                        CAPTURE_OCKC_TRACE="${params.CAPTURE_OCKC_TRACE}"
                         PARALLEL_ITERATIONS="${params.PARALLEL_ITERATIONS}"
                         ADDITIONAL_NODE_LABELS="${params.ADDITIONAL_NODE_LABELS}"
                         OVERRIDE_NODE_LABELS="${params.OVERRIDE_NODE_LABELS}"

--- a/utils.groovy
+++ b/utils.groovy
@@ -285,10 +285,103 @@ def getMaven(software) {
 }
 
 /*
+ * Run the native OCKC self-tests (jcctest and jicc_perf) from the extracted OCK
+ * binaries directory. These tests exercise the OCKC native library directly and
+ * can expose platform-specific initialization or threading failures before the
+ * Java test suite is run.
+ *
+ * jcctest   - loads and initializes OCKC, exercises its built-in self-tests.
+ * jicc_perf - runs a multi-threaded digest/cipher performance sweep; the -t flag
+ *             stresses thread safety paths that have historically triggered issues.
+ *
+ * Both tests run with LIBPATH (AIX) / LD_LIBRARY_PATH (Linux) / DYLD_LIBRARY_PATH
+ * (macOS) pointing at the OCK directory so the shared library is found.
+ * Output is captured to ockctest-{iteration}-{platform}.log and jicc_perf-{iteration}-{platform}.log
+ * and archived as build
+ * artifacts. A non-zero exit code from either test fails the build.
+ */
+def runOckcTests(platform, iteration, software) {
+    if (RUN_OCKC_TESTS != "true") {
+        return
+    }
+    if (software == "windows" || software == "zos") {
+        echo "OCKC native tests are not supported on ${software}; skipping."
+        return
+    }
+
+    echo "Running native OCKC self-test (jcctest) in $WORKSPACE/openjceplus/OCK"
+
+    dir("openjceplus/OCK") {
+        // Set the library search path appropriate to the OS.
+        def libPathVar = "LD_LIBRARY_PATH"
+        if (software == "aix") {
+            libPathVar = "LIBPATH"
+        } else if (software == "mac") {
+            libPathVar = "DYLD_LIBRARY_PATH"
+        }
+        def libPathExport = "export ${libPathVar}=\$PWD:\$PWD/jgsk_sdk/lib64:\$${libPathVar};"
+
+        // jcctest — OCKC self-test
+        def ockcTestLog = "ockctest-${iteration}-${platform}.log"
+        sh "${libPathExport} ./jcctest > ${ockcTestLog} 2>&1"
+        echo "jcctest completed — output in ${ockcTestLog}"
+        archiveArtifacts artifacts: ockcTestLog, allowEmptyArchive: false
+    }
+}
+
+/*
+ * Run the native OCKC performance test (jicc_perf) from the extracted OCK binaries
+ * directory. jicc_perf benchmarks digest and cipher streaming speeds and, when run
+ * with multiple threads via the -t flag, stresses thread-safety paths that have
+ * historically exposed platform-specific failures.
+ *
+ * The number of threads is controlled by the OCKC_PERF_THREADS parameter. When
+ * empty, jicc_perf runs with its built-in default of 1 thread.
+ *
+ * Output is captured to jicc_perf-{iteration}-{platform}.log and archived as a
+ * build artifact. A non-zero exit code fails the build.
+ */
+def runOckcPerf(platform, iteration, software) {
+    if (RUN_OCKC_PERF != "true") {
+        return
+    }
+    if (software == "windows" || software == "zos") {
+        echo "OCKC perf test is not supported on ${software}; skipping."
+        return
+    }
+
+    dir("openjceplus/OCK") {
+        // Set the library search path appropriate to the OS.
+        def libPathVar = "LD_LIBRARY_PATH"
+        if (software == "aix") {
+            libPathVar = "LIBPATH"
+        } else if (software == "mac") {
+            libPathVar = "DYLD_LIBRARY_PATH"
+        }
+        def libPathExport = "export ${libPathVar}=\$PWD:\$PWD/jgsk_sdk/lib64:\$${libPathVar};"
+
+        // Build the jicc_perf command, appending -t <n> only when the user supplied a value.
+        def threads = OCKC_PERF_THREADS?.trim()
+        def threadFlag = threads ? " -t ${threads}" : ""
+        def jiccPerfLog = "ockctest_perf-${iteration}-${platform}.log"
+
+        echo "Running jicc_perf${threadFlag} — output in ${jiccPerfLog}"
+        // Use returnStatus so a non-zero exit does not abort before the log is archived.
+        // A non-zero result is itself diagnostic output — we warn and continue so Maven
+        // tests still run and the log is always captured as a build artifact.
+        def perfRC = sh(script: "${libPathExport} ./jgsk_sdk/bin/jicc_perf${threadFlag} > ${jiccPerfLog} 2>&1", returnStatus: true)
+        archiveArtifacts artifacts: jiccPerfLog, allowEmptyArchive: false
+        if (perfRC != 0) {
+            echo "WARNING: jicc_perf exited with code ${perfRC} — see ${jiccPerfLog} for details"
+        }
+    }
+}
+
+/*
  * Export the appropriate environment variables
  * and run the requested maven commands.
  */
-def runOpenJCEPlus(command, software) {
+def runOpenJCEPlus(command, platform, iteration, software) {
     dir("openjceplus/OpenJCEPlus") {
         def additional_exports = ""
         if (software == "aix" || software == "zos") {
@@ -336,8 +429,31 @@ def runOpenJCEPlus(command, software) {
             environment = "export PATH=/opt/IBM/openxlC/17.1.3/bin:/opt/IBM/openxlC/17.1.3/tools:/opt/IBM/openxlC/17.1.3/compat/llvm:${mavenPath}:\$PATH;"
         }
 
+        // Prepare OCKC trace file before running Maven.
+        // The OCKC native library detects the fixed filename GSKIT_CRYPTO.log in the
+        // current working directory and appends startup/loading diagnostics to it.
+        // After the run we rename it to follow the platform-iteration archive pattern.
+        def captureOckcTrace = CAPTURE_OCKC_TRACE == "true"
+        def ockcTraceLog = "GSKIT_CRYPTO-${iteration}-${platform}.log"
+        if (captureOckcTrace && software != "windows" && software != "zos") {
+            sh "rm -f GSKIT_CRYPTO.log && touch GSKIT_CRYPTO.log"
+            echo "OCKC trace enabled: GSKIT_CRYPTO.log created"
+        }
+
         if (software != "windows") {
             sh "${java_home} ${gskit_home} ${additional_exports} ${environment} mvn '-Dock.library.path=${ock_path}' ${additional_cmd_args} --batch-mode ${command}"
+        }
+
+        // Rename and archive the OCKC trace log so it is accessible from the Jenkins build page.
+        if (captureOckcTrace && software != "windows" && software != "zos") {
+            def logExists = sh(script: "test -s GSKIT_CRYPTO.log && echo yes || echo no", returnStdout: true).trim()
+            if (logExists == "yes") {
+                sh "mv GSKIT_CRYPTO.log ${ockcTraceLog}"
+                archiveArtifacts artifacts: ockcTraceLog, allowEmptyArchive: true
+                echo "OCKC trace archived: ${ockcTraceLog}"
+            } else {
+                echo "OCKC trace enabled but GSKIT_CRYPTO.log is empty or was not written — the OCKC library may not support tracing on this platform."
+            }
         }
     }
 }
@@ -395,6 +511,8 @@ return [
     getJava: this.&getJava,
     getMaven: this.&getMaven,
     cloneOpenJCEPlus: this.&cloneOpenJCEPlus,
+    runOckcTests: this.&runOckcTests,
+    runOckcPerf: this.&runOckcPerf,
     runOpenJCEPlus: this.&runOpenJCEPlus,
     upload_artifactory: this.&upload_artifactory,
     getSanitizedBranchName: this.&getSanitizedBranchName,


### PR DESCRIPTION
Introduce three new opt-in Jenkins parameters and the Groovy helpers that back them:

- RUN_OCKC_TESTS: runs jcctest (OCKC self-test) before the Maven suite and archives ockctest-{iteration}-{platform}.log as a build artifact.

- RUN_OCKC_PERF: runs jicc_perf (digest/cipher benchmark + thread-safety sweep) with a configurable thread count (OCKC_PERF_THREADS, default 4) and archives ockctest_perf-{iteration}-{platform}.log.

- CAPTURE_OCKC_TRACE: creates GSKIT_CRYPTO.log in the build directory before Maven runs so the OCKC native library writes its startup/module- loading diagnostics to it; renames and archives the result as GSKIT_CRYPTO-{iteration}-{platform}.log after the run.

All three features are disabled by default. runOpenJCEPlus() gains platform and iteration parameters so archive filenames are unique across parallel build iterations.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>