### PR TITLE
engineGetKeySpec rejects keys from external providers

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/PQCKeyFactory.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PQCKeyFactory.java
@@ -92,7 +92,7 @@ class PQCKeyFactory extends KeyFactorySpi {
     protected <T extends KeySpec> T engineGetKeySpec(Key key, Class<T> keySpec)
             throws InvalidKeySpecException {
         try {
-            if (key instanceof com.ibm.crypto.plus.provider.PQCPublicKey) {
+            if (key instanceof PublicKey) {
                 // Determine valid key specs
                 Class<?> x509KeySpec = Class.forName("java.security.spec.X509EncodedKeySpec");
 
@@ -101,7 +101,7 @@ class PQCKeyFactory extends KeyFactorySpi {
                 } else {
                     throw new InvalidKeySpecException("Inappropriate key specification");
                 }
-            } else if (key instanceof com.ibm.crypto.plus.provider.PQCPrivateKey) {
+            } else if (key instanceof PrivateKey) {
                 // Determine valid key specs
                 Class<?> pkcs8KeySpec = Class.forName("java.security.spec.PKCS8EncodedKeySpec");
 
@@ -186,19 +186,30 @@ class PQCKeyFactory extends KeyFactorySpi {
     // Internal utility method for checking key algorithm
     private void checkKeyAlgo(Key key) throws InvalidKeyException {
         String keyAlg = key.getAlgorithm();
+        boolean matches = false;
+
         if (keyAlg == null) {
             throw new InvalidKeyException("Algorithm associate with key is null.");
         }
-        
-        // Check if algorithms match exactly or via OID lookup
-        boolean matches = key.getAlgorithm().equalsIgnoreCase(this.algName) ||
-            (PQCKnownOIDs.findMatch(key.getAlgorithm()).stdName().equalsIgnoreCase(this.algName));
-        
-        // Special case for generic ML-KEM: Allow any ML-KEM parameter set variant
-        // (ML-KEM-512, ML-KEM-768, ML-KEM-1024) when using the generic "ML-KEM" KeyFactory.
-        // This enables interoperability with KEM.getInstance("ML-KEM", ...).
-        if (!matches && "ML-KEM".equals(this.algName) && keyAlg.startsWith("ML-KEM")) {
+
+        //Key is generic identified by generic family alg name
+        //This enables interoperability with getInstance using ML-KEM, ML-DSA, etc.
+        if (("ML-KEM".equalsIgnoreCase (this.algName) && (keyAlg.toUpperCase()).startsWith("ML-KEM-")) ||
+            ("ML-DSA".equalsIgnoreCase (this.algName) && (keyAlg.toUpperCase()).startsWith("ML-DSA-")) ||
+            ("ML-KEM".equalsIgnoreCase(keyAlg) && (this.algName.toUpperCase()).startsWith("ML-KEM-")) ||
+            ("ML-DSA".equalsIgnoreCase(keyAlg) && (this.algName.toUpperCase()).startsWith("ML-DSA-")) ) {
             matches = true;
+        } else {
+            // Check if algorithms match exactly or via OID lookup
+            boolean lookup = false;
+            PQCKnownOIDs oid = PQCKnownOIDs.findMatch(key.getAlgorithm());
+
+            if (oid != null ) {
+                lookup = oid.stdName().equalsIgnoreCase(this.algName);
+            }
+
+            matches = key.getAlgorithm().equalsIgnoreCase(this.algName) || lookup;
+        
         }
         
         if (!matches) {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeyInterop.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeyInterop.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+
 public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
 
 
@@ -47,8 +48,6 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
         String pqcAlgorithm = "ML-KEM-512";
         boolean same = false;
 
-        //This is not in the FIPS provider yet.
-        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
         keyPairGenPlus = KeyPairGenerator.getInstance(pqcAlgorithm, getProviderName());
         keyFactoryPlus = KeyFactory.getInstance(pqcAlgorithm, getProviderName());
         keyPairGenInterop = KeyPairGenerator.getInstance(pqcAlgorithm, getInteropProviderName());
@@ -81,8 +80,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     public void testPQCKeyGenKEMAutoKeyConvertion() throws Exception {
         String pqcAlgorithm = "ML-KEM-512";
 
-        //This is not in the FIPS provider yet and BouncyCastle  does not support this test.
-        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+        // BouncyCastle  does not support this test.
         assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName()));
 
         KEM kemInterop = KEM.getInstance(pqcAlgorithm, getProviderName());
@@ -112,8 +110,6 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
         String pqcAlgorithm = "ML-KEM-512";
         boolean same = false;
 
-        //This is not in the FIPS provider yet.
-        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
         // BC provider generates seed format privatekey
         assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName()));
         keyPairGenPlus = KeyPairGenerator.getInstance(pqcAlgorithm, getProviderName());
@@ -149,8 +145,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
         String pqcAlgorithm = "ML-KEM-512";
         boolean same = false;
 
-        //This is not in the FIPS provider yet and Bouncy Castle does not support this test.
-        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+        // Bouncy Castle does not support this test.
         assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName()));
 
         keyPairGenPlus = KeyPairGenerator.getInstance(pqcAlgorithm, getProviderName());
@@ -181,9 +176,6 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
         String pqcAlgorithm = "ML-DSA-65";
         boolean same = false;
 
-        //This is not in the FIPS provider yet.
-        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
-
         keyPairGenPlus = KeyPairGenerator.getInstance(pqcAlgorithm, getProviderName());
         keyFactoryPlus = KeyFactory.getInstance(pqcAlgorithm, getProviderName());
         keyPairGenInterop = KeyPairGenerator.getInstance(pqcAlgorithm, getInteropProviderName2());
@@ -198,7 +190,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
         PKCS8EncodedKeySpec privateKeySpecPlus = new PKCS8EncodedKeySpec(privateKeyBytesPlus);
         EncodedKeySpec publicKeySpecPlus = new X509EncodedKeySpec(publicKeyBytesPlus);
         PublicKey publicKeyInterop = keyFactoryInterop.generatePublic(publicKeySpecPlus);
-        //BC is using a different encoding today for thier ML-DSA private keys.
+        // BC is using a different encoding today for thier ML-DSA private keys.
         // So we can not compare these today.
         if (getInteropProviderName().equals(Utils.PROVIDER_SunJCE)) {
             PrivateKey privateKeyInterop = keyFactoryInterop.generatePrivate(privateKeySpecPlus);
@@ -216,8 +208,6 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
         String pqcAlgorithm = "ML-DSA-65";
         boolean same = false;
 
-        //This is not in the FIPS provider yet.
-        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
         // BC provider generates seed format privatekey
         assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName()));
 
@@ -237,7 +227,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
         PublicKey publicKeyPlus = keyFactoryPlus.generatePublic(publicKeySpecInterop);
         PrivateKey privateKeyPlus = keyFactoryPlus.generatePrivate(privateKeySpecInterop);
 
-        //BC is using a different encoding today for thier ML-DSA private keys.
+        // BC is using a different encoding today for thier ML-DSA private keys.
         // So we can not compare these today.
         if (getInteropProviderName().equals(Utils.PROVIDER_SunJCE)) {
             same = Arrays.equals(privateKeyBytesInterop, privateKeyPlus.getEncoded());
@@ -253,8 +243,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
         String pqcAlgorithm = "ML-DSA-65";
         boolean same = false;
 
-        //This is not in the FIPS provider yet and Bouncy Castle does not support this test.
-        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+        // Bouncy Castle does not support this test.
         assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName()));
 
         keyPairGenPlus = KeyPairGenerator.getInstance(pqcAlgorithm, getProviderName());
@@ -273,7 +262,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
         EncodedKeySpec eksPrivInterop = keyFactoryInterop.getKeySpec(privateKeyInterop, EncodedKeySpec.class);
         PrivateKey priv = keyFactoryPlus.generatePrivate(eksPrivInterop);
         
-        //BC is using a different encoding today for thier ML-DSA private keys.
+        // BC is using a different encoding today for thier ML-DSA private keys.
         // So we can not compare these today.
         if (getInteropProviderName().equals(Utils.PROVIDER_SunJCE)) {
             same = Arrays.equals(privateKeyBytesInterop, priv.getEncoded());
@@ -302,8 +291,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     @ParameterizedTest
     @CsvSource({"ML-DSA", "ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
     public void testSignInteropAndVerifyPlus(String algorithm) throws Exception {
-        //This is not in the FIPS provider yet.
-        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+        // Boucncy Castle does not support this test when ML-DSA is specified.
         assumeFalse(algorithm.equalsIgnoreCase("ML-DSA") && getInteropProviderName2().equalsIgnoreCase("BC"));
 
         try {
@@ -337,8 +325,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     @ParameterizedTest
     @CsvSource({"ML-DSA", "ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
     public void testSignInteropKeysPlusSignVerify(String algorithm) {
-        //This is not in the FIPS provider yet.
-        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+        //Bouncy Castle does not support this test.
         assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName2()));
 
         try {
@@ -371,8 +358,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     @ParameterizedTest
     @CsvSource({"ML-DSA", "ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
     public void testSignPlusKeysInteropSignVerify(String algorithm) {
-        //This is not in the FIPS provider yet.
-        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+        //Bouncy Castle does not support this test.
         assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName2()));
 
         try {
@@ -406,9 +392,6 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     @CsvSource({"ML-DSA", "ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
     public void testSignPlusAndVerifyInterop(String algorithm) {
         try {
-            //This is not in the FIPS provider yet.
-            assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
-
             keyPairGenPlus = KeyPairGenerator.getInstance(algorithm, getProviderName());
             KeyPair keyPairPlus = generateKeyPair(keyPairGenPlus);
 
@@ -439,8 +422,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     @ParameterizedTest
     @CsvSource({"ML-KEM", "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
     public void testKEMPlusKeyInteropAll(String Algorithm) {
-        //This is not in the FIPS provider yet and Oracle Private keys have an extra Octet in them.
-        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+        //Bouncy Castle does not support this test.
         assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName()));
 
         try {
@@ -479,8 +461,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     @ParameterizedTest
     @CsvSource({"ML-KEM", "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
     public void testKEMInteropKeyPlusAll(String Algorithm) {
-        //This is not in the FIPS provider yet and Oracle Private keys have an extra Octet in them.
-        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+        //Bouncy Castle does not support this test.
         assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName()));
 
         try {
@@ -520,9 +501,6 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     @CsvSource({"ML-KEM", "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
     public void testKEMPlusCreatesInteropGet(String Algorithm) {
         try {
-            //This is not in the FIPS provider yet and Oracle Private keys have an extra Octet in them.
-            assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
-
             KEM kemPlus = KEM.getInstance(Algorithm, getProviderName());
             KEM kemInterop = KEM.getInstance("ML-KEM", getInteropProviderName());
 
@@ -558,9 +536,6 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     @CsvSource({"ML-KEM", "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
     public void testKEMInteropCreatesPlusGet(String Algorithm) {
         try {
-            //This is not in the FIPS provider yet and Oracle Private keys have an extra Octet in them.
-            assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
-
             KEM kemPlus = KEM.getInstance(Algorithm, getProviderName());
             KEM kemInterop = KEM.getInstance("ML-KEM", getInteropProviderName());
 
@@ -599,8 +574,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     @ParameterizedTest
     @CsvSource({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
     public void testMLKEMInteropWithNamedParameterSpec(String parameterSet) throws Exception {
-        // Not in FIPS provider yet and BC doesn't support this test
-        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+        //Bouncy Castle does not support this test.
         assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName()));
 
         // Generate key pair using NamedParameterSpec with provider
@@ -636,8 +610,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     @ParameterizedTest
     @CsvSource({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
     public void testMLKEMInteropEmptyParamsWithNamedParameterSpec(String parameterSet) throws Exception {
-        // Not in FIPS provider yet and BC doesn't support this test
-        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+        //Bouncy Castle does not support this test.
         assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName()));
 
         // Generate key pair using NamedParameterSpec with interop provider
@@ -673,8 +646,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     @ParameterizedTest
     @CsvSource({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
     public void testMLKEMInteropSmallerSecretWithNamedParameterSpec(String parameterSet) throws Exception {
-        // Not in FIPS provider yet and BC doesn't support this test
-        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+        // Bouncy Castle does not support this test.
         assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName()));
 
         // Generate key pair using NamedParameterSpec with provider
@@ -710,8 +682,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     @ParameterizedTest
     @CsvSource({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
     public void testMLKEMBidirectionalInteropWithNamedParameterSpec(String parameterSet) throws Exception {
-        // Not in FIPS provider yet and BC doesn't support this test
-        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+        // Bouncy Castle does not support this test.
         assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName()));
 
         // Test 1: Generate with provider, encapsulate with interop provider, decapsulate with provider
@@ -749,8 +720,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     @CsvSource({"ML-KEM", "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
     public void testMLKEMGetKeySpecPrivateInteropToPlus(String algorithm)
             throws Exception {
-        // This is not in the FIPS provider yet.
-        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+        // Bouncy Castle does not support this test.
         assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName()));
 
         KeyFactory openjceplusKeyFactory = KeyFactory.getInstance(algorithm, getProviderName());
@@ -785,8 +755,7 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
     @CsvSource({"ML-DSA", "ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
     public void testMLDSAGetKeySpecPrivateInteropToPlus(String algorithm)
             throws Exception {
-        // This is not in the FIPS provider yet.
-        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
+        // Bouncy Castle does not support this test.
         assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName()));
 
         KeyFactory openjceplusKeyFactory = KeyFactory.getInstance(algorithm, getProviderName());
@@ -805,6 +774,62 @@ public class BaseTestPQCKeyInterop extends BaseTestJunit5Interop {
         verifierInterop.initVerify(interopKeyPair.getPublic());
         verifierInterop.update(origMsg);
         assertTrue(verifierInterop.verify(signaturePlus), "Signature verification failed");
+    }
+
+    @Test
+    public void testKeyFactoryWithOthersMLDSAKeys() throws Exception {
+
+        // Bouncy Castle does not support this test.
+        assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName()));
+
+        KeyPairGenerator kpgDSA = KeyPairGenerator.getInstance("ML-DSA", getInteropProviderName2());
+        kpgDSA.initialize(new NamedParameterSpec("ML_DSA_65"));
+        KeyPair keyPairDSA = kpgDSA.generateKeyPair();
+
+        KeyFactory keyFactory = KeyFactory.getInstance("ML-DSA-65", getProviderName());
+        PublicKey pubK = (PublicKey) keyFactory.translateKey(keyPairDSA.getPublic());
+        PrivateKey privK = (PrivateKey) keyFactory.translateKey(keyPairDSA.getPrivate());
+
+        Signature signerPlus = Signature.getInstance("ML-DSA", getProviderName());
+        signerPlus.initSign(privK);
+        signerPlus.update(origMsg);
+        byte[] signaturePlus = signerPlus.sign();
+
+        Signature verifierInterop = Signature.getInstance("ML-DSA", getProviderName());
+        verifierInterop.initVerify(pubK);
+        verifierInterop.update(origMsg);
+        assertTrue(verifierInterop.verify(signaturePlus), "Signature verification failed");
+
+    }
+
+    @Test
+    public void testKeyFactoryWithOthersMLKEMKeys() throws Exception {
+
+        // Bouncy Castle does not support this test.
+        assumeFalse(Utils.PROVIDER_BC.equals(getInteropProviderName()));
+
+        KeyPairGenerator kpgKEM = KeyPairGenerator.getInstance("ML-KEM", getInteropProviderName());
+        kpgKEM.initialize(new NamedParameterSpec("ML_KEM_768"));
+        KeyPair keyPairKEM = kpgKEM.generateKeyPair();
+
+        KeyFactory keyFactory = KeyFactory.getInstance("ML-KEM-768", getProviderName());
+        PublicKey pubK = (PublicKey) keyFactory.translateKey(keyPairKEM.getPublic());
+        PrivateKey privK = (PrivateKey) keyFactory.translateKey(keyPairKEM.getPrivate());
+
+        KEM interopKem = KEM.getInstance("ML-KEM", getProviderName());
+        KEM.Encapsulator encapsulator =
+                interopKem.newEncapsulator(pubK);
+
+        KEM.Encapsulated encapsulated = encapsulator.encapsulate();
+
+        KEM.Decapsulator decapsulator =
+                interopKem.newDecapsulator(privK);
+
+        SecretKey openjceplusSecret =
+                decapsulator.decapsulate(encapsulated.encapsulation());
+
+        assertArrayEquals(encapsulated.key().getEncoded(),
+            openjceplusSecret.getEncoded());
     }
 
     private void assertPrivateKeyPKCS8SpecEquals(KeySpec expected, KeySpec actual) {

--- a/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeys.java
+++ b/src/test/java/ibm/jceplus/junit/base/BaseTestPQCKeys.java
@@ -27,6 +27,7 @@ import java.util.Base64;
 import java.util.HexFormat;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -35,8 +36,9 @@ import sun.security.util.DerValue;
 import sun.security.x509.AlgorithmId;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class BaseTestPQCKeys extends BaseTestJunit5 {
 
@@ -90,10 +92,18 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
     public void setUp() throws Exception {
     }
 
+    /**
+     * Verifies that key pair generation succeeds for all supported algorithm name variants.
+     * Covers both '-' and '_' name forms for all ML-KEM and ML-DSA families.
+     *
+     * @param Algorithm the algorithm name to test
+     * @throws Exception if key pair generation fails unexpectedly
+     */
     @ParameterizedTest
-    @CsvSource({"ML-KEM", "MLKEM512", "ML_KEM_768", "ML-KEM-1024",
-                "ML_KEM_512", "ML_KEM_768", "ML_KEM_1024",
-                "ML-DSA", "ML_DSA_44", "ML_DSA_65", "ML-DSA-87"})
+    @CsvSource({"ML-KEM", "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024",
+                "MLKEM512", "ML_KEM_512", "ML_KEM_768", "ML_KEM_1024",
+                "ML-DSA", "ML-DSA-44", "ML-DSA-65", "ML-DSA-87",
+                "ML_DSA_44", "ML_DSA_65", "ML_DSA_87"})
     public void testPQCKeyGen(String Algorithm) throws Exception {
         if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS does not support PQC keys currently
@@ -109,9 +119,19 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
         }
     }
 
+    /**
+     * Verifies that a {@link KeyFactory} can reconstruct keys from their encoded forms for all
+     * supported algorithm name variants. Covers both '-' and '_' name forms for all ML-KEM and
+     * ML-DSA families.
+     *
+     * @param Algorithm the algorithm name to test
+     * @throws Exception if key factory creation or encoding round-trip fails unexpectedly
+     */
     @ParameterizedTest
     @CsvSource({"ML-KEM", "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024",
-                "ML-DSA", "ML_DSA_44", "ML_DSA_65", "ML-DSA-87"})
+                "ML_KEM_512", "ML_KEM_768", "ML_KEM_1024",
+                "ML-DSA", "ML-DSA-44", "ML-DSA-65", "ML-DSA-87",
+                "ML_DSA_44", "ML_DSA_65", "ML_DSA_87"})
     public void testPQCKeyFactoryCreateFromEncoded(String Algorithm) throws Exception {
         if (getProviderName().equals("OpenJCEPlusFIPS")) {
             //FIPS does not support PQC keys currently
@@ -143,48 +163,123 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
             keyFactory.generatePublic(publicKeySpec);
             fail("Expected InvalidKeySpecException not thrown");
         } catch (InvalidKeySpecException e) {
-            // this is expected
+            assertTrue(e.getMessage().startsWith("Inappropriate key specification:"), "Different Message than expected: " + e.getMessage());
         }
 
     }
 
+    /**
+     * Verifies that {@code generatePrivate} rejects a {@link PKCS8EncodedKeySpec} that contains
+     * public key bytes (symmetric counterpart to
+     * {@link #generatePublicWithInvalidKeySpec(String)}).
+     *
+     * @param algorithm the algorithm name to test
+     * @throws Exception if an unexpected error occurs
+     */
+    @ParameterizedTest
+    @CsvSource({"ML-DSA", "ML-DSA-44", "ML-DSA-65", "ML-KEM", "ML-KEM-512"})
+    public void generatePrivateWithInvalidKeySpec(String algorithm) throws Exception {
+        KeyFactory keyFactory = KeyFactory.getInstance(algorithm, getProviderName());
+
+        // Pass public key bytes to PKCS8 spec — wrong content for a private key
+        byte[] publicKeyBytes = generateKeyPair(algorithm).getPublic().getEncoded();
+        PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(publicKeyBytes);
+        try {
+            keyFactory.generatePrivate(privateKeySpec);
+            fail("Expected InvalidKeySpecException not thrown");
+        } catch (InvalidKeySpecException e) {
+            assertTrue(e.getMessage().startsWith("Inappropriate key specification:"), "Different Message than expected: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Verifies that a generic ML-KEM {@link KeyPairGenerator} accepts {@link NamedParameterSpec}
+     * using the dash-separated name variants (ML-KEM-512, ML-KEM-768, ML-KEM-1024).
+     *
+     * @param algParamSpecName the {@link NamedParameterSpec} name to initialize with
+     * @throws Exception if initialization or key generation fails unexpectedly
+     */
     @ParameterizedTest
     @CsvSource({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
     public void genWithAlgParameterSpecMLKEM(String algParamSpecName) throws Exception {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("ML-KEM", getProviderName());        
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("ML-KEM", getProviderName());
         AlgorithmParameterSpec param = new NamedParameterSpec(algParamSpecName);
         kpg.initialize(param);
         kpg.generateKeyPair();
     }
 
+    /**
+     * Verifies that a generic ML-DSA {@link KeyPairGenerator} accepts {@link NamedParameterSpec}
+     * using the dash-separated name variants (ML-DSA-44, ML-DSA-65, ML-DSA-87).
+     *
+     * @param algParamSpecName the {@link NamedParameterSpec} name to initialize with
+     * @throws Exception if initialization or key generation fails unexpectedly
+     */
     @ParameterizedTest
     @CsvSource({"ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
     public void genWithAlgParameterSpecMLDSA(String algParamSpecName) throws Exception {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("ML-DSA", getProviderName());        
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("ML-DSA", getProviderName());
         AlgorithmParameterSpec param = new NamedParameterSpec(algParamSpecName);
         kpg.initialize(param);
         kpg.generateKeyPair();
     }
 
+    /**
+     * Verifies that an ML-DSA-44 {@link KeyPairGenerator} rejects {@link NamedParameterSpec}
+     * values for sibling parameter sets. Tests both '-' and '_' name forms
+     * (ML-DSA-65, ML-DSA-87, ML_DSA_65, ML_DSA_87).
+     *
+     * @param algParamSpecName the mismatched {@link NamedParameterSpec} name
+     * @throws Exception if an unexpected error occurs
+     */
     @ParameterizedTest
-    @CsvSource({"ML-DSA-65", "ML-DSA-87"})
+    @CsvSource({"ML-DSA-65", "ML-DSA-87", "ML_DSA_65", "ML_DSA_87"})
     public void genWithAlgParameterSpecMLDSAFaiure(String algParamSpecName) throws Exception {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("ML-DSA-44", getProviderName());        
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("ML-DSA-44", getProviderName());
         AlgorithmParameterSpec param = new NamedParameterSpec(algParamSpecName);
         try {
             kpg.initialize(param);
-            fail("Expected InvalidKeySpecException not thrown");
+            fail("Expected InvalidAlgorithmParameterException not thrown");
         } catch (InvalidAlgorithmParameterException e) {
-            // Expected
+            assertTrue(e.getMessage().equals("Algorithm in AlgorithmParameterSpec: " + algParamSpecName + 
+                " must match the Algorithnm for this KeyPairGenerator: " + "ML-DSA-44"), 
+                "Different Message than expected: " + e.getMessage());
         }
+    }
 
+    /**
+     * Verifies that a specific-variant ML-KEM {@link KeyPairGenerator} rejects
+     * {@link NamedParameterSpec} values for other ML-KEM variants. Tests both '-' and '_'
+     * name forms.
+     *
+     * @param generatorAlg  the algorithm used to obtain the {@link KeyPairGenerator}
+     * @param paramSpecName the mismatched {@link NamedParameterSpec} name
+     * @throws Exception if an unexpected error occurs
+     */
+    @ParameterizedTest
+    @CsvSource({"ML-KEM-512, ML-KEM-768", "ML-KEM-512, ML-KEM-1024",
+                "ML-KEM-512, ML_KEM_768", "ML-KEM-512, ML_KEM_1024",
+                "ML-KEM-768, ML-KEM-512", "ML-KEM-1024, ML-KEM-512",
+                "ML-KEM-768, ML_KEM_512", "ML-KEM-1024, ML_KEM_512"})
+    public void genWithAlgParameterSpecMLKEMFailure(
+            String generatorAlg, String paramSpecName) throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(generatorAlg, getProviderName());
+        AlgorithmParameterSpec param = new NamedParameterSpec(paramSpecName);
+        try {
+            kpg.initialize(param);
+            fail("Expected InvalidAlgorithmParameterException not thrown for "
+                    + generatorAlg + " / " + paramSpecName);
+        } catch (InvalidAlgorithmParameterException e) {
+            assertTrue(e.getMessage().equals("Algorithm in AlgorithmParameterSpec: " + paramSpecName + 
+                " must match the Algorithnm for this KeyPairGenerator: " + generatorAlg), 
+                 "Different Message than expected: " + e.getMessage());
+        }
     }
 
     @ParameterizedTest
     @MethodSource("rfcSeedPrivateKeys")
     public void testRFC9881MLDSARFC9935MLKEMKeyFactory(String algorithm, String privateKeyPem) throws Exception {
 
-        assumeFalse("OpenJCEPlusFIPS".equals(getProviderName()));
         KeyFactory openjceplusKeyFactory = KeyFactory.getInstance(algorithm, getProviderName());
         byte[] rfcPrivateKeyEncoded = decodePEM(privateKeyPem);
 
@@ -194,6 +289,248 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
             fail("Expected InvalidKeySpecException for seed-only private key.");
         } catch (InvalidKeySpecException e) {
             assertEquals(expectedMessage, e.getCause().getMessage());
+        }
+    }
+
+    /**
+     * Verifies the {@code getKeySpec} round-trip for public keys: a generated public key encoded
+     * into an {@link X509EncodedKeySpec} must produce bytes identical to the original encoding.
+     * Covers both '-' and '_' algorithm name forms.
+     *
+     * @param algorithm the algorithm name to test
+     * @throws Exception if key generation or spec extraction fails unexpectedly
+     */
+    @ParameterizedTest
+    @CsvSource({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024",
+                "ML_KEM_512", "ML_KEM_768", "ML_KEM_1024",
+                "ML-DSA-44", "ML-DSA-65", "ML-DSA-87",
+                "ML_DSA_44", "ML_DSA_65", "ML_DSA_87"})
+    public void testGetKeySpecPublicRoundTrip(String algorithm) throws Exception {
+        KeyFactory keyFactory = KeyFactory.getInstance(algorithm, getProviderName());
+        PublicKey publicKey = generateKeyPair(algorithm).getPublic();
+
+        X509EncodedKeySpec spec = keyFactory.getKeySpec(publicKey, X509EncodedKeySpec.class);
+        assertArrayEquals(publicKey.getEncoded(), spec.getEncoded(),
+                "X509EncodedKeySpec bytes do not match original public key - " + algorithm);
+    }
+
+    /**
+     * Verifies the {@code getKeySpec} round-trip for private keys: a generated private key encoded
+     * into a {@link PKCS8EncodedKeySpec} must produce bytes identical to the original encoding.
+     * Covers both '-' and '_' algorithm name forms.
+     *
+     * @param algorithm the algorithm name to test
+     * @throws Exception if key generation or spec extraction fails unexpectedly
+     */
+    @ParameterizedTest
+    @CsvSource({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024",
+                "ML_KEM_512", "ML_KEM_768", "ML_KEM_1024",
+                "ML-DSA-44", "ML-DSA-65", "ML-DSA-87",
+                "ML_DSA_44", "ML_DSA_65", "ML_DSA_87"})
+    public void testGetKeySpecPrivateRoundTrip(String algorithm) throws Exception {
+        KeyFactory keyFactory = KeyFactory.getInstance(algorithm, getProviderName());
+        PrivateKey privateKey = generateKeyPair(algorithm).getPrivate();
+
+        PKCS8EncodedKeySpec spec = keyFactory.getKeySpec(privateKey, PKCS8EncodedKeySpec.class);
+        assertArrayEquals(privateKey.getEncoded(), spec.getEncoded(),
+                "PKCS8EncodedKeySpec bytes do not match original private key - " + algorithm);
+    }
+
+    /**
+     * Verifies that {@code getKeySpec} throws {@link InvalidKeySpecException} when a
+     * {@link PKCS8EncodedKeySpec} is requested for a public key.
+     *
+     * @param algorithm the algorithm name to test
+     * @throws Exception if an unexpected error occurs
+     */
+    @ParameterizedTest
+    @CsvSource({"ML-KEM-512", "ML_KEM_512", "ML-DSA-44", "ML_DSA_44"})
+    public void testGetKeySpecPublicWithWrongSpecType(String algorithm) throws Exception {
+        KeyFactory keyFactory = KeyFactory.getInstance(algorithm, getProviderName());
+        PublicKey publicKey = generateKeyPair(algorithm).getPublic();
+
+        try {
+            keyFactory.getKeySpec(publicKey, PKCS8EncodedKeySpec.class);
+            fail("Expected InvalidKeySpecException for PKCS8EncodedKeySpec on public key - "
+                    + algorithm);
+        } catch (InvalidKeySpecException e) {
+            assertTrue(e.getMessage().equals("Inappropriate key specification"), "Different Message then expected: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Verifies that {@code getKeySpec} throws {@link InvalidKeySpecException} when an
+     * {@link X509EncodedKeySpec} is requested for a private key.
+     *
+     * @param algorithm the algorithm name to test
+     * @throws Exception if an unexpected error occurs
+     */
+    @ParameterizedTest
+    @CsvSource({"ML-KEM-512", "ML_KEM_512", "ML-DSA-44", "ML_DSA_44"})
+    public void testGetKeySpecPrivateWithWrongSpecType(String algorithm) throws Exception {
+        KeyFactory keyFactory = KeyFactory.getInstance(algorithm, getProviderName());
+        PrivateKey privateKey = generateKeyPair(algorithm).getPrivate();
+
+        try {
+            keyFactory.getKeySpec(privateKey, X509EncodedKeySpec.class);
+            fail("Expected InvalidKeySpecException for X509EncodedKeySpec on private key - "
+                    + algorithm);
+        } catch (InvalidKeySpecException e) {
+            assertTrue(e.getMessage().equals("Inappropriate key specification"), "Different Message then expected: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Verifies that {@code generatePublic} throws {@link InvalidKeySpecException} when passed a
+     * {@link PKCS8EncodedKeySpec}, which is the wrong spec type for a public key.
+     *
+     * @param algorithm the algorithm name to test
+     * @throws Exception if an unexpected error occurs
+     */
+    @ParameterizedTest
+    @CsvSource({"ML-KEM-512", "ML_KEM_512", "ML-KEM-768", "ML_KEM_768",
+                "ML-DSA-44", "ML_DSA_44", "ML-DSA-65", "ML_DSA_65"})
+    public void generatePublicWithUnsupportedKeySpec(String algorithm) throws Exception {
+        KeyFactory keyFactory = KeyFactory.getInstance(algorithm, getProviderName());
+
+        // PKCS8EncodedKeySpec is the wrong spec type for generatePublic; must be rejected
+        PKCS8EncodedKeySpec unsupportedSpec = new PKCS8EncodedKeySpec(new byte[]{0x01, 0x02});
+        try {
+            keyFactory.generatePublic(unsupportedSpec);
+            fail("Expected InvalidKeySpecException for PKCS8EncodedKeySpec on generatePublic - "
+                    + algorithm);
+        } catch (InvalidKeySpecException e) {
+            assertTrue(e.getMessage().startsWith("Inappropriate key specification:"), "Different Message then expected: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Verifies that {@code generatePrivate} throws {@link InvalidKeySpecException} when passed an
+     * {@link X509EncodedKeySpec}, which is the wrong spec type for a private key.
+     *
+     * @param algorithm the algorithm name to test
+     * @throws Exception if an unexpected error occurs
+     */
+    @ParameterizedTest
+    @CsvSource({"ML-KEM-512", "ML_KEM_512", "ML-KEM-768", "ML_KEM_768",
+                "ML-DSA-44", "ML_DSA_44", "ML-DSA-65", "ML_DSA_65"})
+    public void generatePrivateWithUnsupportedKeySpec(String algorithm) throws Exception {
+        KeyFactory keyFactory = KeyFactory.getInstance(algorithm, getProviderName());
+
+        // X509EncodedKeySpec is the wrong spec type for generatePrivate; must be rejected
+        X509EncodedKeySpec unsupportedSpec = new X509EncodedKeySpec(new byte[]{0x01, 0x02});
+        try {
+            keyFactory.generatePrivate(unsupportedSpec);
+            fail("Expected InvalidKeySpecException for X509EncodedKeySpec on generatePrivate - "
+                    + algorithm);
+        } catch (InvalidKeySpecException e) {
+            assertTrue(e.getMessage().startsWith("Inappropriate key specification:"), "Different Message then expected: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Verifies that {@code translateKey(null)} throws {@link InvalidKeyException} for both
+     * '-' and '_' algorithm name forms.
+     *
+     * @param algorithm the algorithm name to test
+     * @throws Exception if an unexpected error occurs
+     */
+    @ParameterizedTest
+    @CsvSource({"ML-KEM-512", "ML_KEM_512", "ML-DSA-44", "ML_DSA_44"})
+    public void testTranslateKeyNull(String algorithm) throws Exception {
+        KeyFactory keyFactory = KeyFactory.getInstance(algorithm, getProviderName());
+        try {
+            keyFactory.translateKey(null);
+            fail("Expected InvalidKeyException for null key on " + algorithm);
+        } catch (InvalidKeyException e) {
+            assertTrue(e.getMessage().equals("Key must not be null"), "Different Message then expected: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Verifies that {@code translateKey} returns the identical object reference when the key
+     * already originates from this provider. Covers both '-' and '_' algorithm name forms.
+     *
+     * @param algorithm the algorithm name to test
+     * @throws Exception if translation fails unexpectedly
+     */
+    @ParameterizedTest
+    @CsvSource({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024",
+                "ML_KEM_512", "ML_KEM_768", "ML_KEM_1024",
+                "ML-DSA-44", "ML-DSA-65", "ML-DSA-87",
+                "ML_DSA_44", "ML_DSA_65", "ML_DSA_87"})
+    public void testTranslateKeyIdentity(String algorithm) throws Exception {
+        KeyFactory keyFactory = KeyFactory.getInstance(algorithm, getProviderName());
+        KeyPair keyPair = generateKeyPair(algorithm);
+
+        PublicKey pub = keyPair.getPublic();
+        PrivateKey priv = keyPair.getPrivate();
+
+        assertSame(pub, keyFactory.translateKey(pub),
+                "translateKey should return the same PQCPublicKey object - " + algorithm);
+        assertSame(priv, keyFactory.translateKey(priv),
+                "translateKey should return the same PQCPrivateKey object - " + algorithm);
+    }
+
+    /**
+     * Verifies that a {@link KeyFactory} for one PQC family (e.g. ML-KEM) rejects a key
+     * belonging to a different family (e.g. ML-DSA), and vice versa.
+     *
+     * @throws Exception if an unexpected error occurs
+     */
+    @Test
+    public void testTranslateKeyCrossFamilyRejection() throws Exception {
+
+        // ML-KEM-512 factory must reject an ML-DSA-44 key
+        KeyFactory kemFactory = KeyFactory.getInstance("ML-KEM-512", getProviderName());
+        PrivateKey mlDsaKey = generateKeyPair("ML-DSA-44").getPrivate();
+        try {
+            kemFactory.translateKey(mlDsaKey);
+            fail("Expected InvalidKeyException when translating ML-DSA key with ML-KEM factory");
+        } catch (InvalidKeyException e) {
+            assertTrue(e.getMessage().equals("Expected a ML-KEM-512 key, but got ML-DSA-44"), "Different Message then expected: " + e.getMessage());
+        }
+
+        // ML-DSA-44 factory must reject an ML-KEM-512 key
+        KeyFactory dsaFactory = KeyFactory.getInstance("ML-DSA-44", getProviderName());
+        PublicKey mlKemKey = generateKeyPair("ML-KEM-512").getPublic();
+        try {
+            dsaFactory.translateKey(mlKemKey);
+            fail("Expected InvalidKeyException when translating ML-KEM key with ML-DSA factory");
+        } catch (InvalidKeyException e) {
+            assertTrue(e.getMessage().startsWith("Expected a ML-DSA-44 key, but got ML-KEM-512"), "Different Message then expected: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Verifies that a {@link KeyFactory} for a specific parameter set (e.g. ML-KEM-512) rejects
+     * a key from a sibling parameter set within the same family (e.g. ML-KEM-768 or ML-DSA-87).
+     *
+     * @throws Exception if an unexpected error occurs
+     */
+    @Test
+    public void testTranslateKeySiblingRejection() throws Exception {
+
+        // ML-KEM-512 factory must reject an ML-KEM-768 key
+        KeyFactory kem512Factory = KeyFactory.getInstance("ML-KEM-512", getProviderName());
+        PublicKey mlKem768Key = generateKeyPair("ML-KEM-768").getPublic();
+        try {
+            kem512Factory.translateKey(mlKem768Key);
+            fail("Expected InvalidKeyException when translating ML-KEM-768 key "
+                    + "with ML-KEM-512 factory");
+        } catch (InvalidKeyException e) {
+            assertTrue(e.getMessage().equals("Expected a ML-KEM-512 key, but got ML-KEM-768"), "Different Message then expected: " + e.getMessage());
+        }
+
+        // ML-DSA-44 factory must reject an ML-DSA-87 key
+        KeyFactory dsa44Factory = KeyFactory.getInstance("ML-DSA-44", getProviderName());
+        PrivateKey mlDsa87Key = generateKeyPair("ML-DSA-87").getPrivate();
+        try {
+            dsa44Factory.translateKey(mlDsa87Key);
+            fail("Expected InvalidKeyException when translating ML-DSA-87 key "
+                    + "with ML-DSA-44 factory");
+        } catch (InvalidKeyException e) {
+            assertTrue(e.getMessage().startsWith("Expected a ML-DSA-44 key, but got ML-DSA-87"), "Different Message then expected: " + e.getMessage());
         }
     }
 
@@ -243,23 +580,25 @@ public class BaseTestPQCKeys extends BaseTestJunit5 {
         }
         //System.out.println("Pub key - "+Algorithm+ " = "+HexFormat.of().formatHex(((com.ibm.crypto.plus.provider.PQCPublicKey)(keyPair.getPublic())).getKeyBytes()));
         //System.out.println("Priv key - "+Algorithm+ " = "+HexFormat.of().formatHex(((com.ibm.crypto.plus.provider.PQCPrivateKey)(keyPair.getPrivate())).getKeyBytes()));
- 
+
         return keyPair;
     }
 
     protected void keyFactoryCreateFromEncoded(String Algorithm) throws Exception {
-        
+
         pqcKeyFactory = KeyFactory.getInstance(Algorithm, getProviderName());
         KeyPair pqcKeyPair = generateKeyPair(Algorithm);
-        
+
         X509EncodedKeySpec x509Spec = new X509EncodedKeySpec(pqcKeyPair.getPublic().getEncoded());
         PKCS8EncodedKeySpec pkcs8Spec = new PKCS8EncodedKeySpec(
                 pqcKeyPair.getPrivate().getEncoded());
-        PublicKey pub =  pqcKeyFactory.generatePublic(x509Spec);
-        PrivateKey priv =  pqcKeyFactory.generatePrivate(pkcs8Spec);
+        PublicKey pub = pqcKeyFactory.generatePublic(x509Spec);
+        PrivateKey priv = pqcKeyFactory.generatePrivate(pkcs8Spec);
 
-        assertArrayEquals(pub.getEncoded(), pqcKeyPair.getPublic().getEncoded(), "Public key does not match generated public key - " + Algorithm);
-        assertArrayEquals(priv.getEncoded(), pqcKeyPair.getPrivate().getEncoded(), "Private key does not match generated public key - " + Algorithm);
+        assertArrayEquals(pub.getEncoded(), pqcKeyPair.getPublic().getEncoded(),
+                "Public key does not match generated public key - " + Algorithm);
+        assertArrayEquals(priv.getEncoded(), pqcKeyPair.getPrivate().getEncoded(),
+                "Private key does not match generated private key - " + Algorithm);
 
     }
 


### PR DESCRIPTION
Added code to PQCKeyFactory to allow for ML-KEM and ML-DSA generic Alg names for key translation.

back-ported from: https://github.com/IBM/OpenJCEPlus/pull/1699

Signed-off-by: johnpeck-us-ibm [johnpeck@us.ibm.com](mailto:johnpeck@us.ibm.com)