### PR TITLE
Introduce SystemAccessUtils to all Security Manager permission checks

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/DHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DHKeyAgreement.java
@@ -49,7 +49,8 @@ public final class DHKeyAgreement extends KeyAgreementSpi {
 
         private static boolean getValue() {
             return Boolean.parseBoolean(
-                System.getProperty("jdk.crypto.KeyAgreement.legacyKDF", "false"));
+                SystemAccessUtils.getSystemProperty(
+                        "jdk.crypto.KeyAgreement.legacyKDF", "false"));
         }
     }
 

--- a/src/main/java/com/ibm/crypto/plus/provider/DefaultFIPSProviderAttrs.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DefaultFIPSProviderAttrs.java
@@ -9,8 +9,10 @@
 package com.ibm.crypto.plus.provider;
 
 class DefaultFIPSProviderAttrs {
-    static final boolean allowLegacyHKDF = Boolean.getBoolean("openjceplus.allowLegacyHKDF");
-    static final boolean allowNonOAEPFIPS = Boolean.parseBoolean(System.getProperty("com.ibm.openjceplusfips.allowNonOAEP", "false"));
+    static final boolean allowLegacyHKDF = Boolean.parseBoolean(
+            SystemAccessUtils.getSystemProperty("openjceplus.allowLegacyHKDF", "false"));
+    static final boolean allowNonOAEPFIPS = Boolean.parseBoolean(
+            SystemAccessUtils.getSystemProperty("com.ibm.openjceplusfips.allowNonOAEP", "false"));
     static String defaultFIPSProvAttrs = "Service.AlgorithmParameters.AES = com.ibm.crypto.plus.provider.AESParameters\n"
 
         + "AlgorithmParameters.DiffieHellman.alias.add = DH, OID.1.2.840.113549.1.3.1, 1.2.840.113549.1.3.1\n"

--- a/src/main/java/com/ibm/crypto/plus/provider/DefaultProviderAttrs.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/DefaultProviderAttrs.java
@@ -9,7 +9,8 @@
 package com.ibm.crypto.plus.provider;
 
 class DefaultProviderAttrs {
-    static final boolean allowLegacyHKDF = Boolean.getBoolean("openjceplus.allowLegacyHKDF");
+    static final boolean allowLegacyHKDF = Boolean.parseBoolean(
+            SystemAccessUtils.getSystemProperty("openjceplus.allowLegacyHKDF", "false"));
     static String defaultProvAttrs = "Service.AlgorithmParameters.AES = com.ibm.crypto.plus.provider.AESParameters\n"
 
         + "AlgorithmParameters.DESede.alias.add = TripleDES, 3DES\n"

--- a/src/main/java/com/ibm/crypto/plus/provider/ECDHKeyAgreement.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ECDHKeyAgreement.java
@@ -45,7 +45,9 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi { // implements
     private ECPublicKey ecPublicKey = null;
     private ECPrivateKey ecPrivateKey = null;
     private int secretLen;
-    private static boolean disableSmallCurve = Boolean.parseBoolean(System.getProperty("openjceplus.disableSmallerECKeySizeForSharedKeyComputing", "true"));
+    private static boolean disableSmallCurve = Boolean.parseBoolean(
+            SystemAccessUtils.getSystemProperty(
+                    "openjceplus.disableSmallerECKeySizeForSharedKeyComputing", "true"));
 
     public ECDHKeyAgreement(OpenJCEPlusProvider provider) {
         // System.out.println ("In ECDHKeyAgreement");

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlus.java
@@ -221,7 +221,7 @@ public final class OpenJCEPlus extends OpenJCEPlusProvider {
     private static String getDebugDate(String className) {
         String versionDate = "Unknown";
         try {
-            Class<?> thisClass = Class.forName(className);
+            Class<?> thisClass = SystemAccessUtils.forName(className);
             Package thisPackage = thisClass.getPackage();
             String versionInfo = thisPackage.getImplementationVersion();
             int index = versionInfo.indexOf("_");

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusFIPS.java
@@ -21,9 +21,11 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
     // Field serialVersionUID per tag [SERIALIZATION] in DesignNotes.txt
     private static final long serialVersionUID = 929669768004683845L;
 
-    private static final boolean printFipsDeveloperModeWarning = Boolean.parseBoolean(System.getProperty("openjceplus.fips.devmodewarn", "true"));
+    private static final boolean printFipsDeveloperModeWarning = Boolean.parseBoolean(
+            SystemAccessUtils.getSystemProperty("openjceplus.fips.devmodewarn", "true"));
 
-    private static final boolean allowNonOAEPFIPS = Boolean.parseBoolean(System.getProperty("com.ibm.openjceplusfips.allowNonOAEP", "false"));
+    private static final boolean allowNonOAEPFIPS = Boolean.parseBoolean(
+            SystemAccessUtils.getSystemProperty("com.ibm.openjceplusfips.allowNonOAEP", "false"));
 
     private static final String info = "OpenJCEPlusFIPS Provider implements the following:\n" +
 
@@ -67,8 +69,8 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
         supportedPlatforms.put("Arch", List.of("amd64", "ppc64", "s390x"));
         supportedPlatforms.put("OS", List.of("Linux", "AIX", "Windows", "z/OS"));
 
-        osName = System.getProperty("os.name");
-        osArch = System.getProperty("os.arch");;
+        osName = SystemAccessUtils.getSystemProperty("os.name");
+        osArch = SystemAccessUtils.getSystemProperty("os.arch");
 
         boolean isOsSupported, isArchSupported;
         // Check whether the OpenJCEPlus FIPS is supported.
@@ -180,7 +182,7 @@ public final class OpenJCEPlusFIPS extends OpenJCEPlusProvider {
     private static String getDebugDate(String className) {
         String versionDate = "Unknown";
         try {
-            Class<?> thisClass = Class.forName(className);
+            Class<?> thisClass = SystemAccessUtils.forName(className);
             Package thisPackage = thisClass.getPackage();
             String versionInfo = thisPackage.getImplementationVersion();
             int index = versionInfo.indexOf("_");

--- a/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/OpenJCEPlusProvider.java
@@ -37,9 +37,9 @@ import sun.security.util.Debug;
 public abstract class OpenJCEPlusProvider extends java.security.Provider {
     private static final long serialVersionUID = 1L;
 
-    private static final String PROVIDER_VER = System.getProperty("java.specification.version");
+    private static final String PROVIDER_VER = SystemAccessUtils.getSystemProperty("java.specification.version");
 
-    private static final String JAVA_VER = System.getProperty("java.specification.version");
+    private static final String JAVA_VER = SystemAccessUtils.getSystemProperty("java.specification.version");
 
     static final String DEBUG_VALUE = "jceplus";
 
@@ -57,7 +57,9 @@ public abstract class OpenJCEPlusProvider extends java.security.Provider {
     OpenJCEPlusProvider(String name, String info) {
         super(name, PROVIDER_VER, info);
 
-        numCleaners = Integer.getInteger("openjceplus.cleaners.num", DEFAULT_NUM_CLEANERS);
+        numCleaners = Integer.parseInt(
+                SystemAccessUtils.getSystemProperty("openjceplus.cleaners.num",
+                        String.valueOf(DEFAULT_NUM_CLEANERS)));
         if (numCleaners < 1) {
             throw new IllegalArgumentException(numCleaners + " is an invalid number of cleaner threads, must be at least 1.");
         }
@@ -194,7 +196,7 @@ public abstract class OpenJCEPlusProvider extends java.security.Provider {
 
             Class<?> cls;
             try {
-                cls = Class.forName(className);
+                cls = SystemAccessUtils.forName(className);
             } catch (ClassNotFoundException e) {
                 throw new NoSuchAlgorithmException("class configured for " + type + " (provider: "
                         + provider.getName() + ") cannot be found.", e);
@@ -224,8 +226,8 @@ public abstract class OpenJCEPlusProvider extends java.security.Provider {
                     parameters = new Class<?>[1];
                 }
                 if (openjceplusClass == null) {
-                    openjceplusClass = Class
-                            .forName("com.ibm.crypto.plus.provider.OpenJCEPlusProvider");
+                    openjceplusClass = SystemAccessUtils.forName(
+                            "com.ibm.crypto.plus.provider.OpenJCEPlusProvider");
                 }
                 parameters[0] = openjceplusClass;
                 Constructor<?> constr = cls.getConstructor(parameters);

--- a/src/main/java/com/ibm/crypto/plus/provider/ProviderServiceReader.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ProviderServiceReader.java
@@ -9,11 +9,8 @@
 package com.ibm.crypto.plus.provider;
 
 import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringReader;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -139,11 +136,11 @@ public class ProviderServiceReader {
                 throw new IOException("No file or BufferedReader specified");
             } else if (null == filePath && this.reader != null) {
                 rd = this.reader;
-            } else if (filePath != null && !Files.exists(Paths.get(filePath))) {
+            } else if (filePath != null && !SystemAccessUtils.fileExists(filePath)) {
                 throw new IOException("File not found: " + filePath);
             } else {
                 // this filePath != null && Files.exists(Paths.get(filePath))
-                rd = new BufferedReader(new FileReader(filePath));
+                rd = new BufferedReader(SystemAccessUtils.newFileReader(filePath));
             }
 
             pr.load(rd);

--- a/src/main/java/com/ibm/crypto/plus/provider/RSA.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSA.java
@@ -56,8 +56,10 @@ public final class RSA extends CipherSpi {
     private final static byte[] B0 = new byte[0];
 
     static {
-        doTypeChecking = Boolean.parseBoolean(System.getProperty(DO_TYPE_CHECKING, "true"));
-        allowNonOAEPFIPS = Boolean.parseBoolean(System.getProperty(ALLOW_NON_OAEP_FIPS, "false"));
+        doTypeChecking = Boolean.parseBoolean(
+                SystemAccessUtils.getSystemProperty(DO_TYPE_CHECKING, "true"));
+        allowNonOAEPFIPS = Boolean.parseBoolean(
+                SystemAccessUtils.getSystemProperty(ALLOW_NON_OAEP_FIPS, "false"));
     }
 
     public RSA(OpenJCEPlusProvider provider) {

--- a/src/main/java/com/ibm/crypto/plus/provider/RSAKeyPairGenerator.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/RSAKeyPairGenerator.java
@@ -34,7 +34,8 @@ abstract class RSAKeyPairGenerator extends KeyPairGeneratorSpi {
     private AlgorithmId rsaId;
     public final static List<Integer> ALLOWABLE_MODLEN_FIPS_GENERATION = Arrays.asList(2048, 3072, 4096);
     private static final boolean ALLOW_LEGACY_RSA_KEYGEN_VALIDATION =
-        Boolean.getBoolean("com.ibm.openjceplusfips.allowLegacyRSAKeyGenValidation");
+        Boolean.parseBoolean(SystemAccessUtils.getSystemProperty(
+                "com.ibm.openjceplusfips.allowLegacyRSAKeyGenValidation", "false"));
 
     RSAKeyPairGenerator(OpenJCEPlusProvider provider, KeyType type, int keySize) {
         this.provider = provider;

--- a/src/main/java/com/ibm/crypto/plus/provider/SystemAccessUtils.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/SystemAccessUtils.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright IBM Corp. 2026
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms provided by IBM in the LICENSE file that accompanied
+ * this code, including the "Classpath" Exception described therein.
+ */
+
+package com.ibm.crypto.plus.provider;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+
+/**
+ * Utility methods for running privileged operations on Java versions that
+ * still have a SecurityManager (i.e. Java &lt; 25).
+ *
+ * <p>Each method wraps a specific system operation in
+ * {@code AccessController.doPrivileged} so that it succeeds even when the
+ * calling thread does not hold the required permission.
+ *
+ * <p>On JDK 25 and later where SecurityManager is removed, these methods
+ * become pass-through operations.
+ */
+public final class SystemAccessUtils {
+
+    private SystemAccessUtils() {}
+
+    // -----------------------------------------------------------------------
+    // System property access
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns the value of the named system property, or {@code null} if it
+     * is not set.
+     *
+     * @param key the property name
+     * @return the property value, or {@code null}
+     */
+    @SuppressWarnings("removal")
+    public static String getSystemProperty(String key) {
+        return AccessController.doPrivileged(
+                (PrivilegedAction<String>) () -> System.getProperty(key));
+    }
+
+    /**
+     * Returns the value of the named system property, or {@code defaultValue}
+     * if it is not set.
+     *
+     * @param key          the property name
+     * @param defaultValue the default value
+     * @return the property value, or {@code defaultValue}
+     */
+    @SuppressWarnings("removal")
+    public static String getSystemProperty(String key, String defaultValue) {
+        return AccessController.doPrivileged(
+                (PrivilegedAction<String>) () -> System.getProperty(key, defaultValue));
+    }
+
+    // -----------------------------------------------------------------------
+    // File system operations
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns {@code true} if the file or directory at {@code path} exists.
+     *
+     * @param path the file system path to test
+     * @return {@code true} if the path exists
+     */
+    @SuppressWarnings("removal")
+    public static boolean fileExists(String path) {
+        return AccessController.doPrivileged(
+                (PrivilegedAction<Boolean>) () -> Files.exists(Paths.get(path)));
+    }
+
+    /**
+     * Opens a {@link FileReader} for the file at {@code path} under
+     * {@code doPrivileged}.
+     *
+     * @param path the path to the file
+     * @return a new {@link FileReader}
+     * @throws IOException if the file cannot be opened
+     */
+    @SuppressWarnings("removal")
+    public static FileReader newFileReader(String path) throws IOException {
+        try {
+            return AccessController.doPrivileged(
+                    (PrivilegedExceptionAction<FileReader>) () -> new FileReader(path));
+        } catch (PrivilegedActionException pae) {
+            Exception ex = pae.getException();
+            if (ex instanceof IOException) {
+                throw (IOException) ex;
+            }
+            throw new IOException(ex);
+        }
+    }
+
+    /**
+     * Loads the native library at the given library name under {@code doPrivileged}.
+     *
+     * @param libraryName the path to the native library file
+     */
+    @SuppressWarnings("removal")
+    public static void loadLibrary(String libraryName) {
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            System.load(libraryName);
+            return null;
+        });
+    }
+
+    /**
+     * Returns the canonical path of a File object by calling getCanonicalPath()
+     * under {@code doPrivileged}. Only getCanonicalPath() requires the permission check.
+     *
+     * @param file the File object
+     * @return the canonical path
+     * @throws IOException if an I/O error occurs
+     */
+    @SuppressWarnings("removal")
+    public static String getFileCanonicalPath(java.io.File file) throws IOException {
+        try {
+            return AccessController.doPrivileged(
+                    (PrivilegedExceptionAction<String>) () -> file.getCanonicalPath());
+        } catch (PrivilegedActionException pae) {
+            Exception ex = pae.getException();
+            if (ex instanceof IOException) {
+                throw (IOException) ex;
+            }
+            throw new IOException(ex);
+        }
+    }
+
+    /**
+     * Loads the class with the given class name using reflection
+     * under {@code doPrivileged}.
+     *
+     * @param className the class name
+     * @return the {@link Class} object
+     * @throws ClassNotFoundException if the class cannot be found
+     */
+    @SuppressWarnings("removal")
+    public static Class<?> forName(String className) throws ClassNotFoundException {
+        try {
+            return AccessController.doPrivileged(
+                    (PrivilegedExceptionAction<Class<?>>) () -> Class.forName(className));
+        } catch (PrivilegedActionException pae) {
+            Exception ex = pae.getException();
+            if (ex instanceof ClassNotFoundException) {
+                throw (ClassNotFoundException) ex;
+            }
+            throw new RuntimeException(ex);
+        }
+    }
+
+}

--- a/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/XDHPrivateKeyImpl.java
@@ -42,7 +42,8 @@ final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey, Seriali
     //
     // TODO: Remove this property in the future
     private static final boolean ALLOW_KEYPAIR_GENERATION_IN_CONSTRUCTOR =
-        Boolean.getBoolean("openjceplus.xdh.allowKeyPairGenerationInConstructor");
+        Boolean.parseBoolean(SystemAccessUtils.getSystemProperty(
+                "openjceplus.xdh.allowKeyPairGenerationInConstructor", "false"));
 
     private OpenJCEPlusProvider provider = null;
     private transient NamedParameterSpec params;

--- a/src/main/java/com/ibm/crypto/plus/provider/base/CCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/CCMCipher.java
@@ -9,6 +9,7 @@
 package com.ibm.crypto.plus.provider.base;
 
 import com.ibm.crypto.plus.provider.OpenJCEPlusProvider;
+import com.ibm.crypto.plus.provider.SystemAccessUtils;
 import com.ibm.crypto.plus.provider.ock.NativeOCKAdapterNonFIPS;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -38,7 +39,7 @@ public final class CCMCipher {
 
     static {
         disableCCMAcceleration = Boolean.parseBoolean(
-            System.getProperty(DISABLE_CCM_ACCELERATION, "false"));
+            SystemAccessUtils.getSystemProperty(DISABLE_CCM_ACCELERATION, "false"));
     }
 
 

--- a/src/main/java/com/ibm/crypto/plus/provider/base/Digest.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/Digest.java
@@ -10,8 +10,7 @@ package com.ibm.crypto.plus.provider.base;
 
 import com.ibm.crypto.plus.provider.OpenJCEPlusProvider;
 import com.ibm.crypto.plus.provider.PrimitiveWrapper;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
+import com.ibm.crypto.plus.provider.SystemAccessUtils;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -39,7 +38,7 @@ public final class Digest implements Cloneable {
     final static int[] digestLengths = {32, 48, 64, 28, 20};
 
     //disable caching mechanism for windows OS
-    final static private boolean isWindows = System.getProperty("os.name").startsWith("Windows");
+    final static private boolean isWindows = SystemAccessUtils.getSystemProperty("os.name").startsWith("Windows");
 
     final static private int numContexts;
 
@@ -58,22 +57,18 @@ public final class Digest implements Cloneable {
 
     static {
         // Configurable number of cached contexts
-        numContexts = AccessController.doPrivileged(new PrivilegedAction<Integer>() {
-            public Integer run() {
-                int numContexts;
-                if (isWindows) {
-                    return 0;
-                } else {
-                    try {
-                        numContexts = Integer
-                                .parseInt(System.getProperty(DIGEST_CONTEXT_CACHE_SIZE, "2048"));
-                    } catch (NumberFormatException e) {
-                        numContexts = 0;
-                    }
-                    return numContexts;
-                }
+        int num;
+        if (isWindows) {
+            num = 0;
+        } else {
+            try {
+                num = Integer.parseInt(SystemAccessUtils.getSystemProperty(
+                        DIGEST_CONTEXT_CACHE_SIZE, "2048"));
+            } catch (NumberFormatException e) {
+                num = 0;
             }
-        });
+        }
+        numContexts = num;
     }
 
     void getContext() throws NativeException {

--- a/src/main/java/com/ibm/crypto/plus/provider/base/ECKey.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/ECKey.java
@@ -10,6 +10,7 @@ package com.ibm.crypto.plus.provider.base;
 
 import com.ibm.crypto.plus.provider.OpenJCEPlusProvider;
 import com.ibm.crypto.plus.provider.PrimitiveWrapper;
+import com.ibm.crypto.plus.provider.SystemAccessUtils;
 import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.security.spec.ECParameterSpec;
@@ -18,7 +19,9 @@ import java.util.Arrays;
 public final class ECKey implements AsymmetricKey {
 
     private static final String ALLOW_INCORRECT_KEYSIZES = "openjceplus.ec.allowIncorrectKeysizes";
-    private static final boolean allowIncorrectKeysizes = Boolean.parseBoolean(System.getProperty(ALLOW_INCORRECT_KEYSIZES, "false"));
+
+    private static final boolean allowIncorrectKeysizes = Boolean.parseBoolean(
+            SystemAccessUtils.getSystemProperty(ALLOW_INCORRECT_KEYSIZES, "false"));
 
     // The following is a special byte[] instance to indicate that the
     // private/public key bytes are available but not yet obtained.

--- a/src/main/java/com/ibm/crypto/plus/provider/base/GCMCipher.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/GCMCipher.java
@@ -9,9 +9,8 @@
 package com.ibm.crypto.plus.provider.base;
 
 import com.ibm.crypto.plus.provider.OpenJCEPlusProvider;
+import com.ibm.crypto.plus.provider.SystemAccessUtils;
 import java.nio.ByteBuffer;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -23,8 +22,9 @@ import javax.crypto.ShortBufferException;
 @SuppressWarnings({"removal", "deprecation"})
 public final class GCMCipher {
 
-    private static final boolean disableGCMAcceleration;
     private static final String DISABLE_GCM_ACCELERATION = "com.ibm.crypto.provider.DisableGCMAcceleration";
+    private static final boolean disableGCMAcceleration = Boolean.parseBoolean(
+            SystemAccessUtils.getSystemProperty(DISABLE_GCM_ACCELERATION, "false"));
     private static final String debPrefix = "GCMCipher";
 
     // This tracks if the HARDWARE actually supports GCM (Checked once)
@@ -41,15 +41,6 @@ public final class GCMCipher {
     static final int GCM_MODE_256 = 20;
     static final int GCM_MODE_DECRYPT = 128;
     static final int GCM_AUGMENTED_MODE = 768;
-
-    static {
-        disableGCMAcceleration = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-            public Boolean run() {
-                return ("true"
-                        .equalsIgnoreCase(System.getProperty(DISABLE_GCM_ACCELERATION, "false")));
-            }
-        });
-    }
 
     // Buffer to pass GCM input to native
     private static final ThreadLocal<FastJNIBuffer> inputBuffer = new ThreadLocal<FastJNIBuffer>() {

--- a/src/main/java/com/ibm/crypto/plus/provider/base/IOScheme.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/base/IOScheme.java
@@ -8,6 +8,7 @@
 
 package com.ibm.crypto.plus.provider.base;
 
+import com.ibm.crypto.plus.provider.SystemAccessUtils;
 import java.nio.ByteBuffer;
 
 class IOScheme {
@@ -20,7 +21,7 @@ class IOScheme {
     protected int threshold;
 
     IOScheme() {
-        String platform = System.getProperty("os.arch");
+        String platform = SystemAccessUtils.getSystemProperty("os.arch");
         if (platform.contains("x86") || platform.contains("amd")) {
             threshold = xthreshold;
         } else if (platform.contains("s390")) {

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKAdapter.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms provided by IBM in the LICENSE file that accompanied
@@ -8,12 +8,11 @@
 
 package com.ibm.crypto.plus.provider.ock;
 
+import com.ibm.crypto.plus.provider.SystemAccessUtils;
 import com.ibm.crypto.plus.provider.base.NativeInterface;
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 import java.nio.ByteBuffer;
-import java.security.AccessController;
 import java.security.ProviderException;
 import sun.security.util.Debug;
 
@@ -51,14 +50,9 @@ public abstract class NativeOCKAdapter implements NativeInterface {
     NativeOCKAdapter(boolean useFIPSMode) {
         this.useFIPSMode = useFIPSMode;
 
-        AccessController.doPrivileged(new java.security.PrivilegedAction<Void> () {
-            public Void run() {
-                if (!ockInitialized) {
-                    initializeContext();
-                }
-                return null;
-            }
-        });
+        if (!ockInitialized) {
+            initializeContext();
+        }
     }
 
     // Initialize OCK context(s)
@@ -140,14 +134,9 @@ public abstract class NativeOCKAdapter implements NativeInterface {
         // deserialized in a JVM that has not instantiated the OpenJCEPlus
         // provider yet.
         //
-        AccessController.doPrivileged(new java.security.PrivilegedAction<Void> () {
-            public Void run() {
-                if (!ockInitialized) {
-                    initializeContext();
-                }
-                return null;
-            }
-        });
+        if (!ockInitialized) {
+            initializeContext();
+        }
 
         return ockContext;
     }
@@ -205,8 +194,8 @@ public abstract class NativeOCKAdapter implements NativeInterface {
         try {
             // Check to make sure that the OCK install path is within the JRE
             //
-            String ockLoadPath = new File(NativeOCKImplementation.getOCKLoadPath()).getCanonicalPath();
-            String ockInstallPath = new File(getLibraryInstallPath()).getCanonicalPath();
+            String ockLoadPath = SystemAccessUtils.getFileCanonicalPath(new File(NativeOCKImplementation.getOCKLoadPath()));
+            String ockInstallPath = SystemAccessUtils.getFileCanonicalPath(new File(getLibraryInstallPath()));
 
             if (debug != null) {
                 debug.println("dependent library load path : " + ockLoadPath);
@@ -262,7 +251,7 @@ public abstract class NativeOCKAdapter implements NativeInterface {
         try {
             String line;
             String versionMarker = "# ICC Version ";
-            br = new BufferedReader(new FileReader(ockSigFileName));
+            br = new BufferedReader(SystemAccessUtils.newFileReader(ockSigFileName));
             while ((line = br.readLine()) != null) {
                 if (line.startsWith(versionMarker)) {
                     String version = line.substring(versionMarker.length()).trim();

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKAdapterFIPS.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKAdapterFIPS.java
@@ -8,13 +8,15 @@
 
 package com.ibm.crypto.plus.provider.ock;
 
+import com.ibm.crypto.plus.provider.SystemAccessUtils;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import sun.security.util.Debug;
 
 public class NativeOCKAdapterFIPS extends NativeOCKAdapter {
-    private static final boolean printFipsDeveloperModeWarning = Boolean.parseBoolean(System.getProperty("openjceplus.fips.devmodewarn", "true"));
+    private static final boolean printFipsDeveloperModeWarning = Boolean.parseBoolean(
+                SystemAccessUtils.getSystemProperty("openjceplus.fips.devmodewarn", "true"));
 
     // User enabled debugging
     private static final String DEBUG_VALUE = "jceplus";
@@ -29,8 +31,8 @@ public class NativeOCKAdapterFIPS extends NativeOCKAdapter {
         supportedPlatforms.put("Arch", List.of("amd64", "ppc64", "s390x"));
         supportedPlatforms.put("OS", List.of("Linux", "AIX", "Windows", "z/OS"));
 
-        osName = System.getProperty("os.name");
-        osArch = System.getProperty("os.arch");;
+        osName = SystemAccessUtils.getSystemProperty("os.name");
+        osArch = SystemAccessUtils.getSystemProperty("os.arch");
 
         boolean isOsSupported, isArchSupported;
         // Check whether the OpenJCEPlus FIPS is supported.

--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKImplementation.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKImplementation.java
@@ -8,6 +8,7 @@
 
 package com.ibm.crypto.plus.provider.ock;
 
+import com.ibm.crypto.plus.provider.SystemAccessUtils;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.security.ProviderException;
@@ -60,7 +61,7 @@ final class NativeOCKImplementation {
     }
 
     static String getOCKLoadPath() {
-        String ockOverridePath = System.getProperty("ock.library.path");
+        String ockOverridePath = SystemAccessUtils.getSystemProperty("ock.library.path");
         if (ockOverridePath != null) {
             if (debug != null) {
                 debug.println("Loading ock library using value in property ock.library.path: "
@@ -72,8 +73,8 @@ final class NativeOCKImplementation {
             debug.println("Library path not found for ock, use java home directory.");
         }
 
-        String javaHome = System.getProperty("java.home");
-        osName = System.getProperty("os.name");
+        String javaHome = SystemAccessUtils.getSystemProperty("java.home");
+        osName = SystemAccessUtils.getSystemProperty("os.name");
         String ockPath;
 
         if (osName.startsWith("Windows")) {
@@ -89,7 +90,7 @@ final class NativeOCKImplementation {
     }
 
     static String getJGskitLoadPath() {
-        String jgskitOverridePath = System.getProperty("jgskit.library.path");
+        String jgskitOverridePath = SystemAccessUtils.getSystemProperty("jgskit.library.path");
         if (jgskitOverridePath != null) {
             if (debug != null) {
                 debug.println("Loading jgskit library using value in property jgskit.library.path: " + jgskitOverridePath);
@@ -100,8 +101,8 @@ final class NativeOCKImplementation {
             debug.println("Libpath not found for jgskit, use java home directory.");
         }
 
-        String javaHome = System.getProperty("java.home");
-        osName = System.getProperty("os.name");
+        String javaHome = SystemAccessUtils.getSystemProperty("java.home");
+        osName = SystemAccessUtils.getSystemProperty("os.name");
         String jgskitPath;
 
         if (osName.startsWith("Windows")) {
@@ -117,8 +118,8 @@ final class NativeOCKImplementation {
     }
 
     static void preloadJGskit() {
-        osName = System.getProperty("os.name");
-        osArch = System.getProperty("os.arch");
+        osName = SystemAccessUtils.getSystemProperty("os.name");
+        osArch = SystemAccessUtils.getSystemProperty("os.arch");
         String jgskitPath = getJGskitLoadPath();
         File loadFile = null;
         if (osName.startsWith("Windows") && osArch.equals("amd64")) {
@@ -137,8 +138,8 @@ final class NativeOCKImplementation {
     }
 
     static void preloadOCK() {
-        osName = System.getProperty("os.name");
-        osArch = System.getProperty("os.arch");
+        osName = SystemAccessUtils.getSystemProperty("os.name");
+        osArch = SystemAccessUtils.getSystemProperty("os.arch");
         String ockPath = getOCKLoadPath();
         File loadFile = null;
 
@@ -179,7 +180,7 @@ final class NativeOCKImplementation {
             // loaded by another ClassLoader
             //
             try {
-                System.load(libraryName);
+                SystemAccessUtils.loadLibrary(libraryName);
                 if (debug != null) {
                     debug.println("Loaded : " + libraryName);
                 }


### PR DESCRIPTION
Centralize all security manager permission checks in SystemAccessUtils wrapper methods instead of AccessController.doPrivileged() calls throughout the codebase.

SystemAccessUtils now wraps all permission-requiring operations:
- System property access (getSystemProperty)
- File system access (fileExists, newFileReader, getFileCanonicalPath)
- Library loading (loadLibrary)
- Class loading (forName)

This centralizes permission checks in one utility class, making the codebase cleaner and easier to maintain across JDK versions (SecurityManager in JDK 21 and earlier, removed AccessController.doPrivileged() in JDK 25+).

This is a back port PR from PR: https://github.com/IBM/OpenJCEPlus/pull/1700