### PR TITLE
Set encoding to expandedKey for ML-DSA and ML-KEM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,8 @@
                       --add-opens=openjceplus/ibm.jceplus.junit.tests.parameters.resolvers=ALL-UNNAMED
                       --patch-module openjceplus="target${file.separator}classes${path.separator}target${file.separator}test-classes"
                       -Djava.security.auth.debug=${java.security.auth.debug}
+                      -Djdk.mldsa.pkcs8.encoding=expandedKey
+                      -Djdk.mlkem.pkcs8.encoding=expandedKey
                     </argLine>
                     <trimStackTrace>false</trimStackTrace>
                     <groups>${groups}</groups>
@@ -403,6 +405,8 @@
                       --add-exports=java.base/sun.security.x509=ALL-UNNAMED
                       --add-exports openjceplus/com.ibm.crypto.plus.provider.base=ALL-UNNAMED
                       -Djava.security.auth.debug=${java.security.auth.debug}
+                      -Djdk.mldsa.pkcs8.encoding=expandedKey
+                      -Djdk.mlkem.pkcs8.encoding=expandedKey
                     </argLine>
                     <includes>
                       <include>


### PR DESCRIPTION
Add JVM system properties -Djdk.mldsa.pkcs8.encoding=expandedKey and -Djdk.mlkem.pkcs8.encoding=expandedKey to the Surefire argLine in both Surefire plugin configurations in pom.xml. This ensures ML-DSA and ML-KEM private keys use expanded encodings only.

Back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1616

Signed-off-by: Jason Katonica <katonica@us.ibm.com>