### PR TITLE
Use SystemAccessUtils.fileExists in loadIfExists

### DIFF
--- a/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKImplementation.java
+++ b/src/main/java/com/ibm/crypto/plus/provider/ock/NativeOCKImplementation.java
@@ -175,7 +175,7 @@ final class NativeOCKImplementation {
     private static boolean loadIfExists(File libraryFile) {
         String libraryName = libraryFile.getAbsolutePath();
 
-        if (libraryFile.exists()) {
+        if (SystemAccessUtils.fileExists(libraryName)) {
             // Need a try/catch block in case the library has already been
             // loaded by another ClassLoader
             //


### PR DESCRIPTION
Replace direct `libraryFile.exists()` call in `loadIfExists` with `SystemAccessUtils.fileExists(libraryName)` to ensure file existence checks are routed through the security manager aware utility method, consistent with the rest of the privileged-access pattern used in the native library loading path.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>