### PR TITLE
Add configAlgName for NativeCryptoSelector backend lookup in PBES2Core

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/PBES2Core.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/PBES2Core.java
@@ -42,7 +42,7 @@ abstract class PBES2Core extends CipherSpi {
      */
     PBES2Core(String kdfAlgo, String cipherAlgo, int keySize, OpenJCEPlusProvider provider)
         throws NoSuchAlgorithmException, NoSuchPaddingException {
-        
+
         blkSize = AESCipher.AES_BLOCK_SIZE;
         this.cipherAlgo = cipherAlgo;
         keyLength = keySize * 8;
@@ -50,29 +50,29 @@ abstract class PBES2Core extends CipherSpi {
         this.provider = provider;
 
         if (cipherAlgo.equalsIgnoreCase("AES")) {
-            cipher = new AESCipher(provider);
+            cipher = new AESCipher(provider, pbeAlgo);
 
             switch (kdfAlgo.toLowerCase()) {
                 case "hmacsha1":
-                    kdf = new PBKDF2Core.HmacSHA1(provider);
+                    kdf = new PBKDF2Core.HmacSHA1(provider, "Cipher", pbeAlgo);
                     break;
                 case "hmacsha224":
-                    kdf = new PBKDF2Core.HmacSHA224(provider);
+                    kdf = new PBKDF2Core.HmacSHA224(provider, "Cipher", pbeAlgo);
                     break;
                 case "hmacsha256":
-                    kdf = new PBKDF2Core.HmacSHA256(provider);
+                    kdf = new PBKDF2Core.HmacSHA256(provider, "Cipher", pbeAlgo);
                     break;
                 case "hmacsha384":
-                    kdf = new PBKDF2Core.HmacSHA384(provider);
+                    kdf = new PBKDF2Core.HmacSHA384(provider, "Cipher", pbeAlgo);
                     break;
                 case "hmacsha512":
-                    kdf = new PBKDF2Core.HmacSHA512(provider);
+                    kdf = new PBKDF2Core.HmacSHA512(provider, "Cipher", pbeAlgo);
                     break;
                 case "hmacsha512/224":
-                    kdf = new PBKDF2Core.HmacSHA512_224(provider);
+                    kdf = new PBKDF2Core.HmacSHA512_224(provider, "Cipher", pbeAlgo);
                     break;
                 case "hmacsha512/256":
-                    kdf = new PBKDF2Core.HmacSHA512_256(provider);
+                    kdf = new PBKDF2Core.HmacSHA512_256(provider, "Cipher", pbeAlgo);
                     break;
                 default:
                     throw new NoSuchAlgorithmException(


### PR DESCRIPTION
Follow the same pattern as `PBES1Core`, pass the registered Cipher service name (e.g. "`PBEWithHmacSHA1AndAES_128`") to `PBKDF2Core` and `AESCipher` so that `NativeCryptoSelector` resolves the backend against the same service as the caller.

This is a back port PR from PR: https://github.com/IBM/OpenJCEPlus/pull/1720