### PR TITLE
Fix algorithm names in GenerateSecret tests

### DIFF
--- a/src/test/java/ibm/jceplus/junit/base/BaseTestECDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestECDH.java
@@ -328,10 +328,10 @@ public class BaseTestECDH extends BaseTestJunit5 {
     @Test
     public void test_engineGenerateSecret() throws Exception {
         try {
-            KeyPairGenerator g = KeyPairGenerator.getInstance("DH", getProviderName());
+            KeyPairGenerator g = KeyPairGenerator.getInstance("EC", getProviderName());
             KeyPair kp1 = g.generateKeyPair();
             KeyPair kp2 = g.generateKeyPair();
-            KeyAgreement ka = KeyAgreement.getInstance("DH", getProviderName());
+            KeyAgreement ka = KeyAgreement.getInstance("ECDH", getProviderName());
             for (String alg : List.of("TlsPremasterSecret", "Generic")) {
                 ka.init(kp1.getPrivate());
                 ka.doPhase(kp2.getPublic(), true);

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestXDH.java
@@ -108,10 +108,10 @@ public class BaseTestXDH extends BaseTestJunit5 {
     @Test
     public void test_engineGenerateSecret() throws Exception {
         try {
-            KeyPairGenerator g = KeyPairGenerator.getInstance("DH", getProviderName());
+            KeyPairGenerator g = KeyPairGenerator.getInstance("XDH", getProviderName());
             KeyPair kp1 = g.generateKeyPair();
             KeyPair kp2 = g.generateKeyPair();
-            KeyAgreement ka = KeyAgreement.getInstance("DH", getProviderName());
+            KeyAgreement ka = KeyAgreement.getInstance("XDH", getProviderName());
             for (String alg : List.of("TlsPremasterSecret", "Generic")) {
                 ka.init(kp1.getPrivate());
                 ka.doPhase(kp2.getPublic(), true);


### PR DESCRIPTION
BaseTestECDH.test_engineGenerateSecret and
BaseTestXDH.test_engineGenerateSecret were using "DH" for both KeyPairGenerator and KeyAgreement instead of the correct algorithm names "ECDH" and "XDH" respectively. This caused the tests to exercise the wrong key agreement algorithm rather than the one under test.

Fixes: https://github.com/IBM/OpenJCEPlus/issues/1721

Signed-off-by: Jason Katonica <katonica@us.ibm.com>