### PR TITLE
Add z/OS build and test instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ Build Status:
 `OpenJCEPlus` and `OpenJCEPlusFIPS` providers are currently supported on the following architectures and operating system combinations as reported by `mvn --version` in the values `OS name` and `arch` or `family` in the case of windows:
 | OS name ( or family )   | arch        |
 | ----------------------- | ----------- |
+| AIX                     | ppc64       |
 | linux                   | aarch64     |
 | linux                   | amd64       |
-| linux                   | s390x       |
 | linux                   | ppc64le     |
-| Windows (family)        | amd64       |
-| AIX                     | ppc64       |
-| z/OS                    | s390x       |
+| linux                   | s390x       |
 | Mac OS X                | aarch64     |
 | Mac OS X                | amd64       |
+| Windows (family)        | amd64       |
+| z/OS                    | s390x       |
 
 Follow these steps to build the `OpenJCEPlus` and `OpenJCEPlusFIPS` providers along with a dependent Java Native Interface library. Keep in mind that `$PROJECT_HOME` can represent any directory on your system and will be referred to as such in the subsequent instructions. Also keep in mind that the value `$JAVA_VERSION` below must match the same version of the branch of OpenJCEPlus being built. For example if building the `java21` branch the `$JAVA_VERSION` must match the Java 21 SDK version such as `21.0.2+13`.
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Build Status:
 | linux                   | ppc64le     |
 | Windows (family)        | amd64       |
 | AIX                     | ppc64       |
+| z/OS                    | s390x       |
 | Mac OS X                | aarch64     |
 | Mac OS X                | amd64       |
 
@@ -61,7 +62,7 @@ Follow these steps to build the `OpenJCEPlus` and `OpenJCEPlusFIPS` providers al
 1. Copy the OCK library referred to as ICC to the correct location:
 
     Based on the platform, the library file (i.e., `$LIBJGSKIT_LIBRARY`) is named differently. The  values are as follows:
-   * AIX/Linux: `libjgsk8iccs_64.so`
+   * AIX, Linux, z/OS: `libjgsk8iccs_64.so`
    * Mac OS X (aarch64): `libjgsk8iccs_64.dylib`
    * Mac OS X (x86-64): `libjgsk8iccs.dylib`
    * Windows: `jgsk8iccs_64.dll`
@@ -125,6 +126,17 @@ You can test your installation by issuing `mvn --version`. For example:
 
     **NOTE 2**: You might have to adapt the exported environment variables, if the installation directory of `Visual Studio` is different on your machine, or the versions you have available for `Windows Kits` and `Visual Studio` are diffent (e.g., the `Windows Kits` version in the variables above is `10.0.19041.0`, but it might be different on your machine).
 
+1. **(Only for AIX and z/OS)** If you are using a JDK that bundles `OpenJCEPlus`, like `Semeru`, and you want to make sure that you use an `OCK` library different than the one bundled with the JDK, you need to delete the bundled one. More specifically you need to run:
+
+    ```console
+    rm $JAVA_INSTALL_DIRECTORY/jdk-$JAVA_VERSION/lib/libjgsk8iccs_64.so
+    rm $JAVA_INSTALL_DIRECTORY/jdk-$JAVA_VERSION/lib/libjgskit.so
+    rm -rf $JAVA_INSTALL_DIRECTORY/jdk-$JAVA_VERSION/lib/C
+    rm -rf $JAVA_INSTALL_DIRECTORY/jdk-$JAVA_VERSION/lib/N
+    ```
+
+    Additionally, remove `OpenJCEPlus` from the providers list in `$JAVA_INSTALL_DIRECTORY/jdk-$JAVA_VERSION/conf/security/java.security`.
+
 1. Compile the `OpenJCEPlus` and `OpenJCEPlusFIPS` providers along with the Java Native Interface library. This command intentionally skips test execution. See instructions below for [running tests](#Test-Execution).
 
     ```console
@@ -145,21 +157,19 @@ Tests are available within the `OpenJCEPlus` repository. These JUnit tests can b
 
 #### Run all tests
 
-On AIX:
+On AIX and z/OS, you must set an additional setting for the `LIBPATH` environment variable:
 
-   * You must set an additional setting for the `LIBPATH` environment variable:
+   * On AIX:
 
-   ```console
-    export LIBPATH="$PROJECT_HOME/OCK/:$PROJECT_HOME/OCK/jgsk_sdk"
-   ```
+     ```console
+     export LIBPATH="$PROJECT_HOME/OCK/:$PROJECT_HOME/OCK/jgsk_sdk"
+     ```
 
-   * If you are using a JDK that bundles `OpenJCEPlus`, like `Semeru`, and you want to make sure that you use an `OCK` library different than the one bundled with the JDK, you need to delete the bundled one. More specifically you need to run:
+   * On z/OS:
 
-   ```console
-    rm $JAVA_INSTALL_DIRECTORY/jdk-$JAVA_VERSION/lib/libjgsk8iccs_64.so
-    rm -rf $JAVA_INSTALL_DIRECTORY/jdk-$JAVA_VERSION/lib/C
-    rm -rf $JAVA_INSTALL_DIRECTORY/jdk-$JAVA_VERSION/lib/N
-   ```
+     ```console
+     export LIBPATH="$PROJECT_HOME/OCK/:$PROJECT_HOME/OCK/jgsk_sdk:$PROJECT_HOME/OpenJCEPlus/target/jgskit-mz-64:$LIBPATH"
+     ```
 
 On all platforms set the following environment variables and execute all the tests using `mvn`. You must set your JAVA_HOME value to the latest generally available version of Java when using code located in the `main` branch.
 
@@ -173,11 +183,19 @@ mvn '-Dock.library.path=$PROJECT_HOME/OCK/' test
 
 #### Run single test
 
-On AIX you must set an additional setting for the `LIBPATH` environment variable:
+On AIX and z/OS you must set an additional setting for the `LIBPATH` environment variable:
 
-```console
-export LIBPATH="$PROJECT_HOME/OCK/:$PROJECT_HOME/OCK/jgsk_sdk"
-```
+   * On AIX:
+
+     ```console
+     export LIBPATH="$PROJECT_HOME/OCK/:$PROJECT_HOME/OCK/jgsk_sdk"
+     ```
+
+   * On z/OS:
+
+     ```console
+     export LIBPATH="$PROJECT_HOME/OCK/:$PROJECT_HOME/OCK/jgsk_sdk:$PROJECT_HOME/OpenJCEPlus/target/jgskit-mz-64:$LIBPATH"
+     ```
 
 On all platforms change to the OpenJCEPlus directory and set the following environment variables and execute a specific test class using `mvn`. You must set your JAVA_HOME value to the latest generally available version of Java when using code located in the `main` branch.
 


### PR DESCRIPTION
This update adds build and test configuration instructions for z/OS (s390x) to the README, and consolidates the Semeru JDK setup instructions for AIX and z/OS.

Signed-off-by: Michael Ma <michael.ma@ibm.com>